### PR TITLE
Updated pyproj to export all the different format files on the conda env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ include = ["tethysapp*"]
     "*.css",
     "*.gltf",
     "*.json",
+    "*.geojson",
     "*.svg",
 ]
 


### PR DESCRIPTION
Added wildcard to allow for images and other formats outside the `/public/` folder