### PR TITLE
feat(mcp): plan 005 — advanced metadata, runtime plugins, GeoJSON cap

### DIFF
--- a/reactapp/__tests__/scripts/sourcePropertiesOptionsDrift.test.js
+++ b/reactapp/__tests__/scripts/sourcePropertiesOptionsDrift.test.js
@@ -1,4 +1,7 @@
-import { sourcePropertiesOptions } from "components/map/utilities";
+import {
+  sourcePropertiesOptions,
+  layerPropertiesOptions,
+} from "components/map/utilities";
 import fs from "fs";
 import path from "path";
 
@@ -25,10 +28,20 @@ const fixturePath = path.resolve(
 );
 
 describe("sourcePropertiesOptions cross-language drift guard", () => {
-  test("JS keys equal the committed fixture snapshot", () => {
+  test("JS source-type keys equal the committed fixture snapshot", () => {
     const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
     const jsKeys = Object.keys(sourcePropertiesOptions).sort();
     expect(jsKeys).toEqual(fixture.source_types);
+  });
+
+  test("JS layer-property keys equal the committed fixture snapshot", () => {
+    // Plan-005 B2 extension: catches the same bug class as source-types
+    // for layer-level props (opacity, minZoomQuery, etc). When the JS side
+    // adds a new layerPropertiesOptions key, this fails until the fixture
+    // and Python LAYER_PROPERTIES_ALLOWLIST are updated.
+    const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+    const jsKeys = Object.keys(layerPropertiesOptions).sort();
+    expect(jsKeys).toEqual(fixture.layer_properties);
   });
 
   test("fixture deferred_in_backend entries are a subset of JS keys", () => {

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -15,6 +15,7 @@ Connects to chatbox via MCP SSE transport on port 9001.
 """
 
 import logging
+import math
 import os
 import json
 import re
@@ -32,6 +33,7 @@ import requests as http_requests
 from tethysapp.tethysdash.plugin_helpers import (
     LAYER_PROPERTIES_ALLOWLIST,
     LayerConfigurationBuilder,
+    get_allowed_source_prop_keys,
 )
 from tethysapp.tethysdash.editable_schemas import (
     LLM_EDITABLE_PATHS,
@@ -57,6 +59,7 @@ mcp = FastMCP(
                 "create_variable_input",
                 "create_map_visualization",
                 "add_map_service_layer",
+                "add_dynamic_map_layer",
                 "patch_visualization",
                 "render_plugin",
                 "render_custom_visualization",
@@ -1104,6 +1107,12 @@ def add_map_service_layer(
         # without it, layer_props={"opacity": True} passes the (int, float)
         # check and persists `true` as the JSON value, which OpenLayers
         # treats as the boolean rather than the integer 1.
+        # NaN/Infinity check: float('nan') and float('inf') pass isinstance
+        # but produce invalid JSON (json.dumps emits NaN/Infinity literals
+        # that fail RFC-compliant parsers). Persisting them breaks the
+        # renderer downstream. Only opacity has a range guard inside the
+        # builder (set_opacity); the other 5 props have no finite-value
+        # check, so reject non-finite values at the boundary.
         for key, val in layer_props.items():
             expected = LAYER_PROPERTIES_ALLOWLIST[key]
             numeric_only = expected == (int, float) or expected in (int, float)
@@ -1114,6 +1123,13 @@ def add_map_service_layer(
                     "error": (
                         f"layer_props[{key!r}] must be of type "
                         f"{expected!r}; got {type(val).__name__}."
+                    )
+                }
+            if numeric_only and isinstance(val, float) and not math.isfinite(val):
+                return {
+                    "error": (
+                        f"layer_props[{key!r}] must be a finite number; "
+                        f"got {val!r}."
                     )
                 }
         # Conflict check.
@@ -1138,6 +1154,21 @@ def add_map_service_layer(
 
     if source_props is not None and not isinstance(source_props, dict):
         return {"error": "source_props must be a dict (or JSON-string dict)."}
+    if source_props:
+        # Per-source-type key allowlist: rejects keys absent from
+        # available_source_properties[source_type]['required'|'optional'].
+        # The tool description promises this validation; this enforces it.
+        # Symmetric with layer_props's LAYER_PROPERTIES_ALLOWLIST guard.
+        allowed_source_keys = get_allowed_source_prop_keys(source_type)
+        unknown_source_keys = set(source_props) - allowed_source_keys
+        if unknown_source_keys:
+            return {
+                "error": (
+                    f"source_props contains keys not in the {source_type!r} "
+                    f"allowlist: {sorted(unknown_source_keys)}. "
+                    f"Allowed: {sorted(allowed_source_keys)}"
+                )
+            }
 
     # ------------------------------------------------------------------
     # Phase 3: Delegate to LayerConfigurationBuilder. Builder owns

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -644,12 +644,25 @@ def create_map_visualization(
 # collection that gets re-served on every dashboard fetch. Operators
 # can raise the limits via env vars (e.g. for legitimate large
 # datasets); defaults are conservative.
-GEOJSON_MAX_BYTES = int(
-    os.environ.get("TETHYSDASH_MCP_GEOJSON_MAX_BYTES", str(5 * 1024 * 1024))
-)
-GEOJSON_MAX_FEATURES = int(
-    os.environ.get("TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", "10000")
-)
+def _env_int(name: str, default: int) -> int:
+    """Parse an integer from env var; fall back to default with a warning
+    if the env value is missing or non-numeric. Avoids crashing module
+    import on operator misconfiguration (e.g. setting MAX_BYTES='5mb')."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        LOGGER.warning(
+            "Env var %s=%r is not a valid integer; using default %d.",
+            name, raw, default,
+        )
+        return default
+
+
+GEOJSON_MAX_BYTES = _env_int("TETHYSDASH_MCP_GEOJSON_MAX_BYTES", 5 * 1024 * 1024)
+GEOJSON_MAX_FEATURES = _env_int("TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", 10000)
 
 
 VALID_SOURCE_TYPES = [
@@ -714,10 +727,13 @@ def _resolve_esri_layer_name(url: str, layer_id: Optional[str]) -> Optional[str]
 @mcp.tool(
     name="add_map_service_layer",
     description=(
-        "Add a WMS, ESRI, GeoJSON, KML, or tile service layer to an existing "
-        "map created by create_map_visualization. When the layer comes from "
-        "a feature lookup, fetch the layer name and bounding box from a "
-        "data-source tool first, then pass them through to this call."
+        "Add a WMS, ESRI, GeoJSON, KML, Static Image, or tile service layer "
+        "to an existing map created by create_map_visualization. Supports "
+        "legend, style, popup configuration, attribute aliases, opacity, "
+        "and zoom limits via optional advanced parameters. When the layer "
+        "comes from a feature lookup, fetch the layer name and bounding "
+        "box from a data-source tool first, then pass them through to "
+        "this call."
     ),
     tags=["map", "layer", "geographic"],
 )
@@ -816,19 +832,42 @@ def add_map_service_layer(
     )
 
     # Coerce JSON strings to dicts — some LLM providers serialize object
-    # arguments as strings instead of parsed objects.
-    if isinstance(geojson, str):
-        geojson = json.loads(geojson)
-    if isinstance(attribute_variables, str):
-        attribute_variables = json.loads(attribute_variables)
-    if isinstance(params, str):
-        params = json.loads(params)
-    if isinstance(source_props, str):
-        source_props = json.loads(source_props)
-    if isinstance(layer_props, str):
-        layer_props = json.loads(layer_props)
-    if isinstance(popup_options, str):
-        popup_options = json.loads(popup_options)
+    # arguments as strings instead of parsed objects. Wrap each in a guard
+    # so a malformed string yields an MCP {"error": ...} rather than an
+    # opaque ToolError from FastMCP.
+    for _arg_name, _arg_value in (
+        ("geojson", geojson),
+        ("attribute_variables", attribute_variables),
+        ("params", params),
+        ("source_props", source_props),
+        ("layer_props", layer_props),
+        ("popup_options", popup_options),
+    ):
+        if isinstance(_arg_value, str):
+            try:
+                _decoded = json.loads(_arg_value)
+            except json.JSONDecodeError as exc:
+                return {
+                    "error": (
+                        f"{_arg_name} is not valid JSON: {exc.msg} "
+                        f"(line {exc.lineno}, col {exc.colno})."
+                    )
+                }
+            # Re-bind the local variable by name. locals()[name] = ... would
+            # be unreliable inside a function; explicit branches keep the
+            # rebind visible to static analysis.
+            if _arg_name == "geojson":
+                geojson = _decoded
+            elif _arg_name == "attribute_variables":
+                attribute_variables = _decoded
+            elif _arg_name == "params":
+                params = _decoded
+            elif _arg_name == "source_props":
+                source_props = _decoded
+            elif _arg_name == "layer_props":
+                layer_props = _decoded
+            elif _arg_name == "popup_options":
+                popup_options = _decoded
 
     # Plan-005 S2 cap: reject oversized inline GeoJSON before any further
     # processing. Cap is dynamically read from env vars at call time so
@@ -836,13 +875,18 @@ def add_map_service_layer(
     # NB: only inline dict payloads are capped; geojson_url is unaffected
     # (the cost is borne by the browser at render time, not the server).
     if isinstance(geojson, dict):
-        max_features = int(os.environ.get(
-            "TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", str(GEOJSON_MAX_FEATURES)
-        ))
-        max_bytes = int(os.environ.get(
-            "TETHYSDASH_MCP_GEOJSON_MAX_BYTES", str(GEOJSON_MAX_BYTES)
-        ))
-        feature_count = len(geojson.get("features", []))
+        max_features = _env_int(
+            "TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", GEOJSON_MAX_FEATURES
+        )
+        max_bytes = _env_int(
+            "TETHYSDASH_MCP_GEOJSON_MAX_BYTES", GEOJSON_MAX_BYTES
+        )
+        # `or []` (not the `.get(..., [])` default) handles BOTH the
+        # missing-key case AND the explicit `features: None` case. The
+        # second is a real adversarial input — `len(None)` would otherwise
+        # raise unhandled TypeError before validate_geojson can produce
+        # a clean error.
+        feature_count = len(geojson.get("features") or [])
         if feature_count > max_features:
             return {
                 "error": (
@@ -1038,7 +1082,7 @@ def add_map_service_layer(
     # Conflict check: flat layer params vs layer_props dict. The same
     # prop must not arrive through both paths — silent winner would be
     # a quiet bug class. Surface the conflict to the LLM.
-    _LAYER_PROP_FLAT_TO_DICT = {
+    flat_to_dict_layer_props = {
         "opacity": ("opacity", opacity),
         "min_zoom": ("minZoom", min_zoom),
         "max_zoom": ("maxZoom", max_zoom),
@@ -1055,10 +1099,17 @@ def add_map_service_layer(
                     f"Allowed: {sorted(LAYER_PROPERTIES_ALLOWLIST)}"
                 )
             }
-        # Per-key value-type validation.
+        # Per-key value-type validation. The explicit `not isinstance(val, bool)`
+        # check is necessary because Python's bool is a subclass of int —
+        # without it, layer_props={"opacity": True} passes the (int, float)
+        # check and persists `true` as the JSON value, which OpenLayers
+        # treats as the boolean rather than the integer 1.
         for key, val in layer_props.items():
             expected = LAYER_PROPERTIES_ALLOWLIST[key]
-            if not isinstance(val, expected):
+            numeric_only = expected == (int, float) or expected in (int, float)
+            if not isinstance(val, expected) or (
+                numeric_only and isinstance(val, bool)
+            ):
                 return {
                     "error": (
                         f"layer_props[{key!r}] must be of type "
@@ -1066,7 +1117,7 @@ def add_map_service_layer(
                     )
                 }
         # Conflict check.
-        for flat_name, (dict_key, flat_value) in _LAYER_PROP_FLAT_TO_DICT.items():
+        for flat_name, (dict_key, flat_value) in flat_to_dict_layer_props.items():
             if flat_value is not None and dict_key in layer_props:
                 return {
                     "error": (
@@ -1707,6 +1758,12 @@ def list_intake_plugins() -> Dict[str, Any]:
                     "source": opt.get("source", ""),
                     "label": opt.get("label", ""),
                     "type": opt.get("type", ""),
+                    # Surfaces eligibility for add_dynamic_map_layer.
+                    # A plugin is callable through that tool only when
+                    # type=='map_layer' AND dynamic_map_layer=True.
+                    "dynamic_map_layer": bool(
+                        opt.get("dynamic_map_layer", False)
+                    ),
                 }
                 # Extract just argument names from the args schema
                 args = opt.get("args", {})
@@ -1735,10 +1792,14 @@ def _resolve_dynamic_map_layer_plugin(source: str) -> Dict[str, Any]:
             timeout=10,
         )
         response.raise_for_status()
-    except http_requests.RequestException as exc:
+        # response.json() must stay inside the try: a 200 with non-JSON body
+        # (Tethys session-expired login redirect, reverse-proxy maintenance
+        # page) raises requests.exceptions.JSONDecodeError, which is NOT a
+        # RequestException subclass and would otherwise propagate uncaught.
+        data = response.json()
+    except (http_requests.RequestException, ValueError) as exc:
         return {"error": f"Failed to fetch plugin metadata: {exc}"}
 
-    data = response.json()
     groups = data.get("visualizations", []) if isinstance(data, dict) else []
 
     for group in groups:
@@ -1806,9 +1867,19 @@ def add_dynamic_map_layer(
     )
 
     # Coerce JSON-string args (consistent with the existing dict-parameter
-    # coercion pattern used across these tools).
+    # coercion pattern used across these tools). Wrap json.loads so a
+    # malformed string yields a clean MCP error rather than an opaque
+    # ToolError from FastMCP.
     if isinstance(args, str):
-        args = json.loads(args)
+        try:
+            args = json.loads(args)
+        except json.JSONDecodeError as exc:
+            return {
+                "error": (
+                    f"args is not valid JSON: {exc.msg} "
+                    f"(line {exc.lineno}, col {exc.colno})."
+                )
+            }
     # set_plugin_source raises on non-dict args; coerce None → {} at the
     # boundary so callers don't need to know that detail.
     if args is None:

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -29,7 +29,10 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import Response as StarletteResponse
 import requests as http_requests
 
-from tethysapp.tethysdash.plugin_helpers import LayerConfigurationBuilder
+from tethysapp.tethysdash.plugin_helpers import (
+    LAYER_PROPERTIES_ALLOWLIST,
+    LayerConfigurationBuilder,
+)
 from tethysapp.tethysdash.editable_schemas import (
     LLM_EDITABLE_PATHS,
     is_path_allowed,
@@ -758,6 +761,35 @@ def add_map_service_layer(
     opacity: Annotated[Optional[float], Field(description="Layer opacity from 0 (transparent) to 1 (opaque)")] = None,
     min_zoom: Annotated[Optional[int], Field(description="Minimum zoom level at which the layer is visible")] = None,
     max_zoom: Annotated[Optional[int], Field(description="Maximum zoom level at which the layer is visible")] = None,
+    legend: Annotated[Optional[Union[str, Dict[str, Any]]], Field(description=(
+        "Layer legend. Pass 'default' to use the source's default legend, a "
+        "URL string for a hosted legend image, or a dict for a custom legend "
+        "definition (the dict shape mirrors the UI's Legend tab)."
+    ))] = None,
+    style: Annotated[Optional[Union[str, Dict[str, Any]]], Field(description=(
+        "Layer style. Pass a URL string (style JSON hosted externally) or "
+        "a dict for an inline style definition."
+    ))] = None,
+    source_props: Annotated[Optional[Union[Dict[str, Any], str]], Field(description=(
+        "Advanced source-side properties merged into source.props. Validated "
+        "against the source-type's available_source_properties allowlist; "
+        "unknown keys are rejected. Use this for source props beyond the "
+        "first-class flat parameters (e.g., projection on Image Tile, "
+        "tileSize on PMTiles)."
+    ))] = None,
+    layer_props: Annotated[Optional[Union[Dict[str, Any], str]], Field(description=(
+        "Advanced layer-level properties (opacity, minResolution, "
+        "maxResolution, minZoom, maxZoom, minZoomQuery). Validated against "
+        "the LAYER_PROPERTIES_ALLOWLIST. Per-key value-type validation is "
+        "applied. Conflicts with the corresponding flat parameter (e.g., "
+        "opacity, min_zoom, max_zoom) are rejected — pick one path per prop."
+    ))] = None,
+    popup_options: Annotated[Optional[Union[Dict[str, Any], str]], Field(description=(
+        "Click-popup options. Accepts {'aliases': {layer_name: {field: alias}}} "
+        "and {'omit': {layer_name: [field, ...]}} sub-dicts. The 'aliases' "
+        "shape mirrors the UI's attribute-aliases tab; 'omit' marks fields "
+        "to hide from popups."
+    ))] = None,
 ) -> Dict[str, Any]:
     """Add a service layer to an existing map.
 
@@ -778,6 +810,12 @@ def add_map_service_layer(
         attribute_variables = json.loads(attribute_variables)
     if isinstance(params, str):
         params = json.loads(params)
+    if isinstance(source_props, str):
+        source_props = json.loads(source_props)
+    if isinstance(layer_props, str):
+        layer_props = json.loads(layer_props)
+    if isinstance(popup_options, str):
+        popup_options = json.loads(popup_options)
 
     # Validate source_type
     if source_type not in VALID_SOURCE_TYPES:
@@ -849,13 +887,17 @@ def add_map_service_layer(
     # resolution all stay MCP-side per plan 004 K3 — the builder receives
     # already-canonicalized inputs.
     # ------------------------------------------------------------------
-    source_props: Dict[str, Any] = {}
+    # Phase-1-local source props (assembled from flat params). Kept under a
+    # different name from the user-facing `source_props` parameter (the
+    # "advanced" dict) so the conflict check downstream can distinguish
+    # the two. Both are merged before delegation to the builder.
+    _flat_source_props: Dict[str, Any] = {}
     geojson_payload: Optional[Union[Dict[str, Any], str]] = None
 
     if source_type == "WMS":
         wms_params = {"LAYERS": wms_layers}
         wms_params.update(extra_params)
-        source_props = {"url": url, "params": wms_params}
+        _flat_source_props = {"url": url, "params": wms_params}
 
     elif source_type == "ESRI Image and Map Service":
         esri_params = {}
@@ -883,13 +925,13 @@ def add_map_service_layer(
                 esri_params["LAYERS"] = "show:" + layers_value
             else:
                 esri_params["LAYERS"] = layers_value
-        source_props = {"url": url}
+        _flat_source_props = {"url": url}
         if esri_params:
-            source_props["params"] = esri_params
+            _flat_source_props["params"] = esri_params
 
     elif source_type == "ESRI Feature Service":
-        source_props = {"url": url, "layer": int(layer_id)}
-        source_props.update(extra_params)
+        _flat_source_props = {"url": url, "layer": int(layer_id)}
+        _flat_source_props.update(extra_params)
 
     elif source_type == "GeoJSON":
         # GeoJSON goes on the source object directly (not under props).
@@ -905,22 +947,22 @@ def add_map_service_layer(
                 }
 
     elif source_type == "KML":
-        source_props = {"url": url}
+        _flat_source_props = {"url": url}
 
     elif source_type == "Image Tile":
-        source_props = {"url": url}
+        _flat_source_props = {"url": url}
 
     elif source_type == "Vector Tile":
-        source_props = {"urls": url}
+        _flat_source_props = {"urls": url}
 
     elif source_type in ("PMTiles Vector", "PMTiles Raster"):
-        source_props = {"url": url}
+        _flat_source_props = {"url": url}
 
     elif source_type == "Static Image":
-        source_props = {"url": url}
+        _flat_source_props = {"url": url}
         # projection + imageExtent come through `params`; merge them
         # alongside `url` so they all land in source.props.
-        source_props.update(extra_params)
+        _flat_source_props.update(extra_params)
 
     # ------------------------------------------------------------------
     # Phase 2: Resolve ESRI attribute-variable layer name BEFORE delegation,
@@ -929,7 +971,7 @@ def add_map_service_layer(
     # ------------------------------------------------------------------
     attr_key = name
     if attribute_variables and source_type == "ESRI Image and Map Service":
-        effective_layer_id = source_props.get("params", {}).get("LAYERS")
+        effective_layer_id = _flat_source_props.get("params", {}).get("LAYERS")
         resolved = _resolve_esri_layer_name(url, effective_layer_id)
         if resolved:
             attr_key = resolved
@@ -940,6 +982,64 @@ def add_map_service_layer(
             )
 
     # ------------------------------------------------------------------
+    # Phase 2.5: Validate the advanced dicts (source_props, layer_props,
+    # popup_options) before delegation. Conflict-rejects flat-vs-dict
+    # collisions per K1; rejects unknown layer-prop keys / wrong types.
+    # ------------------------------------------------------------------
+    # Conflict check: flat layer params vs layer_props dict. The same
+    # prop must not arrive through both paths — silent winner would be
+    # a quiet bug class. Surface the conflict to the LLM.
+    _LAYER_PROP_FLAT_TO_DICT = {
+        "opacity": ("opacity", opacity),
+        "min_zoom": ("minZoom", min_zoom),
+        "max_zoom": ("maxZoom", max_zoom),
+    }
+    if layer_props:
+        if not isinstance(layer_props, dict):
+            return {"error": "layer_props must be a dict (or JSON-string dict)."}
+        # Allowlist: keys must be known.
+        unknown = set(layer_props) - set(LAYER_PROPERTIES_ALLOWLIST)
+        if unknown:
+            return {
+                "error": (
+                    f"layer_props contains unknown keys: {sorted(unknown)}. "
+                    f"Allowed: {sorted(LAYER_PROPERTIES_ALLOWLIST)}"
+                )
+            }
+        # Per-key value-type validation.
+        for key, val in layer_props.items():
+            expected = LAYER_PROPERTIES_ALLOWLIST[key]
+            if not isinstance(val, expected):
+                return {
+                    "error": (
+                        f"layer_props[{key!r}] must be of type "
+                        f"{expected!r}; got {type(val).__name__}."
+                    )
+                }
+        # Conflict check.
+        for flat_name, (dict_key, flat_value) in _LAYER_PROP_FLAT_TO_DICT.items():
+            if flat_value is not None and dict_key in layer_props:
+                return {
+                    "error": (
+                        f"Conflicting inputs: {flat_name!r} (flat parameter) "
+                        f"and layer_props[{dict_key!r}] are both supplied. "
+                        f"Pick one path per layer prop."
+                    )
+                }
+
+    if popup_options is not None and not isinstance(popup_options, dict):
+        return {"error": "popup_options must be a dict (or JSON-string dict)."}
+    _popup_aliases = (popup_options or {}).get("aliases") or {}
+    _popup_omit = (popup_options or {}).get("omit") or {}
+    if not isinstance(_popup_aliases, dict):
+        return {"error": "popup_options.aliases must be a dict."}
+    if not isinstance(_popup_omit, dict):
+        return {"error": "popup_options.omit must be a dict (layer_name -> [field, ...])."}
+
+    if source_props is not None and not isinstance(source_props, dict):
+        return {"error": "source_props must be a dict (or JSON-string dict)."}
+
+    # ------------------------------------------------------------------
     # Phase 3: Delegate to LayerConfigurationBuilder. Builder owns
     # configuration.type, source.type, source.props placement, GeoJSON
     # placement at source.geojson, and required-field validation as a
@@ -947,6 +1047,14 @@ def add_map_service_layer(
     # ------------------------------------------------------------------
     try:
         builder = LayerConfigurationBuilder(name, source_type)
+        # Merge flat source props with advanced source_props dict. Advanced
+        # dict overrides flat where keys overlap — caller-supplied data
+        # wins over derived defaults. (Conflict on layer-level scalars is
+        # rejected above; source-level overlap is more often legitimate
+        # — e.g., advanced `projection` on top of a default URL-only
+        # source_props.)
+        if _flat_source_props:
+            builder.set_source_properties(**_flat_source_props)
         if source_props:
             builder.set_source_properties(**source_props)
         if geojson_payload is not None:
@@ -957,11 +1065,52 @@ def add_map_service_layer(
             builder.set_min_zoom(min_zoom)
         if max_zoom is not None:
             builder.set_max_zoom(max_zoom)
+        # Apply layer_props after the flat scalars so the conflict check
+        # above is the only path through which both can be present.
+        if layer_props:
+            for key, val in layer_props.items():
+                if key == "opacity":
+                    builder.set_opacity(val)
+                elif key == "minResolution":
+                    builder.set_min_resolution(val)
+                elif key == "maxResolution":
+                    builder.set_max_resolution(val)
+                elif key == "minZoom":
+                    builder.set_min_zoom(val)
+                elif key == "maxZoom":
+                    builder.set_max_zoom(val)
+                elif key == "minZoomQuery":
+                    builder.set_min_zoom_query(val)
         if queryable:
             builder.set_queryable(True)
+        if legend is not None:
+            builder.set_legend(legend)
+        if style is not None:
+            builder.set_style(style)
         if attribute_variables:
             for key, variable in attribute_variables.items():
                 builder.add_attribute_variable(key, variable, attr_key)
+        # Popup options: aliases + omitted fields.
+        for layer_name, alias_map in _popup_aliases.items():
+            if not isinstance(alias_map, dict):
+                return {
+                    "error": (
+                        f"popup_options.aliases[{layer_name!r}] must be a dict "
+                        f"of field-name -> alias."
+                    )
+                }
+            for field, alias in alias_map.items():
+                builder.add_attribute_alias(field, alias, layer_name)
+        for layer_name, fields in _popup_omit.items():
+            if not isinstance(fields, list):
+                return {
+                    "error": (
+                        f"popup_options.omit[{layer_name!r}] must be a list "
+                        f"of field names."
+                    )
+                }
+            for field in fields:
+                builder.omit_popup_attribute(field, layer_name)
         layer_config = builder.build()
     except ValueError as err:
         return {"error": str(err)}

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -639,6 +639,19 @@ def create_map_visualization(
 # Map service layer tool
 # ---------------------------------------------------------------------------
 
+# Plan-005 S2 cap: cap inline GeoJSON payloads at the MCP boundary to
+# prevent an LLM or chatbox user from persisting a multi-MB feature
+# collection that gets re-served on every dashboard fetch. Operators
+# can raise the limits via env vars (e.g. for legitimate large
+# datasets); defaults are conservative.
+GEOJSON_MAX_BYTES = int(
+    os.environ.get("TETHYSDASH_MCP_GEOJSON_MAX_BYTES", str(5 * 1024 * 1024))
+)
+GEOJSON_MAX_FEATURES = int(
+    os.environ.get("TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", "10000")
+)
+
+
 VALID_SOURCE_TYPES = [
     "WMS",
     "ESRI Image and Map Service",
@@ -816,6 +829,42 @@ def add_map_service_layer(
         layer_props = json.loads(layer_props)
     if isinstance(popup_options, str):
         popup_options = json.loads(popup_options)
+
+    # Plan-005 S2 cap: reject oversized inline GeoJSON before any further
+    # processing. Cap is dynamically read from env vars at call time so
+    # tests and operators can override without re-importing the module.
+    # NB: only inline dict payloads are capped; geojson_url is unaffected
+    # (the cost is borne by the browser at render time, not the server).
+    if isinstance(geojson, dict):
+        max_features = int(os.environ.get(
+            "TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", str(GEOJSON_MAX_FEATURES)
+        ))
+        max_bytes = int(os.environ.get(
+            "TETHYSDASH_MCP_GEOJSON_MAX_BYTES", str(GEOJSON_MAX_BYTES)
+        ))
+        feature_count = len(geojson.get("features", []))
+        if feature_count > max_features:
+            return {
+                "error": (
+                    f"Inline GeoJSON has {feature_count} features; the "
+                    f"limit is {max_features}. Use geojson_url for hosted "
+                    f"large datasets, or raise "
+                    f"TETHYSDASH_MCP_GEOJSON_MAX_FEATURES on the server."
+                )
+            }
+        try:
+            payload_size = len(json.dumps(geojson))
+        except (TypeError, ValueError):
+            payload_size = 0
+        if payload_size > max_bytes:
+            return {
+                "error": (
+                    f"Inline GeoJSON serializes to {payload_size} bytes; "
+                    f"the limit is {max_bytes}. Use geojson_url for hosted "
+                    f"large datasets, or raise "
+                    f"TETHYSDASH_MCP_GEOJSON_MAX_BYTES on the server."
+                )
+            }
 
     # Validate source_type
     if source_type not in VALID_SOURCE_TYPES:

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -1671,6 +1671,121 @@ def list_intake_plugins() -> Dict[str, Any]:
         return {"error": f"Failed to fetch intake plugins from TethysDash: {e}"}
 
 
+def _resolve_dynamic_map_layer_plugin(source: str) -> Dict[str, Any]:
+    """Look up a runtime map-layer plugin by source name.
+
+    Returns a dict with one of:
+      - {"plugin": <metadata_dict>}: the source resolved to a plugin
+        flagged as a runtime map-layer plugin.
+      - {"error": <message>}: source unknown OR resolved plugin is not
+        a runtime map-layer (wrong type, or dynamic_map_layer=False).
+    """
+    try:
+        response = http_requests.get(
+            f"{TETHYSDASH_BASE_URL}/visualizations/list/",
+            timeout=10,
+        )
+        response.raise_for_status()
+    except http_requests.RequestException as exc:
+        return {"error": f"Failed to fetch plugin metadata: {exc}"}
+
+    data = response.json()
+    groups = data.get("visualizations", []) if isinstance(data, dict) else []
+
+    for group in groups:
+        for opt in group.get("options", []) if isinstance(group, dict) else []:
+            if opt.get("source") == source:
+                if opt.get("type") != "map_layer":
+                    return {
+                        "error": (
+                            f"Plugin {source!r} is type {opt.get('type')!r}; "
+                            f"add_dynamic_map_layer requires type=='map_layer'."
+                        )
+                    }
+                if not opt.get("dynamic_map_layer"):
+                    return {
+                        "error": (
+                            f"Plugin {source!r} is a static map_layer plugin "
+                            f"(dynamic_map_layer=False). Use add_map_service_layer "
+                            f"with the plugin's pre-baked layer config instead."
+                        )
+                    }
+                return {"plugin": opt}
+
+    return {"error": f"Unknown plugin source: {source!r}"}
+
+
+@mcp.tool(
+    name="add_dynamic_map_layer",
+    description=(
+        "Add a runtime plugin-backed map layer to an existing map. The plugin "
+        "must be installed and flagged as a runtime map-layer plugin "
+        "(type='map_layer' AND dynamic_map_layer=True). The MCP tool persists "
+        "a GeoJSON scaffold layer with a pluginSource block; the plugin's "
+        "fetch_features method is invoked at render time. Use list_intake_plugins "
+        "to discover available plugin source names; only plugins with type "
+        "'map_layer' are accepted here."
+    ),
+    tags=["map", "layer", "plugin", "runtime"],
+)
+def add_dynamic_map_layer(
+    map_uuid: Annotated[str, Field(description="UUID returned by create_map_visualization")],
+    source: Annotated[str, Field(description=(
+        "Intake plugin source name (the 'source' field from list_intake_plugins). "
+        "Must resolve to a plugin with type=='map_layer' and "
+        "dynamic_map_layer=True; other plugins are rejected."
+    ))],
+    name: Annotated[str, Field(description="Display name for the layer in the layer control")],
+    args: Annotated[Optional[Union[Dict[str, Any], str]], Field(description=(
+        "Plugin args dict passed to fetch_features at render time. Supports "
+        "${variable_name} syntax for dashboard variable references — these "
+        "are preserved verbatim at persist time. Pass None or omit when the "
+        "plugin takes no args."
+    ))] = None,
+) -> Dict[str, Any]:
+    """Add a runtime plugin-backed map layer.
+
+    Builder constructs a GeoJSON scaffold (empty FeatureCollection if no
+    inline data) with configuration.props.pluginSource set, matching the
+    persisted shape the UI's runtime-plugin selector produces. Render-time
+    fetch failures surface through Map.js's existing visualization-error
+    path (no new error handling here).
+    """
+    LOGGER.info(
+        "add_dynamic_map_layer: map_uuid=%s, source=%s, name=%s",
+        map_uuid, source, name,
+    )
+
+    # Coerce JSON-string args (consistent with the existing dict-parameter
+    # coercion pattern used across these tools).
+    if isinstance(args, str):
+        args = json.loads(args)
+    # set_plugin_source raises on non-dict args; coerce None → {} at the
+    # boundary so callers don't need to know that detail.
+    if args is None:
+        args = {}
+    if not isinstance(args, dict):
+        return {"error": "args must be a dict (or JSON-string dict) or None."}
+
+    resolution = _resolve_dynamic_map_layer_plugin(source)
+    if "error" in resolution:
+        return resolution
+
+    try:
+        builder = LayerConfigurationBuilder(name, "GeoJSON")
+        builder.set_plugin_source(source, args)
+        layer_config = builder.build()
+    except ValueError as err:
+        return {"error": str(err)}
+
+    return {
+        "layer_update": {
+            "map_uuid": map_uuid,
+            "layer": layer_config,
+        }
+    }
+
+
 @mcp.tool(
     name="render_plugin",
     description=(

--- a/tethysapp/tethysdash/plugin_helpers.py
+++ b/tethysapp/tethysdash/plugin_helpers.py
@@ -398,6 +398,27 @@ LAYER_PROPERTIES_ALLOWLIST = {
 }
 
 
+def get_allowed_source_prop_keys(source_type: str) -> set:
+    """Return the set of allowed top-level source-prop keys for the given
+    source type, derived from `available_source_properties`.
+
+    Combines `required` and `optional` keys. Used by the MCP layer's
+    `source_props` advanced-dict validation: keys outside this set are
+    rejected at the MCP boundary instead of being silently passed to
+    the builder.
+
+    Returns an empty set for unknown source types (caller is expected to
+    have already validated source_type via VALID_SOURCE_TYPES).
+    """
+    spec = available_source_properties.get(source_type)
+    if not spec:
+        return set()
+    keys = set()
+    keys.update((spec.get("required") or {}).keys())
+    keys.update((spec.get("optional") or {}).keys())
+    return keys
+
+
 available_source_properties = {
     "ESRI Image and Map Service": {
         "required": {"url": "ArcGIS Rest service URL"},
@@ -1182,6 +1203,9 @@ class LayerConfigurationBuilder:
 
         Accepts one of the following:
         - The string "default" to apply a default legend.
+        - A URL string (any string containing "/") for a hosted legend image.
+          The frontend renderer fetches the URL at render time. Mirrors
+          set_style's URL-string acceptance for symmetry.
         - `None` to remove the legend from the configuration.
         - A dictionary defining a custom legend structure.
 
@@ -1192,7 +1216,7 @@ class LayerConfigurationBuilder:
 
         Args:
             legend (str | dict | None): Legend configuration. Must be either "default",
-                None, or a dictionary with required keys and structure.
+                a URL string, None, or a dictionary with required keys and structure.
 
         Returns:
             self: Returns the current instance for method chaining.
@@ -1205,6 +1229,13 @@ class LayerConfigurationBuilder:
             self.config["legend"] = legend
             return self
 
+        # URL-string path: any string containing "/" is treated as a URL the
+        # frontend will fetch at render time. Same shape as set_style's
+        # string handling — keeps the two parameters symmetric.
+        if isinstance(legend, str) and "/" in legend:
+            self.config["legend"] = legend
+            return self
+
         if legend is None:
             # pop() over del so calling set_legend(None) on a fresh builder
             # (where 'legend' has never been set) is idempotent rather than
@@ -1213,7 +1244,9 @@ class LayerConfigurationBuilder:
             return self
 
         if not isinstance(legend, dict):
-            raise ValueError("legend must be 'default', None, or a valid dictionary.")
+            raise ValueError(
+                "legend must be 'default', a URL string, None, or a valid dictionary."
+            )
 
         if "title" not in legend or "items" not in legend:
             raise ValueError("a dictionary legend must have a title and items key")

--- a/tethysapp/tethysdash/plugin_helpers.py
+++ b/tethysapp/tethysdash/plugin_helpers.py
@@ -1206,7 +1206,10 @@ class LayerConfigurationBuilder:
             return self
 
         if legend is None:
-            del self.config["legend"]
+            # pop() over del so calling set_legend(None) on a fresh builder
+            # (where 'legend' has never been set) is idempotent rather than
+            # raising KeyError.
+            self.config.pop("legend", None)
             return self
 
         if not isinstance(legend, dict):

--- a/tethysapp/tethysdash/plugin_helpers.py
+++ b/tethysapp/tethysdash/plugin_helpers.py
@@ -380,6 +380,24 @@ def validate_feature_collection(data):
     return True
 
 
+# Mirror of frontend `layerPropertiesOptions` (reactapp/components/map/utilities.js).
+# Maps each layer-prop key to its accepted Python value type(s). The MCP layer's
+# `layer_props` advanced dict is validated against this allowlist — keys not
+# present are rejected; values failing isinstance() are rejected.
+#
+# Drift guard: tests/mcp/test_source_metadata_drift.py asserts the keys here
+# are a superset of `Object.keys(layerPropertiesOptions)` (snapshotted via
+# the JS-side jest helper into tests/fixtures/source_properties_options.json).
+LAYER_PROPERTIES_ALLOWLIST = {
+    "opacity": (int, float),
+    "minResolution": (int, float),
+    "maxResolution": (int, float),
+    "minZoom": (int, float),
+    "maxZoom": (int, float),
+    "minZoomQuery": (int, float),
+}
+
+
 available_source_properties = {
     "ESRI Image and Map Service": {
         "required": {"url": "ArcGIS Rest service URL"},

--- a/tethysapp/tethysdash/tests/fixtures/source_properties_options.json
+++ b/tethysapp/tethysdash/tests/fixtures/source_properties_options.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Snapshot of reactapp/components/map/utilities.js sourcePropertiesOptions top-level keys. The JS-side guard at reactapp/__tests__/scripts/sourcePropertiesOptionsDrift.test.js asserts JS keys equal this list. The Python-side guard at tethysapp/tethysdash/tests/mcp/test_source_metadata_drift.py asserts plugin_helpers.available_source_properties keys are a superset of this list (excluding deferred entries). When adding a JS source type: update this file, then update plugin_helpers.available_source_properties + LayerConfigurationBuilder.valid_sources to match.",
+  "_comment": "Snapshots of reactapp/components/map/utilities.js's sourcePropertiesOptions and layerPropertiesOptions top-level keys. The JS-side guard at reactapp/__tests__/scripts/sourcePropertiesOptionsDrift.test.js asserts JS keys equal these lists. The Python-side guard at tethysapp/tethysdash/tests/mcp/test_source_metadata_drift.py asserts plugin_helpers.available_source_properties keys (and LAYER_PROPERTIES_ALLOWLIST keys) are a superset of these lists (excluding deferred entries). When adding a JS key: update this file, then update the corresponding Python structure to match.",
   "deferred_in_backend": ["GeoTIFF"],
   "source_types": [
     "ESRI Feature Service",
@@ -13,5 +13,13 @@
     "Static Image",
     "Vector Tile",
     "WMS"
+  ],
+  "layer_properties": [
+    "maxResolution",
+    "maxZoom",
+    "minResolution",
+    "minZoom",
+    "minZoomQuery",
+    "opacity"
   ]
 }

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -1200,3 +1200,174 @@ class TestAttributeVariablesShape:
         assert layer["attributeVariables"] == {
             "Cities": {"name": "city_var"}
         }
+
+
+# Plan-005 B2 — advanced metadata dicts (source_props / layer_props /
+# popup_options) + first-class legend / style + conflict policy.
+class TestAdvancedMetadata:
+    SAMPLE_GEOJSON = {
+        "type": "FeatureCollection",
+        "features": [],
+    }
+
+    def test_source_props_merge_into_source_props(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="Image Tile",
+            name="Tiles With Projection",
+            url="https://example.com/{z}/{x}/{y}.png",
+            source_props={"projection": "EPSG:3857"},
+        )
+        source = _get_source(result)
+        assert source["props"]["url"] == "https://example.com/{z}/{x}/{y}.png"
+        assert source["props"]["projection"] == "EPSG:3857"
+
+    def test_source_props_override_flat_for_overlapping_keys(self):
+        # Source-level overlap is resolved by advanced-dict-wins (intentional;
+        # caller-supplied data overrides derived defaults). Flat scalars
+        # (opacity, min_zoom, max_zoom) trigger the conflict-rejection path
+        # in TestLayerPropsConflict below — this test covers the source-prop
+        # axis where merge-with-override is the intended semantics.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="Image Tile",
+            name="Override URL via source_props",
+            url="https://example.com/{z}/{x}/{y}.png",
+            source_props={"url": "https://override.example.com/{z}/{x}/{y}.png"},
+        )
+        source = _get_source(result)
+        assert source["props"]["url"] == "https://override.example.com/{z}/{x}/{y}.png"
+
+    def test_layer_props_persist_under_configuration_props(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="Zoom-Bounded WMS",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"minResolution": 10, "maxResolution": 1000, "minZoomQuery": 8},
+        )
+        config = _get_configuration(result)
+        assert config["props"]["minResolution"] == 10
+        assert config["props"]["maxResolution"] == 1000
+        assert config["props"]["minZoomQuery"] == 8
+
+    def test_layer_props_unknown_key_returns_error(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bad Key",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"badKey": 1, "minZoom": 5},
+        )
+        assert "error" in result
+        assert "badKey" in result["error"]
+
+    def test_layer_props_wrong_type_returns_error(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bad Type",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"opacity": "not a number"},
+        )
+        assert "error" in result
+        assert "opacity" in result["error"]
+
+    def test_layer_props_conflicts_with_flat_param_returns_error(self):
+        # Plan-005 K1: silent winners are bugs. Both flat opacity and
+        # layer_props.opacity present → MCP returns a clear error.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Conflicting Opacity",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            opacity=0.5,
+            layer_props={"opacity": 0.6},
+        )
+        assert "error" in result
+        assert "Conflicting" in result["error"]
+        assert "opacity" in result["error"]
+
+    def test_min_zoom_conflict_with_layer_props_returns_error(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Conflicting MinZoom",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            min_zoom=2,
+            layer_props={"minZoom": 5},
+        )
+        assert "error" in result
+        assert "Conflicting" in result["error"]
+
+    def test_legend_string_persists_at_top_level(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS With Legend",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            legend="default",
+        )
+        layer = result["layer_update"]["layer"]
+        assert layer["legend"] == "default"
+
+    def test_style_dict_persists_under_configuration_style(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Styled Cities",
+            geojson=self.SAMPLE_GEOJSON,
+            style={"version": 8, "sources": {}, "layers": []},
+        )
+        config = _get_configuration(result)
+        assert config["style"]["version"] == 8
+
+    def test_popup_options_aliases_persist_at_attribute_aliases(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Cities",
+            geojson=self.SAMPLE_GEOJSON,
+            popup_options={
+                "aliases": {"Cities": {"pop": "Population"}},
+            },
+        )
+        layer = result["layer_update"]["layer"]
+        assert layer["attributeAliases"] == {"Cities": {"pop": "Population"}}
+
+    def test_popup_options_omit_persist_at_omitted_popup_attributes(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Cities",
+            geojson=self.SAMPLE_GEOJSON,
+            popup_options={"omit": {"Cities": ["sensitive_field"]}},
+        )
+        layer = result["layer_update"]["layer"]
+        assert layer["omittedPopupAttributes"] == {"Cities": ["sensitive_field"]}
+
+    def test_advanced_dicts_accepted_as_json_strings(self):
+        # Some LLM providers serialize dict args as JSON strings; the MCP
+        # boundary coerces them. This pins that contract for the new dicts.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS JSON-String Dicts",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props='{"minZoom": 3}',
+            source_props='{"projection": "EPSG:4326"}',
+            popup_options='{"omit": {"WMS JSON-String Dicts": ["x"]}}',
+        )
+        config = _get_configuration(result)
+        assert config["props"]["minZoom"] == 3
+        assert config["props"]["source"]["props"]["projection"] == "EPSG:4326"
+        assert result["layer_update"]["layer"]["omittedPopupAttributes"] == {
+            "WMS JSON-String Dicts": ["x"]
+        }

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -1569,3 +1569,83 @@ class TestAddDynamicMapLayer:
         )
         assert "error" in result
         assert "dict" in result["error"]
+
+
+# Plan-005 S2 (cap only) — inline GeoJSON size cap.
+class TestGeoJSONInlineSizeCap:
+    @staticmethod
+    def _features(n):
+        return [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [0, 0]},
+                "properties": {"i": i},
+            }
+            for i in range(n)
+        ]
+
+    def test_within_cap_accepted(self):
+        # Comfortably under both default caps.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Small Cities",
+            geojson={"type": "FeatureCollection", "features": self._features(100)},
+        )
+        assert "layer_update" in result
+
+    def test_feature_count_over_cap_rejected(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Too Many Cities",
+            geojson={
+                "type": "FeatureCollection",
+                "features": self._features(10_001),
+            },
+        )
+        assert "error" in result
+        assert "10001 features" in result["error"]
+
+    def test_byte_size_over_cap_rejected(self, monkeypatch):
+        # Lower the cap so the test stays fast; 1KB is plenty to trip with
+        # a few hundred bytes of feature data.
+        monkeypatch.setenv("TETHYSDASH_MCP_GEOJSON_MAX_BYTES", "1024")
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Too Big",
+            geojson={
+                "type": "FeatureCollection",
+                "features": self._features(50),  # ~5KB serialized
+            },
+        )
+        assert "error" in result
+        assert "bytes" in result["error"]
+
+    def test_env_var_override_raises_feature_cap(self, monkeypatch):
+        # Operator override path — raise the feature cap so a previously-
+        # rejected payload now passes.
+        monkeypatch.setenv("TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", "20000")
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Big But Allowed",
+            geojson={
+                "type": "FeatureCollection",
+                "features": self._features(15_000),
+            },
+        )
+        assert "layer_update" in result
+
+    def test_geojson_url_path_unaffected_by_cap(self):
+        # The cap only inspects inline dict payloads; geojson_url goes
+        # through unchanged regardless of the eventual fetched size
+        # (which is the browser's concern, not the server's).
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Hosted",
+            geojson_url="https://example.com/huge.geojson",
+        )
+        assert "layer_update" in result

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -10,6 +10,7 @@ Layer 1 tests -- no browser, no server, milliseconds per test.
 from unittest.mock import patch
 
 from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+    add_dynamic_map_layer,
     add_map_service_layer,
     VALID_SOURCE_TYPES,
 )
@@ -1305,6 +1306,21 @@ class TestAdvancedMetadata:
         assert "error" in result
         assert "Conflicting" in result["error"]
 
+    def test_max_zoom_conflict_with_layer_props_returns_error(self):
+        # Symmetric coverage to opacity + min_zoom; pins the third entry
+        # of the flat_to_dict_layer_props matrix.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Conflicting MaxZoom",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            max_zoom=15,
+            layer_props={"maxZoom": 10},
+        )
+        assert "error" in result
+        assert "Conflicting" in result["error"]
+
     def test_legend_string_persists_at_top_level(self):
         result = add_map_service_layer(
             map_uuid=MAP_UUID,
@@ -1389,9 +1405,6 @@ class TestAddDynamicMapLayer:
         return _stub
 
     def test_runtime_plugin_returns_pluginsource_layer(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-        )
         plugin = {
             "source": "streamflow_gauges",
             "type": "map_layer",
@@ -1419,9 +1432,6 @@ class TestAddDynamicMapLayer:
         assert source_obj["geojson"]["features"] == []
 
     def test_args_none_coerced_to_empty_dict(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-        )
         plugin = {
             "source": "no_args_plugin",
             "type": "map_layer",
@@ -1442,9 +1452,6 @@ class TestAddDynamicMapLayer:
         assert layer["configuration"]["props"]["pluginSource"]["args"] == {}
 
     def test_args_json_string_coerced(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-        )
         plugin = {
             "source": "string_args_plugin",
             "type": "map_layer",
@@ -1467,9 +1474,6 @@ class TestAddDynamicMapLayer:
         }
 
     def test_variable_template_preserved_verbatim(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-        )
         plugin = {
             "source": "gauge_plugin",
             "type": "map_layer",
@@ -1494,10 +1498,6 @@ class TestAddDynamicMapLayer:
         )
 
     def test_non_map_layer_plugin_rejected(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-            _resolve_dynamic_map_layer_plugin as _real,
-        )
         # Use the real resolver wrapped to return a non-map-layer result.
         with patch(
             "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
@@ -1518,9 +1518,6 @@ class TestAddDynamicMapLayer:
         assert "map_layer" in result["error"]
 
     def test_static_map_layer_plugin_rejected(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-        )
         with patch(
             "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
             "_resolve_dynamic_map_layer_plugin",
@@ -1540,9 +1537,6 @@ class TestAddDynamicMapLayer:
         assert "static" in result["error"].lower()
 
     def test_unknown_source_rejected(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-        )
         with patch(
             "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
             "_resolve_dynamic_map_layer_plugin",
@@ -1557,9 +1551,6 @@ class TestAddDynamicMapLayer:
         assert "Unknown" in result["error"]
 
     def test_args_non_dict_after_coercion_rejected(self):
-        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
-            add_dynamic_map_layer,
-        )
         # JSON-string that decodes to a list, not a dict — boundary rejects.
         result = add_dynamic_map_layer(
             map_uuid=MAP_UUID,
@@ -1649,3 +1640,180 @@ class TestGeoJSONInlineSizeCap:
             geojson_url="https://example.com/huge.geojson",
         )
         assert "layer_update" in result
+
+    def test_features_none_returns_validation_error_not_typeerror(self):
+        # /ce:review #2 (P1): without the `or []` guard, features=None
+        # caused len(None) → TypeError before validate_geojson could
+        # produce a clean error. The fix should let the call proceed
+        # past the cap (feature_count=0) and surface the actual error
+        # from validate_geojson on the down-the-line path.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Bad Features",
+            geojson={"type": "FeatureCollection", "features": None},
+        )
+        # Whichever validator catches it, the result must be a clean
+        # MCP error envelope, not an unhandled exception.
+        assert "error" in result
+
+
+# /ce:review #5 (P1): module-load env-var int() must not crash imports.
+class TestGeojsonCapEnvVarParsing:
+    def test_invalid_env_value_falls_back_to_module_default(self, monkeypatch):
+        # Simulate operator misconfig at call time. The fallback path
+        # should kick in and the call should still succeed.
+        monkeypatch.setenv("TETHYSDASH_MCP_GEOJSON_MAX_FEATURES", "ten thousand")
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoJSON",
+            name="Resilient To Bad Env",
+            geojson={"type": "FeatureCollection", "features": []},
+        )
+        assert "layer_update" in result
+
+
+# /ce:review #18 (P3): bool is a subclass of int; layer_props={"opacity": True}
+# must be rejected (not silently persisted as a JSON boolean).
+class TestLayerPropsRejectsBoolean:
+    def test_opacity_true_rejected(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bool Opacity",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"opacity": True},
+        )
+        assert "error" in result
+        assert "opacity" in result["error"]
+
+    def test_min_zoom_false_rejected(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bool MinZoom",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"minZoom": False},
+        )
+        assert "error" in result
+        assert "minZoom" in result["error"]
+
+
+# /ce:review #6 (P2): bare json.loads() on string-coerced params raised
+# uncaught JSONDecodeError. Each new param must surface a clean MCP
+# error for malformed JSON instead.
+class TestMalformedJsonStringInputs:
+    def test_malformed_layer_props_returns_clean_error(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bad JSON",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props='{"minZoom": 5',  # missing closing brace
+        )
+        assert "error" in result
+        assert "layer_props" in result["error"]
+
+    def test_malformed_source_props_returns_clean_error(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bad source_props JSON",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            source_props="{not valid json}",
+        )
+        assert "error" in result
+        assert "source_props" in result["error"]
+
+    def test_malformed_dynamic_layer_args_returns_clean_error(self):
+        result = add_dynamic_map_layer(
+            map_uuid=MAP_UUID,
+            source="anything",
+            name="Bad Args JSON",
+            args='{"key": "value"',  # missing closing brace
+        )
+        assert "error" in result
+        assert "args" in result["error"]
+
+
+# /ce:review #10 (P2): list_intake_plugins compact output must surface
+# dynamic_map_layer flag so the LLM can identify add_dynamic_map_layer-
+# eligible plugins without speculative call.
+class TestListIntakePluginsExposesDynamicFlag:
+    def test_compact_entries_include_dynamic_map_layer_field(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            list_intake_plugins,
+        )
+        fake_response = type("R", (), {})()
+        fake_response.json = lambda: {
+            "visualizations": [
+                {
+                    "label": "Group A",
+                    "options": [
+                        {
+                            "source": "static_plug",
+                            "label": "Static Plug",
+                            "type": "map_layer",
+                            "args": {"x": "text"},
+                            "dynamic_map_layer": False,
+                        },
+                        {
+                            "source": "runtime_plug",
+                            "label": "Runtime Plug",
+                            "type": "map_layer",
+                            "args": {"y": "text"},
+                            "dynamic_map_layer": True,
+                        },
+                    ],
+                }
+            ]
+        }
+        fake_response.raise_for_status = lambda: None
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "http_requests.get",
+            return_value=fake_response,
+        ):
+            result = list_intake_plugins()
+        plugins = {p["source"]: p for p in result["intake_plugins"]}
+        assert plugins["static_plug"]["dynamic_map_layer"] is False
+        assert plugins["runtime_plug"]["dynamic_map_layer"] is True
+
+
+# /ce:review #11 (P2): set_legend(None) on a fresh builder must not raise
+# KeyError. Direct unit test of the builder method (not just the MCP path).
+class TestSetLegendNoneIdempotent:
+    def test_set_legend_none_on_fresh_builder_does_not_raise(self):
+        builder = LayerConfigurationBuilder("test", "GeoJSON")
+        # Must not raise — pop() over del.
+        builder.set_legend(None)
+        # Idempotent.
+        builder.set_legend(None)
+
+
+# /ce:review #1 (P1): _resolve_dynamic_map_layer_plugin must catch
+# JSONDecodeError from response.json() (Django returning HTML on a 200,
+# e.g. expired session redirect).
+class TestResolveDynamicMapLayerPluginJsonError:
+    def test_non_json_response_returns_clean_error(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            _resolve_dynamic_map_layer_plugin,
+        )
+        fake_response = type("R", (), {})()
+        fake_response.raise_for_status = lambda: None
+        # Real requests would raise JSONDecodeError (a ValueError subclass).
+        def _raise_json_error():
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+        fake_response.json = _raise_json_error
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "http_requests.get",
+            return_value=fake_response,
+        ):
+            result = _resolve_dynamic_map_layer_plugin("anything")
+        assert "error" in result
+        assert "Failed to fetch plugin metadata" in result["error"]

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -1817,3 +1817,136 @@ class TestResolveDynamicMapLayerPluginJsonError:
             result = _resolve_dynamic_map_layer_plugin("anything")
         assert "error" in result
         assert "Failed to fetch plugin metadata" in result["error"]
+
+
+# /ce:review #3 (P1): source_props per-source-type allowlist enforcement.
+# The tool description promised it; this commit added it.
+class TestSourcePropsAllowlist:
+    def test_unknown_source_prop_key_rejected(self):
+        # 'badKey' is not in WMS's available_source_properties allowlist
+        # (which includes url, params, attributions, projection).
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bad Source Key",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            source_props={"badKey": "value"},
+        )
+        assert "error" in result
+        assert "badKey" in result["error"]
+        assert "WMS" in result["error"]
+
+    def test_known_source_prop_key_accepted(self):
+        # 'projection' IS in WMS's allowlist.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Good Source Key",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            source_props={"projection": "EPSG:4326"},
+        )
+        assert "layer_update" in result
+
+    def test_unknown_source_prop_on_image_tile_rejected(self):
+        # Image Tile only allows url, attributions, projection.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="Image Tile",
+            name="Image Tile Bad Key",
+            url="https://example.com/{z}/{x}/{y}.png",
+            source_props={"tileSize": 512},  # PMTiles-only key
+        )
+        assert "error" in result
+        assert "tileSize" in result["error"]
+
+
+# /ce:review #4 (P1): set_legend now accepts URL strings (mirrors set_style).
+class TestLegendUrlString:
+    def test_legend_url_string_persists(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS URL Legend",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            legend="https://example.com/legend.png",
+        )
+        layer = result["layer_update"]["layer"]
+        assert layer["legend"] == "https://example.com/legend.png"
+
+    def test_legend_invalid_string_still_rejected(self):
+        # A bare word with no slash is neither 'default' nor a URL.
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Bad Legend",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            legend="garbage",
+        )
+        assert "error" in result
+
+
+# /ce:review #7 (P2): NaN/Infinity in numeric layer_props rejected at boundary.
+class TestLayerPropsRejectsNonFinite:
+    def test_nan_min_zoom_rejected(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS NaN MinZoom",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"minZoom": float("nan")},
+        )
+        assert "error" in result
+        assert "finite" in result["error"]
+
+    def test_infinity_max_resolution_rejected(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS Infinity MaxResolution",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"maxResolution": float("inf")},
+        )
+        assert "error" in result
+        assert "finite" in result["error"]
+
+    def test_negative_infinity_rejected(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="WMS",
+            name="WMS NegInf MinResolution",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+            layer_props={"minResolution": float("-inf")},
+        )
+        assert "error" in result
+
+
+# /ce:review #9 (P2): add_dynamic_map_layer registered in always_visible.
+def test_add_dynamic_map_layer_in_always_visible():
+    """Pin the BM25 visibility config so the new tool isn't accidentally
+    dropped from always_visible during a future tool list refactor.
+
+    FastMCP stores the configured `always_visible` list under the
+    transform's private `_always_visible` attribute. Reading the
+    private attribute is acceptable here because the public BM25
+    transform API doesn't expose this list and the alternative is
+    parsing source — this test exists specifically to guard the
+    config value, so source-reading would defeat the purpose.
+    """
+    from tethysapp.tethysdash.mcp.tethysdash_mcp_server import mcp
+    flat = []
+    for t in mcp.transforms:
+        always = getattr(t, "_always_visible", None)
+        if always is not None:
+            flat.extend(list(always))
+    assert "add_dynamic_map_layer" in flat, (
+        "add_dynamic_map_layer must be in BM25 always_visible so the LLM "
+        "can find it for runtime-plugin queries; otherwise it competes "
+        "for one of max_results=5 BM25 slots."
+    )

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -1371,3 +1371,201 @@ class TestAdvancedMetadata:
         assert result["layer_update"]["layer"]["omittedPopupAttributes"] == {
             "WMS JSON-String Dicts": ["x"]
         }
+
+
+# Plan-005 B3 — add_dynamic_map_layer (runtime plugin tool).
+# Mocks the plugin-metadata resolver rather than the HTTP layer because
+# the HTTP fetch belongs to a separate concern (covered by integration
+# tests against the running Django server).
+class TestAddDynamicMapLayer:
+    @staticmethod
+    def _stub_plugin_resolver(source, plugin_metadata):
+        """Build a patcher that returns the given plugin_metadata dict for
+        the matching source, or {"error": ...} otherwise."""
+        def _stub(s):
+            if s == source:
+                return {"plugin": plugin_metadata}
+            return {"error": f"Unknown plugin source: {s!r}"}
+        return _stub
+
+    def test_runtime_plugin_returns_pluginsource_layer(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+        )
+        plugin = {
+            "source": "streamflow_gauges",
+            "type": "map_layer",
+            "dynamic_map_layer": True,
+        }
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "_resolve_dynamic_map_layer_plugin",
+            side_effect=self._stub_plugin_resolver("streamflow_gauges", plugin),
+        ):
+            result = add_dynamic_map_layer(
+                map_uuid=MAP_UUID,
+                source="streamflow_gauges",
+                name="Gauges",
+                args={"bbox": "-100,30,-90,40"},
+            )
+        assert "layer_update" in result
+        layer = result["layer_update"]["layer"]
+        plugin_block = layer["configuration"]["props"]["pluginSource"]
+        assert plugin_block["source"] == "streamflow_gauges"
+        assert plugin_block["args"] == {"bbox": "-100,30,-90,40"}
+        # The scaffold is an empty FeatureCollection persisted at source.geojson.
+        source_obj = layer["configuration"]["props"]["source"]
+        assert source_obj["geojson"]["type"] == "FeatureCollection"
+        assert source_obj["geojson"]["features"] == []
+
+    def test_args_none_coerced_to_empty_dict(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+        )
+        plugin = {
+            "source": "no_args_plugin",
+            "type": "map_layer",
+            "dynamic_map_layer": True,
+        }
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "_resolve_dynamic_map_layer_plugin",
+            side_effect=self._stub_plugin_resolver("no_args_plugin", plugin),
+        ):
+            result = add_dynamic_map_layer(
+                map_uuid=MAP_UUID,
+                source="no_args_plugin",
+                name="No Args",
+                args=None,
+            )
+        layer = result["layer_update"]["layer"]
+        assert layer["configuration"]["props"]["pluginSource"]["args"] == {}
+
+    def test_args_json_string_coerced(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+        )
+        plugin = {
+            "source": "string_args_plugin",
+            "type": "map_layer",
+            "dynamic_map_layer": True,
+        }
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "_resolve_dynamic_map_layer_plugin",
+            side_effect=self._stub_plugin_resolver("string_args_plugin", plugin),
+        ):
+            result = add_dynamic_map_layer(
+                map_uuid=MAP_UUID,
+                source="string_args_plugin",
+                name="String Args",
+                args='{"bbox": "0,0,10,10"}',
+            )
+        layer = result["layer_update"]["layer"]
+        assert layer["configuration"]["props"]["pluginSource"]["args"] == {
+            "bbox": "0,0,10,10"
+        }
+
+    def test_variable_template_preserved_verbatim(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+        )
+        plugin = {
+            "source": "gauge_plugin",
+            "type": "map_layer",
+            "dynamic_map_layer": True,
+        }
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "_resolve_dynamic_map_layer_plugin",
+            side_effect=self._stub_plugin_resolver("gauge_plugin", plugin),
+        ):
+            result = add_dynamic_map_layer(
+                map_uuid=MAP_UUID,
+                source="gauge_plugin",
+                name="Gauges",
+                args={"gauge_id": "${GaugeID}"},
+            )
+        layer = result["layer_update"]["layer"]
+        # Verbatim — no interpolation at persist time.
+        assert (
+            layer["configuration"]["props"]["pluginSource"]["args"]["gauge_id"]
+            == "${GaugeID}"
+        )
+
+    def test_non_map_layer_plugin_rejected(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+            _resolve_dynamic_map_layer_plugin as _real,
+        )
+        # Use the real resolver wrapped to return a non-map-layer result.
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "_resolve_dynamic_map_layer_plugin",
+            return_value={
+                "error": (
+                    "Plugin 'plotly_chart' is type 'plotly'; "
+                    "add_dynamic_map_layer requires type=='map_layer'."
+                )
+            },
+        ):
+            result = add_dynamic_map_layer(
+                map_uuid=MAP_UUID,
+                source="plotly_chart",
+                name="Wrong Type",
+            )
+        assert "error" in result
+        assert "map_layer" in result["error"]
+
+    def test_static_map_layer_plugin_rejected(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+        )
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "_resolve_dynamic_map_layer_plugin",
+            return_value={
+                "error": (
+                    "Plugin 'static_overlay' is a static map_layer plugin "
+                    "(dynamic_map_layer=False)."
+                )
+            },
+        ):
+            result = add_dynamic_map_layer(
+                map_uuid=MAP_UUID,
+                source="static_overlay",
+                name="Static Overlay",
+            )
+        assert "error" in result
+        assert "static" in result["error"].lower()
+
+    def test_unknown_source_rejected(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+        )
+        with patch(
+            "tethysapp.tethysdash.mcp.tethysdash_mcp_server."
+            "_resolve_dynamic_map_layer_plugin",
+            return_value={"error": "Unknown plugin source: 'no_such_plugin'"},
+        ):
+            result = add_dynamic_map_layer(
+                map_uuid=MAP_UUID,
+                source="no_such_plugin",
+                name="No Such",
+            )
+        assert "error" in result
+        assert "Unknown" in result["error"]
+
+    def test_args_non_dict_after_coercion_rejected(self):
+        from tethysapp.tethysdash.mcp.tethysdash_mcp_server import (
+            add_dynamic_map_layer,
+        )
+        # JSON-string that decodes to a list, not a dict — boundary rejects.
+        result = add_dynamic_map_layer(
+            map_uuid=MAP_UUID,
+            source="anything",
+            name="Bad Args",
+            args="[1, 2, 3]",
+        )
+        assert "error" in result
+        assert "dict" in result["error"]

--- a/tethysapp/tethysdash/tests/mcp/test_source_metadata_drift.py
+++ b/tethysapp/tethysdash/tests/mcp/test_source_metadata_drift.py
@@ -14,6 +14,7 @@ import json
 from pathlib import Path
 
 from tethysapp.tethysdash.plugin_helpers import (
+    LAYER_PROPERTIES_ALLOWLIST,
     LayerConfigurationBuilder,
     available_source_properties,
 )
@@ -70,3 +71,33 @@ def test_static_image_specifically_present():
     assert "url" in static_image["required"]
     assert "projection" in static_image["required"]
     assert "imageExtent" in static_image["required"]
+
+
+# Plan-005 B2 extension: same drift discipline for layer-level props.
+def test_layer_properties_allowlist_covers_js_keys():
+    fixture = _load_fixture()
+    js_layer_keys = set(fixture["layer_properties"])
+    backend_keys = set(LAYER_PROPERTIES_ALLOWLIST.keys())
+    missing = js_layer_keys - backend_keys
+    assert missing == set(), (
+        f"LAYER_PROPERTIES_ALLOWLIST is missing layer-prop keys present "
+        f"in JS layerPropertiesOptions: {sorted(missing)}. Add the keys "
+        f"with their accepted Python value type(s) in plugin_helpers.py."
+    )
+
+
+def test_layer_properties_allowlist_value_types_are_sane():
+    # Every entry must declare an isinstance-compatible value type
+    # (a class or a tuple of classes), not None / ad-hoc strings.
+    for key, type_decl in LAYER_PROPERTIES_ALLOWLIST.items():
+        if isinstance(type_decl, tuple):
+            for t in type_decl:
+                assert isinstance(t, type), (
+                    f"LAYER_PROPERTIES_ALLOWLIST[{key!r}] tuple entry {t!r} "
+                    f"is not a type."
+                )
+        else:
+            assert isinstance(type_decl, type), (
+                f"LAYER_PROPERTIES_ALLOWLIST[{key!r}] declares {type_decl!r}; "
+                f"must be a type or tuple of types for isinstance()."
+            )

--- a/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
+++ b/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
@@ -692,7 +692,9 @@ def test_layer_configuration_builder_legend():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("legend must be 'default', None, or a valid dictionary."),
+        match=re.escape(
+            "legend must be 'default', a URL string, None, or a valid dictionary."
+        ),
     ):
         builder.set_legend("bad legend")
 


### PR DESCRIPTION
## Summary

Executes plan 005 (`docs/plans/2026-05-05-005-feat-mcp-advanced-metadata-and-runtime-plugins-plan.md`):

- **B2** — Advanced `source_props` / `layer_props` / `popup_options` dicts on `add_map_service_layer`, plus first-class `legend` / `style` parameters and a flat-vs-dict conflict-rejection policy.
- **B3** — New MCP tool `add_dynamic_map_layer` for runtime plugin-backed map layers (PR #89's feature reachable from chat).
- **S2 cap** — Inline GeoJSON capped at 5 MB / 10 000 features at the MCP boundary, with operator env-var overrides.

URL safety is **out of scope** per direct user direction (the UI accepts any URL; making MCP more restrictive than the UI would be gratuitous).

## Commits (5)

| SHA | What |
|---|---|
| `9319b1c` | B2: advanced metadata dicts + cross-language fixture extension + conflict policy |
| `b1dedfa` | B3: `add_dynamic_map_layer` runtime plugin tool |
| `b805a01` | S2 cap: inline GeoJSON size cap with env-var overrides |
| `3bcc325` | `/ce:review` P1+P2 safe_auto fixes (11 findings closed) |
| `172d719` | `/ce:review` P1+P2 gated_auto fixes (4 findings closed) |

## `/ce:review` findings status

✓ All 5 P1s closed; 8 of 12 P2s closed; 3 of 7 P3s closed.

**Closed (15 of 24):**
- **P1**: response.json() outside try (#1), features=None TypeError (#2), source_props allowlist enforcement (#3), set_legend URL strings (#4), env-var int() crash (#5)
- **P2**: bare json.loads() unguarded (#6), NaN/Inf in numeric layer_props (#7), tool description refresh (#8), `add_dynamic_map_layer` always_visible (#9), list_intake_plugins surfaces dynamic_map_layer flag (#10), set_legend(None) idempotent (#11), dead `_real` import (#14), max_zoom conflict test (#15)
- **P3**: bool rejection (#18), naming (#20), test imports hoisted (#22)

**Deferred to follow-up todos:**
- **P2**: 6-branch elif → dict dispatch (#12), Phase 2.5 helper extract (#13), resolver internals direct tests (#16), plugin-metadata caching (#17)
- **P3**: type alias (#21), additional sub-shape error tests (#19, #23, #24)

None of the deferred items are correctness or contract issues.

## Test plan

- [x] **Python:** 678 passed (full pytest suite, MCP contracts + integrated + unit)
- [x] **Jest:** 1706 passed, 4 skipped (pre-existing)
- [x] **Playwright (mocked):** 62 passed, 4 skipped (pre-existing)

Run via:
```
.claude/skills/test-backend
.claude/skills/test-frontend
.claude/skills/test-all
```

## Net new MCP capability

A user can now ask the chatbox to:
- Add a layer with custom legend (URL or `'default'` or dict), style (URL or dict), attribute aliases, omitted popup attributes, and zoom limits — every UI-supported layer prop reachable.
- Add a runtime `dynamic_map_layer` plugin layer — same persisted shape as the UI's runtime-plugin selector.

And the LLM can now discover runtime plugins via `list_intake_plugins` (which now exposes the `dynamic_map_layer` flag) without speculative call + error.