### PR TITLE
Disabled Map Layer Query Option

### DIFF
--- a/reactapp/__tests__/components/inputs/custom/AddMapLayer.test.js
+++ b/reactapp/__tests__/components/inputs/custom/AddMapLayer.test.js
@@ -41,6 +41,12 @@ it("AddMapLayer update existing", async () => {
     title: "Legend Title",
     items: [{ color: "red", label: "legend label", symbol: "square" }],
   };
+  layerConfiguration.attributeVariables = {
+    states: { the_geom: "some variable" },
+  };
+  layerConfiguration.omittedPopupAttributes = { states: ["the_geom"] };
+  layerConfiguration.queryable = false;
+
   const onChange = jest.fn();
   const setShowingSubModal = jest.fn();
   const values = [layerConfiguration];
@@ -96,6 +102,11 @@ it("AddMapLayer update existing", async () => {
 
   expect(onChange).toHaveBeenCalledWith([
     {
+      attributeVariables: {
+        states: {
+          the_geom: "some variable",
+        },
+      },
       configuration: {
         props: {
           name: "New Layer Name",
@@ -120,6 +131,10 @@ it("AddMapLayer update existing", async () => {
         ],
         title: "Legend Title",
       },
+      omittedPopupAttributes: {
+        states: ["the_geom"],
+      },
+      queryable: false,
     },
   ]);
 });

--- a/reactapp/__tests__/components/map/Map.test.js
+++ b/reactapp/__tests__/components/map/Map.test.js
@@ -9,7 +9,7 @@ import { Map } from "ol";
 
 global.ResizeObserver = require("resize-observer-polyfill");
 
-const TestingComponent = ({ expectedLayerCount, mapProps }) => {
+const TestingComponent = ({ mapProps }) => {
   const visualizationRef = useRef();
   const { mapReady } = useMapContext();
   const [view, setView] = useState();
@@ -160,7 +160,7 @@ test("Map Layers and Updated Layers", async () => {
 
   render(
     <MapContextProvider>
-      <TestingComponent expectedLayerCount={2} mapProps={{ layers }} />
+      <TestingComponent mapProps={{ layers }} />
     </MapContextProvider>
   );
 
@@ -242,10 +242,7 @@ test("Bad Map Layers", async () => {
 
   rerender(
     <MapContextProvider>
-      <TestingComponent
-        expectedLayerCount={1}
-        mapProps={{ layers: updatedLayers }}
-      />
+      <TestingComponent mapProps={{ layers: updatedLayers }} />
     </MapContextProvider>
   );
 
@@ -275,10 +272,7 @@ test("Bad Map Layers", async () => {
 
   rerender(
     <MapContextProvider>
-      <TestingComponent
-        expectedLayerCount={1}
-        mapProps={{ layers: updatedLayers }}
-      />
+      <TestingComponent mapProps={{ layers: updatedLayers }} />
     </MapContextProvider>
   );
 
@@ -316,7 +310,7 @@ test("Map Layer Styles", async () => {
 
   render(
     <MapContextProvider>
-      <TestingComponent expectedLayerCount={1} mapProps={{ layers }} />
+      <TestingComponent mapProps={{ layers }} />
     </MapContextProvider>
   );
 
@@ -332,7 +326,6 @@ test("Map Layer Styles", async () => {
 });
 
 TestingComponent.propTypes = {
-  expectedLayerCount: PropTypes.number,
   mapProps: PropTypes.shape({
     onMapClick: PropTypes.func,
     layers: PropTypes.array,

--- a/reactapp/__tests__/components/modals/MapLayer/AttributesPane.test.js
+++ b/reactapp/__tests__/components/modals/MapLayer/AttributesPane.test.js
@@ -39,6 +39,7 @@ const TestingComponent = ({
       <p data-testid="omittedPopupAttributes">
         {JSON.stringify(attributeProps.omitted)}
       </p>
+      <p data-testid="queryable">{JSON.stringify(attributeProps.queryable)}</p>
     </>
   );
 };
@@ -588,6 +589,57 @@ test("AttributesPane bad GeoJSON", async () => {
       "Expected property name or '}' in JSON at position 1"
     )
   ).toBeInTheDocument();
+});
+
+test("AttributesPane allow layer query", async () => {
+  mockedGetLayerAttributes.mockResolvedValue({
+    states: [
+      { name: "the_geom", alias: "the_geom" },
+      { name: "STATE_NAME", alias: "STATE_NAME" },
+    ],
+  });
+
+  const sourceProps = {
+    type: "WMS",
+    props: {
+      url: "http://localhost:8081/geoserver/wms",
+      params: {
+        LAYERS: "topp:states",
+      },
+    },
+  };
+  render(
+    <TestingComponent
+      sourceProps={sourceProps}
+      layerProps={{
+        name: "esri",
+      }}
+      tabKey={"attributes"}
+      initialAttributeProps={{
+        variables: { states: { the_geom: "some variable" } },
+        omitted: { states: ["the_geom"] },
+        queryable: false,
+      }}
+    />
+  );
+
+  const layerQuery = screen.getByLabelText("Allow Layer Query");
+  expect(layerQuery.checked).toBe(false);
+  expect(screen.getByTestId("queryable")).toHaveTextContent(
+    JSON.stringify(false)
+  );
+
+  fireEvent.click(layerQuery);
+
+  expect(layerQuery.checked).toBe(true);
+  expect(screen.getByTestId("queryable")).toBeEmptyDOMElement();
+
+  fireEvent.click(layerQuery);
+
+  expect(layerQuery.checked).toBe(false);
+  expect(screen.getByTestId("queryable")).toHaveTextContent(
+    JSON.stringify(false)
+  );
 });
 
 TestingComponent.propTypes = {

--- a/reactapp/__tests__/components/modals/MapLayer/AttributesPane.test.js
+++ b/reactapp/__tests__/components/modals/MapLayer/AttributesPane.test.js
@@ -15,35 +15,29 @@ jest.mock("components/map/utilities", () => {
 const mockedGetLayerAttributes = jest.mocked(getLayerAttributes);
 
 const TestingComponent = ({
-  initialAttributeVariables,
-  initialOmittedPopupAttributes,
+  initialAttributeProps,
   sourceProps,
   layerProps,
   tabKey,
 }) => {
-  const [omittedPopupAttributes, setOmittedPopupAttributes] = useState(
-    initialOmittedPopupAttributes ?? {}
-  );
-  const [attributeVariables, setAttributeVariables] = useState(
-    initialAttributeVariables ?? {}
+  const [attributeProps, setAttributeProps] = useState(
+    initialAttributeProps ?? {}
   );
 
   return (
     <>
       <AttributesPane
-        attributeVariables={attributeVariables}
-        setAttributeVariables={setAttributeVariables}
-        omittedPopupAttributes={omittedPopupAttributes}
-        setOmittedPopupAttributes={setOmittedPopupAttributes}
+        attributeProps={attributeProps}
+        setAttributeProps={setAttributeProps}
         sourceProps={sourceProps}
         layerProps={layerProps}
         tabKey={tabKey}
       />
       <p data-testid="attributeVariables">
-        {JSON.stringify(attributeVariables)}
+        {JSON.stringify(attributeProps.variables)}
       </p>
       <p data-testid="omittedPopupAttributes">
-        {JSON.stringify(omittedPopupAttributes)}
+        {JSON.stringify(attributeProps.omitted)}
       </p>
     </>
   );
@@ -118,11 +112,18 @@ test("AttributesPane successful query no initial variables or popups", async () 
   // Body
   expect(screen.getAllByText("the_geom").length).toBe(2);
   expect(screen.getAllByText("STATE_NAME").length).toBe(2);
-  expect(screen.getAllByRole("checkbox").length).toBe(3); // includes header and 2 rows
   expect(screen.getAllByRole("textbox").length).toBe(2);
-
   expect(screen.getAllByRole("textbox")[0].value).toBe("");
   expect(screen.getAllByRole("textbox")[1].value).toBe("");
+
+  const popupCheckboxes = screen.getAllByLabelText("Show in popup row");
+  expect(popupCheckboxes.length).toBe(2); // includes header and 2 rows
+  const headerCheckbox = screen.getByLabelText("Show in popup header");
+  expect(headerCheckbox).toBeInTheDocument();
+
+  expect(headerCheckbox.checked).toBe(true);
+  expect(popupCheckboxes[0].checked).toBe(true);
+  expect(popupCheckboxes[1].checked).toBe(true);
 });
 
 test("AttributesPane successful query with initial variables or popups", async () => {
@@ -149,10 +150,14 @@ test("AttributesPane successful query with initial variables or popups", async (
         name: "esri",
       }}
       tabKey={"attributes"}
-      initialOmittedPopupAttributes={{ states: ["the_geom"] }}
-      initialAttributeVariables={{ states: { the_geom: "some variable" } }}
+      initialAttributeProps={{
+        variables: { states: { the_geom: "some variable" } },
+        omitted: { states: ["the_geom"] },
+      }}
     />
   );
+
+  expect(screen.getByLabelText("Allow Layer Query").checked).toBe(true); // allow llayer query checkbox should be on
 
   const spinner = screen.getByTestId("Loading...");
   expect(spinner).toBeInTheDocument();
@@ -167,15 +172,21 @@ test("AttributesPane successful query with initial variables or popups", async (
   // Body
   expect(screen.getAllByText("the_geom").length).toBe(2);
   expect(screen.getAllByText("STATE_NAME").length).toBe(2);
-  expect(screen.getAllByRole("checkbox").length).toBe(3); // includes header and 2 rows
-  expect(screen.getAllByRole("textbox").length).toBe(2);
 
-  expect(screen.getAllByRole("textbox")[0].value).toBe("some variable");
-  expect(screen.getAllByRole("textbox")[1].value).toBe("");
+  const variableTextboxes = screen.getAllByLabelText("variable row");
+  expect(variableTextboxes.length).toBe(2);
 
-  expect(screen.getAllByRole("checkbox")[0].checked).toBe(true);
-  expect(screen.getAllByRole("checkbox")[1].checked).toBe(false);
-  expect(screen.getAllByRole("checkbox")[2].checked).toBe(true);
+  expect(variableTextboxes[0].value).toBe("some variable");
+  expect(variableTextboxes[1].value).toBe("");
+
+  const popupCheckboxes = screen.getAllByLabelText("Show in popup row");
+  expect(popupCheckboxes.length).toBe(2); // includes header and 2 rows
+  const headerCheckbox = screen.getByLabelText("Show in popup header");
+  expect(headerCheckbox).toBeInTheDocument();
+
+  expect(headerCheckbox.checked).toBe(true);
+  expect(popupCheckboxes[0].checked).toBe(false);
+  expect(popupCheckboxes[1].checked).toBe(true);
 });
 
 test("AttributesPane unsuccessful query no initial variables or popups", async () => {
@@ -208,16 +219,19 @@ test("AttributesPane unsuccessful query no initial variables or popups", async (
     )
   ).toBeInTheDocument();
 
+  expect(screen.getByLabelText("Allow Layer Query").checked).toBe(true); // allow llayer query checkbox should be on
+
   // Headers
   expect(await screen.findByText("states")).toBeInTheDocument();
   expect(await screen.findByText("Name")).toBeInTheDocument();
   expect(screen.getByText("Show in popup")).toBeInTheDocument();
   expect(screen.getByText("Variable Input Name")).toBeInTheDocument();
 
-  expect(screen.getAllByRole("checkbox").length).toBe(1); // includes  1 row
+  let popCheckboxes = screen.getAllByRole("checkbox", { name: /popup/i });
+  expect(popCheckboxes.length).toBe(1); // includes 1 row
   expect(screen.getAllByRole("textbox").length).toBe(2); // name and variable input
 
-  const rowCheckbox = screen.getAllByRole("checkbox")[0];
+  const rowCheckbox = popCheckboxes[0];
   fireEvent.click(rowCheckbox);
   expect(screen.getByTestId("omittedPopupAttributes")).toHaveTextContent(
     JSON.stringify({})
@@ -238,7 +252,8 @@ test("AttributesPane unsuccessful query no initial variables or popups", async (
   variableTextbox.focus();
   // adds a new row
   await userEvent.tab();
-  expect(screen.getAllByRole("checkbox").length).toBe(2);
+  popCheckboxes = screen.getAllByRole("checkbox", { name: /popup/i });
+  expect(popCheckboxes.length).toBe(2);
   expect(screen.getAllByRole("textbox").length).toBe(4);
   expect(screen.getAllByRole("textbox")[2]).toHaveFocus();
 
@@ -288,8 +303,10 @@ test("AttributesPane unsuccessful query with initial variables or popups", async
         name: "esri",
       }}
       tabKey={"attributes"}
-      initialOmittedPopupAttributes={{ esri: ["the_geom", "STATE_NAME"] }}
-      initialAttributeVariables={{ esri: { the_geom: "some variable" } }}
+      initialAttributeProps={{
+        variables: { esri: { the_geom: "some variable" } },
+        omitted: { esri: ["the_geom", "STATE_NAME"] },
+      }}
     />
   );
 
@@ -307,7 +324,10 @@ test("AttributesPane unsuccessful query with initial variables or popups", async
   expect(screen.getByText("Show in popup")).toBeInTheDocument();
   expect(screen.getByText("Variable Input Name")).toBeInTheDocument();
 
-  expect(screen.getAllByRole("checkbox").length).toBe(2); // includes 2 row
+  expect(screen.getByLabelText("Allow Layer Query").checked).toBe(true); // allow llayer query checkbox should be on
+
+  const popCheckboxes = screen.getAllByRole("checkbox", { name: /popup/i });
+  expect(popCheckboxes.length).toBe(2); // includes 2 row
   expect(screen.getAllByRole("textbox").length).toBe(4); // name and variable input
 
   expect(screen.getAllByRole("textbox")[0].value).toBe("the_geom");
@@ -315,8 +335,8 @@ test("AttributesPane unsuccessful query with initial variables or popups", async
   expect(screen.getAllByRole("textbox")[2].value).toBe("STATE_NAME");
   expect(screen.getAllByRole("textbox")[3].value).toBe("");
 
-  expect(screen.getAllByRole("checkbox")[0].checked).toBe(false);
-  expect(screen.getAllByRole("checkbox")[1].checked).toBe(false);
+  expect(popCheckboxes[0].checked).toBe(false);
+  expect(popCheckboxes[1].checked).toBe(false);
 });
 
 test("AttributesPane popups header and body change", async () => {
@@ -347,12 +367,12 @@ test("AttributesPane popups header and body change", async () => {
   );
 
   expect(await screen.findByTestId("omittedPopupAttributes")).toHaveTextContent(
-    JSON.stringify({})
+    ""
   );
 
   // header popup controls all popups. unchecking means that all fields are omitted
   expect(await screen.findByText("states")).toBeInTheDocument();
-  const headerCheckbox = screen.getAllByRole("checkbox")[0];
+  const headerCheckbox = screen.getByLabelText("Show in popup header");
   await waitFor(() => {
     expect(headerCheckbox.checked).toBe(true);
   });
@@ -365,7 +385,8 @@ test("AttributesPane popups header and body change", async () => {
   );
 
   // turn field popup back on. header should come back as well
-  const theGeomCheckbox = screen.getAllByRole("checkbox")[1];
+  const popupCheckboxes = screen.getAllByLabelText("Show in popup row");
+  const theGeomCheckbox = popupCheckboxes[0];
   fireEvent.click(theGeomCheckbox);
   await waitFor(() => {
     expect(headerCheckbox.checked).toBe(true);
@@ -410,24 +431,27 @@ test("AttributesPane popups initial values", async () => {
         name: "esri",
       }}
       tabKey={"attributes"}
-      initialOmittedPopupAttributes={initialOmittedPopupAttributes}
+      initialAttributeProps={{ omitted: initialOmittedPopupAttributes }}
     />
   );
+
   expect(await screen.findByTestId("omittedPopupAttributes")).toHaveTextContent(
     JSON.stringify({ states: ["the_geom", "STATE_NAME"] })
   );
 
+  expect(screen.getByLabelText("Allow Layer Query").checked).toBe(true); // allow llayer query checkbox should be on
+
   // since all field popups are off, so should the header checkbox
   expect(await screen.findByText("states")).toBeInTheDocument();
-  const checkboxes = screen.getAllByRole("checkbox");
-  checkboxes.forEach((checkbox) => expect(checkbox.checked).toBe(false));
+  const popupCheckboxes = screen.getAllByLabelText("Show in popup row");
+  popupCheckboxes.forEach((checkbox) => expect(checkbox.checked).toBe(false));
 
-  const headerCheckbox = screen.getAllByRole("checkbox")[0];
+  const headerCheckbox = screen.getByLabelText("Show in popup header");
   fireEvent.click(headerCheckbox);
   await waitFor(() => {
     expect(headerCheckbox.checked).toBe(true);
   });
-  checkboxes.forEach((checkbox) => expect(checkbox.checked).toBe(true));
+  popupCheckboxes.forEach((checkbox) => expect(checkbox.checked).toBe(true));
 });
 
 test("AttributesPane attributes change", async () => {

--- a/reactapp/__tests__/components/modals/MapLayer/AttributesPane.test.js
+++ b/reactapp/__tests__/components/modals/MapLayer/AttributesPane.test.js
@@ -643,8 +643,7 @@ test("AttributesPane allow layer query", async () => {
 });
 
 TestingComponent.propTypes = {
-  initialAttributeVariables: PropTypes.object,
-  initialOmittedPopupAttributes: PropTypes.object,
+  initialAttributeProps: PropTypes.object,
   sourceProps: PropTypes.object,
   layerProps: PropTypes.object,
   tabKey: PropTypes.string,

--- a/reactapp/__tests__/components/modals/MapLayer/MapLayer.test.js
+++ b/reactapp/__tests__/components/modals/MapLayer/MapLayer.test.js
@@ -551,9 +551,8 @@ test("MapLayerModal attribute variables and omitted popups", async () => {
   const attributesTabContent = screen.getByLabelText("layer-attributes-tab");
   const variableInput = within(attributesTabContent).getAllByRole("textbox")[0];
   fireEvent.change(variableInput, { target: { value: "Some Variable" } });
-  const popupCheckbox =
-    within(attributesTabContent).getAllByRole("checkbox")[1];
-  fireEvent.click(popupCheckbox);
+  const popupCheckboxes = screen.getAllByLabelText("Show in popup row");
+  fireEvent.click(popupCheckboxes[0]);
 
   const createLayerButton = await screen.findByLabelText("Create Layer Button");
   fireEvent.click(createLayerButton);

--- a/reactapp/__tests__/components/modals/MapLayer/SourcePane.test.js
+++ b/reactapp/__tests__/components/modals/MapLayer/SourcePane.test.js
@@ -26,11 +26,13 @@ const exampleGeoJSON = {
 
 const TestingComponent = ({ initialSourceProps }) => {
   const [sourceProps, setSourceProps] = useState(initialSourceProps ?? {});
-  const [attributeVariables, setAttributeVariables] = useState({
-    someLayer: { someField: "someVariable" },
-  });
-  const [omittedPopupAttributes, setOmittedPopupAttributes] = useState({
-    someLayer: ["someField"],
+  const [attributeProps, setAttributeProps] = useState({
+    variables: {
+      someLayer: { someField: "someVariable" },
+    },
+    omitted: {
+      someLayer: ["someField"],
+    },
   });
 
   return (
@@ -38,15 +40,14 @@ const TestingComponent = ({ initialSourceProps }) => {
       <SourcePane
         sourceProps={sourceProps}
         setSourceProps={setSourceProps}
-        setAttributeVariables={setAttributeVariables}
-        setOmittedPopupAttributes={setOmittedPopupAttributes}
+        setAttributeProps={setAttributeProps}
       />
       <p data-testid="sourceProps">{JSON.stringify(sourceProps)}</p>
       <p data-testid="attributeVariables">
-        {JSON.stringify(attributeVariables)}
+        {JSON.stringify(attributeProps.variables)}
       </p>
       <p data-testid="omittedPopupAttributes">
-        {JSON.stringify(omittedPopupAttributes)}
+        {JSON.stringify(attributeProps.omitted)}
       </p>
     </>
   );

--- a/reactapp/__tests__/components/visualizations/Map.test.js
+++ b/reactapp/__tests__/components/visualizations/Map.test.js
@@ -91,7 +91,6 @@ const exampleStyle = {
 };
 
 const TestingComponent = ({
-  expectedLayerCount,
   onMapClick,
   onMapPointerMove,
   onMapZoom,
@@ -143,7 +142,6 @@ test("Map default and update layers", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           mapProps={{
             mapConfig: {},
             viewConfig: {},
@@ -193,7 +191,6 @@ test("Map default and update layers", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           mapProps={{
             mapConfig: {},
             viewConfig: {},
@@ -257,7 +254,6 @@ test("Map GeoJSON with legend and style", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           mapProps={{
             mapConfig: {},
             viewConfig: {},
@@ -334,7 +330,6 @@ test("Map click", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -407,7 +402,6 @@ test("Map click", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={3}
           onMapClick={true}
           clickCoordinates={newClickCoordinates}
           mapProps={{
@@ -460,6 +454,100 @@ test("Map click", async () => {
   ]);
 });
 
+test("Map click no queryable layer", async () => {
+  mockedQueryLayerFeatures.mockResolvedValue([
+    {
+      attributes: { field1: "some value" },
+      geometry: {
+        paths: [
+          [
+            [0, 0],
+            [0, 1],
+          ],
+          [
+            [1, 0],
+            [1, 1],
+          ],
+        ],
+      },
+      layerName: "Some Layer",
+    },
+  ]);
+  jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);
+  const addLayerSpy = jest.spyOn(Map.prototype, "addLayer");
+
+  const layers = [
+    {
+      configuration: {
+        type: "ImageLayer",
+        props: {
+          name: "NWC not queryable",
+          source: {
+            type: "ESRI Image and Map Service",
+            props: {
+              url: "some_url",
+            },
+          },
+        },
+      },
+      queryable: false,
+    },
+    {
+      configuration: {
+        type: "ImageLayer",
+        props: {
+          name: "NWC",
+          source: {
+            type: "ESRI Image and Map Service",
+            props: {
+              url: "some_url",
+            },
+          },
+        },
+      },
+    },
+  ];
+  const clickCoordinates = [10, 20];
+  const LoadedComponent = createLoadedComponent({
+    children: (
+      <MapContextProvider>
+        <TestingComponent
+          onMapClick={true}
+          clickCoordinates={clickCoordinates}
+          mapProps={{
+            mapConfig: {},
+            viewConfig: {},
+            layers,
+            baseMap: null,
+            layerControl: false,
+          }}
+        />
+      </MapContextProvider>
+    ),
+  });
+  render(LoadedComponent);
+
+  expect(await screen.findByLabelText("Map Div")).toBeInTheDocument();
+  expect(await screen.findByText("Map Ready")).toBeInTheDocument();
+
+  // layer, marker, and highlight layer
+  await waitFor(() => {
+    expect(addLayerSpy.mock.calls.length).toBe(4);
+  });
+
+  expect(addLayerSpy.mock.calls[0][0].values_.name).toBe("ClickMarkerLayer");
+  expect(addLayerSpy.mock.calls[1][0].values_.name).toBe(
+    "ClickHighlighterLayer"
+  );
+  expect(addLayerSpy.mock.calls[2][0].values_.name).toBe("NWC not queryable");
+  expect(addLayerSpy.mock.calls[3][0].values_.name).toBe("NWC");
+
+  expect(mockedQueryLayerFeatures.mock.calls.length).toBe(1);
+  expect(
+    mockedQueryLayerFeatures.mock.calls[0][0].configuration.props.name
+  ).toBe("NWC");
+});
+
 test("Map click no attributes found", async () => {
   mockedQueryLayerFeatures.mockResolvedValue([]);
   jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);
@@ -486,7 +574,6 @@ test("Map click no attributes found", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -545,7 +632,6 @@ test("Map click all attributes omitted", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -606,7 +692,6 @@ test("Map click attribute variables update text variable input", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -695,7 +780,6 @@ test("Map click attribute variables update dropdown variable input", async () =>
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -780,7 +864,6 @@ test("Map click attribute variables Null values", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -842,7 +925,6 @@ test("Map click query error", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -891,7 +973,6 @@ test("Map click not happen in dataviewer mode", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapClick={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -953,7 +1034,6 @@ test("Map info div in dataviewer mode with pontermove", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           clickCoordinates={clickCoordinates}
           onMapPointerMove={true}
           mapProps={{
@@ -1007,7 +1087,6 @@ test("Map info div in dataviewer mode with zoom", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={1}
           onMapZoom={true}
           clickCoordinates={clickCoordinates}
           mapProps={{
@@ -1049,7 +1128,6 @@ test("Map bad basemap", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={0}
           mapProps={{
             mapConfig: {},
             viewConfig: {},
@@ -1105,7 +1183,6 @@ test("Map bad GeoJSON", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={0}
           mapProps={{
             mapConfig: {},
             viewConfig: {},
@@ -1167,7 +1244,6 @@ test("Map bad style", async () => {
     children: (
       <MapContextProvider>
         <TestingComponent
-          expectedLayerCount={0}
           mapProps={{
             mapConfig: {},
             viewConfig: {},
@@ -1205,7 +1281,6 @@ test("Map bad style", async () => {
 });
 
 TestingComponent.propTypes = {
-  expectedLayerCount: PropTypes.number,
   mapProps: PropTypes.shape({
     onMapClick: PropTypes.func,
     layers: PropTypes.array,

--- a/reactapp/components/inputs/custom/AddMapLayer.js
+++ b/reactapp/components/inputs/custom/AddMapLayer.js
@@ -71,9 +71,12 @@ const MapLayerTemplate = ({
     const existingMapLayer = mapLayers.find(
       (t) => t.configuration.props.name === mapLayerName
     );
+    const attributeVariables = existingMapLayer.attributeVariables ?? {};
+    const omittedPopupAttributes =
+      existingMapLayer.omittedPopupAttributes ?? {};
+    const queryableLayer = existingMapLayer.queryable === false ? false : true;
 
-    // Set the layerInfo and existingLayerOriginalName to the specified mapLayer
-    setLayerInfo({
+    const updatedLayerInfo = {
       sourceProps: existingMapLayer.configuration.props.source,
       layerProps: Object.fromEntries(
         Object.entries(existingMapLayer.configuration.props).filter(
@@ -82,9 +85,15 @@ const MapLayerTemplate = ({
       ),
       legend: existingMapLayer.legend,
       style: existingMapLayer.configuration.style,
-      attributeVariables: existingMapLayer.attributeVariables ?? {}, // {layerName: {"field1": "Variable Name 1"}}
-      omittedPopupAttributes: existingMapLayer.omittedPopupAttributes ?? {}, // {layerName: ["field1", "field2"]}
-    });
+      attributeProps: {
+        variables: attributeVariables,
+        omitted: omittedPopupAttributes,
+        queryable: queryableLayer,
+      },
+    };
+
+    // Set the layerInfo and existingLayerOriginalName to the specified mapLayer
+    setLayerInfo(updatedLayerInfo);
     existingLayerOriginalName.current =
       existingMapLayer.configuration.props.name;
 

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -748,6 +748,7 @@ export const omittedPopupAttributesPropType = PropTypes.objectOf(
 export const attributePropsPropType = PropTypes.shape({
   variables: attributeVariablesPropType,
   omitted: omittedPopupAttributesPropType,
+  queryable: PropTypes.bool,
 });
 
 export const sourcePropType = PropTypes.shape({

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -745,6 +745,11 @@ export const omittedPopupAttributesPropType = PropTypes.objectOf(
   PropTypes.arrayOf(PropTypes.string)
 );
 
+export const attributePropsPropType = PropTypes.shape({
+  variables: attributeVariablesPropType,
+  omitted: omittedPopupAttributesPropType,
+});
+
 export const sourcePropType = PropTypes.shape({
   props: PropTypes.object, // an object of source properties like url, params, etc. see components/map/utilities.js (sourcePropertiesOptions) for examples
   type: PropTypes.string, // layer source type

--- a/reactapp/components/modals/MapLayer/AttributesPane.js
+++ b/reactapp/components/modals/MapLayer/AttributesPane.js
@@ -6,6 +6,7 @@ import Alert from "react-bootstrap/Alert";
 import {
   getLayerAttributes,
   sourcePropertiesOptions,
+  attributePropsPropType,
   attributeVariablesPropType,
   omittedPopupAttributesPropType,
   sourcePropType,
@@ -42,11 +43,14 @@ const CenteredTD = styled.td`
   vertical-align: middle;
 `;
 
+const QueryLabel = styled.label`
+  margin-bottom: 1rem;
+  font-weight: bold;
+`;
+
 const AttributesPane = ({
-  attributeVariables,
-  setAttributeVariables,
-  omittedPopupAttributes,
-  setOmittedPopupAttributes,
+  attributeProps,
+  setAttributeProps,
   sourceProps,
   layerProps,
   tabKey,
@@ -54,11 +58,10 @@ const AttributesPane = ({
   const [warningMessage, setWarningMessage] = useState(null);
   const [errorMessage, setErrorMessage] = useState(null);
   const [attributes, setAttributes] = useState({});
-  const attributeVariableValues = useRef(attributeVariables ?? {});
-  const omittedPopupAttributesValues = useRef(omittedPopupAttributes ?? {});
   const previousSourceProps = useRef({});
   const [customAttributes, setCustomAttributes] = useState(null);
   const [layerPopupSwitch, setLayerPopupSwitch] = useState({});
+  const [queryable, setQueryable] = useState(true);
 
   useEffect(() => {
     if (tabKey === "attributes") {
@@ -162,10 +165,10 @@ const AttributesPane = ({
 
               // check to see if there are any current attributes or ommitted popups setup for the layer
               const existingLayerattributeVariableFields = Object.keys(
-                attributeVariableValues.current[layerName] || {}
+                attributeProps?.variables?.[layerName] || {}
               );
               const existingOmittedPopupAttributesFields =
-                omittedPopupAttributesValues.current[layerName] || [];
+                attributeProps?.omitted?.[layerName] || [];
 
               // get a unique array of attributes already configured for either popups or attributes
               const existingAttributes = [
@@ -214,10 +217,14 @@ const AttributesPane = ({
           // set states and refs after processing all done
           setAttributes(layerAttributes);
           setLayerPopupSwitch(popupSwitchValues);
-          attributeVariableValues.current =
-            extractVariableInputs(layerAttributes);
-          omittedPopupAttributesValues.current =
-            extractFalsePopups(layerAttributes);
+
+          setAttributeProps((previousAttributeProps) => ({
+            ...previousAttributeProps,
+            ...{
+              variables: extractVariableInputs(layerAttributes),
+              omitted: extractFalsePopups(layerAttributes),
+            },
+          }));
         });
       }
     }
@@ -256,14 +263,14 @@ const AttributesPane = ({
 
         // check to see if the attribute is already being omitted in the popup
         const existingPopup =
-          !omittedPopupAttributesValues.current[layerName] ||
-          !omittedPopupAttributesValues.current[layerName].includes(name);
+          !attributeProps?.omitted?.[layerName] ||
+          !attributeProps.omitted[layerName].includes(name);
         layerAttribute["popup"] = existingPopup;
 
         // check to see if the attribute is already configured for a variable
         const existingvariableInput =
-          attributeVariableValues.current[layerName] &&
-          attributeVariableValues.current[layerName][name];
+          attributeProps?.variables?.[layerName] &&
+          attributeProps.variables[layerName][name];
         layerAttribute["variableInput"] = existingvariableInput ?? "";
 
         newObj[layerName].push(layerAttribute);
@@ -333,14 +340,13 @@ const AttributesPane = ({
     }
     setAttributes(updatedAttributes);
 
-    // extract attribute variables and set state and ref
-    attributeVariableValues.current = extractVariableInputs(updatedAttributes);
-    setAttributeVariables(attributeVariableValues.current);
-
-    // extract omitted popups and set state and ref
-    omittedPopupAttributesValues.current =
-      extractFalsePopups(updatedAttributes);
-    setOmittedPopupAttributes(omittedPopupAttributesValues.current);
+    setAttributeProps((previousAttributeProps) => ({
+      ...previousAttributeProps,
+      ...{
+        variables: extractVariableInputs(updatedAttributes),
+        omitted: extractFalsePopups(updatedAttributes),
+      },
+    }));
 
     // if a popup is being altered, check to see if the header checkbox needs to be updated
     if (field === "popup") {
@@ -375,120 +381,142 @@ const AttributesPane = ({
       })),
     };
 
-    // update states and refs
-    omittedPopupAttributesValues.current =
-      extractFalsePopups(updatedAttributes);
+    setAttributeProps((previousAttributeProps) => ({
+      ...previousAttributeProps,
+      ...{
+        omitted: extractFalsePopups(updatedAttributes),
+      },
+    }));
     setAttributes(updatedAttributes);
-    setOmittedPopupAttributes(omittedPopupAttributesValues.current);
+  }
+
+  function updatedQueryable(e) {
+    const newqueryable = e.target.checked;
+    setQueryable(newqueryable);
   }
 
   return (
     <>
-      {errorMessage ? (
-        <Alert key="danger" variant="danger" dismissible>
-          {errorMessage}
-        </Alert>
-      ) : (
+      <QueryLabel>
+        <input
+          type="checkbox"
+          onChange={updatedQueryable}
+          checked={queryable}
+        ></input>{" "}
+        Allow Layer Query
+      </QueryLabel>
+      {queryable && (
         <>
-          {warningMessage && (
-            <Alert key="warning" variant="warning" dismissible>
-              {warningMessage}
+          {errorMessage ? (
+            <Alert key="danger" variant="danger" dismissible>
+              {errorMessage}
             </Alert>
-          )}
-          {customAttributes === null ? (
-            <StyledSpinner
-              data-testid="Loading..."
-              animation="border"
-              variant="info"
-            />
-          ) : customAttributes ? (
-            Object.keys(attributes).map((layerName, index) => (
-              <div key={index}>
-                <p>
-                  <b>{layerName}</b>:
-                </p>
-                <FixedTable striped bordered hover size="sm">
-                  <thead>
-                    <tr>
-                      <th className="text-center" style={{ width: "25%" }}>
-                        Name
-                      </th>
-                      <th className="text-center" style={{ width: "25%" }}>
-                        Alias
-                      </th>
-                      <th className="text-center" style={{ width: "20%" }}>
-                        Show in popup
-                        <br />
-                        <input
-                          type="checkbox"
-                          checked={layerPopupSwitch[layerName]}
-                          onChange={(e) =>
-                            handleLayerPopup(layerName, e.target.checked)
-                          }
-                        />
-                      </th>
-                      <th className="text-center">Variable Input Name</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {attributes[layerName].map(({ name, alias }, index) => (
-                      <tr key={index}>
-                        <OverflowTD>{name}</OverflowTD>
-                        <OverflowTD>{alias}</OverflowTD>
-                        <CenteredTD>
-                          <input
-                            type="checkbox"
-                            checked={attributes[layerName][index]["popup"]}
-                            onChange={(e) => {
-                              updateAttributes({
-                                index,
-                                layerName,
-                                field: "popup",
-                                fieldChange: e.target.checked,
-                              });
-                            }}
-                          />
-                        </CenteredTD>
-                        <td>
-                          <StyledInput
-                            value={
-                              attributes[layerName][index]["variableInput"]
-                            }
-                            onChange={(e) => {
-                              updateAttributes({
-                                index,
-                                layerName,
-                                field: "variableInput",
-                                fieldChange: e.target.value,
-                              });
-                            }}
-                          />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </FixedTable>
-              </div>
-            ))
           ) : (
-            Object.keys(attributes).map((layerName, index) => (
-              <InputTable
-                key={index}
-                label={layerName}
-                onChange={({ newValue, field, fullChange }) =>
-                  updateAttributes({
-                    index,
-                    layerName,
-                    field,
-                    fieldChange: newValue,
-                    fullChange: fullChange,
-                  })
-                }
-                values={attributes[layerName]}
-                allowRowCreation={true}
-                headers={["Name", "Show in popup", "Variable Input Name"]}
-              />
-            ))
+            <>
+              {warningMessage && (
+                <Alert key="warning" variant="warning" dismissible>
+                  {warningMessage}
+                </Alert>
+              )}
+              {customAttributes === null ? (
+                <StyledSpinner
+                  data-testid="Loading..."
+                  animation="border"
+                  variant="info"
+                />
+              ) : customAttributes ? (
+                Object.keys(attributes).map((layerName, index) => (
+                  <div key={index}>
+                    <p>
+                      <b>{layerName}</b>:
+                    </p>
+                    <FixedTable striped bordered hover size="sm">
+                      <thead>
+                        <tr>
+                          <th className="text-center" style={{ width: "25%" }}>
+                            Name
+                          </th>
+                          <th className="text-center" style={{ width: "25%" }}>
+                            Alias
+                          </th>
+                          <th className="text-center" style={{ width: "20%" }}>
+                            Show in popup
+                            <br />
+                            <input
+                              type="checkbox"
+                              checked={layerPopupSwitch[layerName]}
+                              onChange={(e) =>
+                                handleLayerPopup(layerName, e.target.checked)
+                              }
+                              aria-label="Show in popup header"
+                            />
+                          </th>
+                          <th className="text-center">Variable Input Name</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {attributes[layerName].map(({ name, alias }, index) => (
+                          <tr key={index}>
+                            <OverflowTD>{name}</OverflowTD>
+                            <OverflowTD>{alias}</OverflowTD>
+                            <CenteredTD>
+                              <input
+                                type="checkbox"
+                                checked={attributes[layerName][index]["popup"]}
+                                aria-label="Show in popup row"
+                                onChange={(e) => {
+                                  updateAttributes({
+                                    index,
+                                    layerName,
+                                    field: "popup",
+                                    fieldChange: e.target.checked,
+                                  });
+                                }}
+                              />
+                            </CenteredTD>
+                            <td>
+                              <StyledInput
+                                value={
+                                  attributes[layerName][index]["variableInput"]
+                                }
+                                aria-label="variable row"
+                                onChange={(e) => {
+                                  updateAttributes({
+                                    index,
+                                    layerName,
+                                    field: "variableInput",
+                                    fieldChange: e.target.value,
+                                  });
+                                }}
+                              />
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </FixedTable>
+                  </div>
+                ))
+              ) : (
+                Object.keys(attributes).map((layerName, index) => (
+                  <InputTable
+                    key={index}
+                    label={layerName}
+                    onChange={({ newValue, field, fullChange }) =>
+                      updateAttributes({
+                        index,
+                        layerName,
+                        field,
+                        fieldChange: newValue,
+                        fullChange: fullChange,
+                      })
+                    }
+                    values={attributes[layerName]}
+                    allowRowCreation={true}
+                    headers={["Name", "Show in popup", "Variable Input Name"]}
+                  />
+                ))
+              )}
+            </>
           )}
         </>
       )}
@@ -497,10 +525,8 @@ const AttributesPane = ({
 };
 
 AttributesPane.propTypes = {
-  attributeVariables: attributeVariablesPropType, // react state that tracks what attributes are configured for variables
-  setAttributeVariables: PropTypes.func.isRequired, // state setter for attributeVariables
-  omittedPopupAttributes: omittedPopupAttributesPropType, // react state that tracks what attributes are not shown in popups
-  setOmittedPopupAttributes: PropTypes.func.isRequired, // state setter for omittedPopupAttributes
+  attributeProps: attributePropsPropType, // react state that tracks attribute properties
+  setAttributeProps: PropTypes.func, // state setter for attributeProps
   sourceProps: sourcePropType, // configuration and properties for openlayers layer source
   layerProps: PropTypes.shape({
     name: PropTypes.string,

--- a/reactapp/components/modals/MapLayer/AttributesPane.js
+++ b/reactapp/components/modals/MapLayer/AttributesPane.js
@@ -7,8 +7,6 @@ import {
   getLayerAttributes,
   sourcePropertiesOptions,
   attributePropsPropType,
-  attributeVariablesPropType,
-  omittedPopupAttributesPropType,
   sourcePropType,
 } from "components/map/utilities";
 import Spinner from "react-bootstrap/Spinner";

--- a/reactapp/components/modals/MapLayer/AttributesPane.js
+++ b/reactapp/components/modals/MapLayer/AttributesPane.js
@@ -61,7 +61,9 @@ const AttributesPane = ({
   const previousSourceProps = useRef({});
   const [customAttributes, setCustomAttributes] = useState(null);
   const [layerPopupSwitch, setLayerPopupSwitch] = useState({});
-  const [queryable, setQueryable] = useState(true);
+  const [allowLayerQuery, setAllowLayerQuery] = useState(
+    attributeProps.queryable ?? true
+  );
 
   useEffect(() => {
     if (tabKey === "attributes") {
@@ -391,8 +393,16 @@ const AttributesPane = ({
   }
 
   function updatedQueryable(e) {
-    const newqueryable = e.target.checked;
-    setQueryable(newqueryable);
+    const newAllowLayerQuery = e.target.checked;
+    setAllowLayerQuery(newAllowLayerQuery);
+
+    setAttributeProps((previousAttributeProps) => {
+      const { queryable, ...rest } = previousAttributeProps;
+
+      return newAllowLayerQuery
+        ? rest // remove 'queryable'
+        : { ...rest, queryable: newAllowLayerQuery }; // keep or set it to false
+    });
   }
 
   return (
@@ -401,11 +411,11 @@ const AttributesPane = ({
         <input
           type="checkbox"
           onChange={updatedQueryable}
-          checked={queryable}
+          checked={allowLayerQuery}
         ></input>{" "}
         Allow Layer Query
       </QueryLabel>
-      {queryable && (
+      {allowLayerQuery && (
         <>
           {errorMessage ? (
             <Alert key="danger" variant="danger" dismissible>

--- a/reactapp/components/modals/MapLayer/MapLayer.js
+++ b/reactapp/components/modals/MapLayer/MapLayer.js
@@ -121,6 +121,10 @@ const MapLayerModal = ({
       mapConfiguration.omittedPopupAttributes = attributeProps.omitted;
     }
 
+    if (attributeProps.queryable === false) {
+      mapConfiguration.queryable = false;
+    }
+
     if (legend && Object.keys(legend).length > 0) {
       if (legend.title === "") {
         setErrorMessage(

--- a/reactapp/components/modals/MapLayer/MapLayer.js
+++ b/reactapp/components/modals/MapLayer/MapLayer.js
@@ -54,14 +54,11 @@ const MapLayerModal = ({
   const [errorMessage, setErrorMessage] = useState(null);
   const [sourceProps, setSourceProps] = useState(layerInfo.sourceProps ?? {});
   const [layerProps, setLayerProps] = useState(layerInfo.layerProps ?? {});
+  const [attributeProps, setAttributeProps] = useState(
+    layerInfo.attributeProps ?? {}
+  );
   const [style, setStyle] = useState(layerInfo.style);
   const [legend, setLegend] = useState(layerInfo.legend);
-  const [attributeVariables, setAttributeVariables] = useState(
-    layerInfo.attributeVariables
-  );
-  const [omittedPopupAttributes, setOmittedPopupAttributes] = useState(
-    layerInfo.omittedPopupAttributes
-  );
   const containerRef = useRef(null);
   const { csrf } = useContext(AppContext);
 
@@ -86,8 +83,6 @@ const MapLayerModal = ({
       );
       return;
     }
-
-    const minAttributeVariables = removeEmptyValues(attributeVariables);
 
     if (sourceProps.type === "Vector Tile") {
       validSourceProps.urls = validSourceProps.urls.split(",");
@@ -114,12 +109,16 @@ const MapLayerModal = ({
       },
     };
 
+    const minAttributeVariables = removeEmptyValues(
+      attributeProps.variables ?? {}
+    );
+
     if (Object.keys(minAttributeVariables).length > 0) {
       mapConfiguration.attributeVariables = minAttributeVariables;
     }
 
-    if (Object.keys(omittedPopupAttributes).length > 0) {
-      mapConfiguration.omittedPopupAttributes = omittedPopupAttributes;
+    if (Object.keys(attributeProps.omitted ?? []).length > 0) {
+      mapConfiguration.omittedPopupAttributes = attributeProps.omitted;
     }
 
     if (legend && Object.keys(legend).length > 0) {
@@ -219,8 +218,7 @@ const MapLayerModal = ({
               <SourcePane
                 sourceProps={sourceProps}
                 setSourceProps={setSourceProps}
-                setAttributeVariables={setAttributeVariables}
-                setOmittedPopupAttributes={setOmittedPopupAttributes}
+                setAttributeProps={setAttributeProps}
               />
             </Tab>
             <Tab
@@ -252,10 +250,8 @@ const MapLayerModal = ({
               className="layer-attributes-tab"
             >
               <AttributesPane
-                attributeVariables={attributeVariables}
-                setAttributeVariables={setAttributeVariables}
-                omittedPopupAttributes={omittedPopupAttributes}
-                setOmittedPopupAttributes={setOmittedPopupAttributes}
+                attributeProps={attributeProps}
+                setAttributeProps={setAttributeProps}
                 sourceProps={sourceProps}
                 layerProps={layerProps}
                 tabKey={tabKey}

--- a/reactapp/components/modals/MapLayer/MapLayer.js
+++ b/reactapp/components/modals/MapLayer/MapLayer.js
@@ -15,10 +15,9 @@ import { AppContext } from "components/contexts/Contexts";
 import {
   sourcePropertiesOptions,
   layerPropType,
-  omittedPopupAttributesPropType,
-  attributeVariablesPropType,
   legendPropType,
   sourcePropType,
+  attributePropsPropType,
   saveLayerJSON,
 } from "components/map/utilities";
 import {
@@ -306,8 +305,7 @@ MapLayerModal.propTypes = {
     }), // an object of layer properties like opacity, zoom, etc. see components/map/utilities.js (layerPropertiesOptions) for examples
     legend: legendPropType,
     style: PropTypes.string, // name of .json file that is save with the application that contain the actual style json
-    attributeVariables: attributeVariablesPropType,
-    omittedPopupAttributes: omittedPopupAttributesPropType,
+    attributeProps: attributePropsPropType,
   }),
   mapLayers: PropTypes.arrayOf(layerPropType),
   existingLayerOriginalName: PropTypes.shape({

--- a/reactapp/components/modals/MapLayer/SourcePane.js
+++ b/reactapp/components/modals/MapLayer/SourcePane.js
@@ -88,12 +88,7 @@ function parsePropertiesArray(properties) {
   }, {});
 }
 
-const SourcePane = ({
-  sourceProps,
-  setSourceProps,
-  setAttributeVariables,
-  setOmittedPopupAttributes,
-}) => {
+const SourcePane = ({ sourceProps, setSourceProps, setAttributeProps }) => {
   const [sourceProperties, setSourceProperties] = useState([]); // array of objects that represent properties that will be rendered in the table
   const [propertyPlaceholders, SetPropertyPlaceholders] = useState([]); // array of objects that represent placeholders for the table inputs
   const [propertyTypes, SetPropertyTypes] = useState([]); // array of objects that represent types for the table inputs
@@ -174,8 +169,7 @@ const SourcePane = ({
     }));
 
     // reset attribute variable and omitted popup attributes since the source has changed
-    setAttributeVariables({});
-    setOmittedPopupAttributes({});
+    setAttributeProps({});
   }
 
   function handleGeoJSONUpload({ fileContent }) {
@@ -247,8 +241,7 @@ const SourcePane = ({
 SourcePane.propTypes = {
   sourceProps: sourcePropType,
   setSourceProps: PropTypes.func, // setter for sourceProps state
-  setAttributeVariables: PropTypes.func, // setter for attributeVariables state
-  setOmittedPopupAttributes: PropTypes.func, // setter for omittedPopupAttributes state
+  setAttributeProps: PropTypes.func, // setter for attributeProps state
 };
 
 export default SourcePane;

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -287,32 +287,42 @@ const MapVisualization = ({
     markerLayer.current = newMarkerLayer;
     map.addLayer(newMarkerLayer);
 
+    const queryableLayers = layers.filter(
+      (item) => !(item.queryable === false)
+    );
+
     // reduce the layer attributes variables values into a simplified object of layer names and then values
-    const mapAttributeVariables = layers.reduce((combined, current) => {
-      if (
-        current.attributeVariables &&
-        typeof current.attributeVariables === "object"
-      ) {
-        // Merge the example object into the combined object
-        Object.assign(combined, current.attributeVariables);
-      }
-      return combined;
-    }, {});
+    const mapAttributeVariables = queryableLayers.reduce(
+      (combined, current) => {
+        if (
+          current.attributeVariables &&
+          typeof current.attributeVariables === "object"
+        ) {
+          // Merge the example object into the combined object
+          Object.assign(combined, current.attributeVariables);
+        }
+        return combined;
+      },
+      {}
+    );
 
     // reduce the layer omitted popup attribute values into a simplified object of layer names and then values
-    const mapOmittedPopupAttributes = layers.reduce((combined, current) => {
-      if (
-        current.omittedPopupAttributes &&
-        typeof current.omittedPopupAttributes === "object"
-      ) {
-        // Merge the example object into the combined object
-        Object.assign(combined, current.omittedPopupAttributes);
-      }
-      return combined;
-    }, {});
+    const mapOmittedPopupAttributes = queryableLayers.reduce(
+      (combined, current) => {
+        if (
+          current.omittedPopupAttributes &&
+          typeof current.omittedPopupAttributes === "object"
+        ) {
+          // Merge the example object into the combined object
+          Object.assign(combined, current.omittedPopupAttributes);
+        }
+        return combined;
+      },
+      {}
+    );
 
     // query the layers
-    const queryCalls = layers.map((layer) =>
+    const queryCalls = queryableLayers.map((layer) =>
       queryLayerFeatures(layer, map, coordinate, pixel)
         .then((layerFeatures) => {
           // [{attributes: {key: value}, geometry: {x: "", y: ""}, layerName: ""}]


### PR DESCRIPTION
This PR adds an option for layers to not be queried when clicked. This allows layers to be added to a map to more of a visual reference and help instead of an interactive element.