### PR TITLE
fix(plugin_helpers): ArcGIS attribute-fetch hardening

### DIFF
--- a/tethysapp/tethysdash/plugin_helpers.py
+++ b/tethysapp/tethysdash/plugin_helpers.py
@@ -885,6 +885,31 @@ class LayerConfigurationBuilder:
                 f"{self.layer_source} is not currently configured to return attributes"
             )
 
+    @staticmethod
+    def _fetch_json(url: str, timeout: int = 10) -> dict:
+        """Fetch + parse JSON from a remote URL with a hard timeout.
+
+        Centralizes the get → raise_for_status → .json() pattern shared by
+        the four ArcGIS / map-service attribute fetchers below. Closes
+        three pre-existing gaps in one helper:
+
+          - Per-call timeout (a slow upstream service no longer pins a
+            Django/MCP worker thread indefinitely).
+          - raise_for_status() before .json() so 4xx/5xx HTTP responses
+            surface as HTTPError, not the downstream JSONDecodeError that
+            an HTML error body would produce.
+          - Single edit site for future hardening (retries, header
+            injection, etc.).
+
+        Raises whatever requests.get + .json() would raise — caller
+        decides how to wrap. Default timeout matches
+        _resolve_dynamic_map_layer_plugin's value in mcp/tethysdash_mcp_server.py
+        for consistency across server-side outbound fetches.
+        """
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        return response.json()
+
     def _get_arcgis_layer_names(self, url):
         """
         Fetch the list of layer names from an ArcGIS Map or Image Service.
@@ -898,15 +923,14 @@ class LayerConfigurationBuilder:
         Raises:
             ValueError: If `url` is not provided.
             requests.HTTPError: If the HTTP request to the ArcGIS service fails.
+            requests.Timeout: If the service does not respond within the timeout.
             requests.RequestException: For other network-related errors.
         """
         if not url:
             raise ValueError(
                 "url must be provided. Set using .set_source_properties(url='some_url')"
             )
-        response = requests.get(f"{url}?f=json")
-        response.raise_for_status()
-        data = response.json()
+        data = self._fetch_json(f"{url}?f=json")
         return [layer["name"] for layer in data.get("layers", [])]
 
     def _get_arcgis_image_attributes(self, url):
@@ -927,20 +951,25 @@ class LayerConfigurationBuilder:
         Raises:
             ValueError: If `url` is not provided.
             requests.HTTPError: If a request to the ArcGIS service or layer fails.
+            requests.Timeout: If a request does not complete within the timeout.
             requests.RequestException: For other network-related errors.
         """
         if not url:
             raise ValueError(
                 "url must be provided. Set using .set_source_properties(url='some_url')"
             )
-        response = requests.get(f"{url}?f=json")
-        response.raise_for_status()
-        data = response.json()
+        data = self._fetch_json(f"{url}?f=json")
         attributes = {}
         for index, layer in enumerate(data.get("layers", [])):
             name = layer["name"]
-            layer_url = f"{url}/{index}?f=json"
-            layer_data = requests.get(layer_url).json()
+            # Use the layer's own `id` field, not the loop position, so
+            # services with non-contiguous layer IDs (e.g., [0, 5, 10]
+            # after deletions) hit the right endpoints. Falls back to
+            # `index` if a layer object lacks `id` (defensive — ArcGIS
+            # metadata shape variation).
+            layer_id = layer.get("id", index)
+            layer_url = f"{url}/{layer_id}?f=json"
+            layer_data = self._fetch_json(layer_url)
             fields = [
                 {"name": f["name"], "alias": f["alias"]}
                 for f in layer_data.get("fields", [])
@@ -981,9 +1010,7 @@ class LayerConfigurationBuilder:
             )
 
         layer_url = f"{url.rstrip('/')}/{layer_number}?f=json"
-        response = requests.get(layer_url)
-        response.raise_for_status()
-        data = response.json()
+        data = self._fetch_json(layer_url)
         fields = [
             {"name": f["name"], "alias": f["alias"]} for f in data.get("fields", [])
         ]
@@ -1059,7 +1086,9 @@ class LayerConfigurationBuilder:
                 "typename": layer,
             }
 
-            response = requests.get(url, params=query_params)
+            # Timeout matches _fetch_json's default; WMS XML responses
+            # share the same risk profile as the ArcGIS JSON ones.
+            response = requests.get(url, params=query_params, timeout=10)
             try:
                 response.raise_for_status()
             except requests.HTTPError as e:

--- a/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
+++ b/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
@@ -27,7 +27,8 @@ def test_layer_configuration_builder_ESRI_map(mocker):
     layer_names = builder.get_layer_names()
 
     mock_requests_get.assert_called_once_with(
-        "https://maps.water.noaa.gov/server/rest/services/rfc/rfc_max_forecast/MapServer?f=json"  # noqa: E501
+        "https://maps.water.noaa.gov/server/rest/services/rfc/rfc_max_forecast/MapServer?f=json",  # noqa: E501
+        timeout=10,
     )
     assert layer_names == ["some layer"]
 
@@ -254,7 +255,8 @@ def test_layer_configuration_builder_ESRI_feature(mocker):
     layer_attributes = builder.get_layer_attributes()
 
     mock_requests_get.assert_called_once_with(
-        "https://maps.water.noaa.gov/server/rest/services/rfc/rfc_based_5day_max_streamflow/FeatureServer/0?f=json"  # noqa: E501
+        "https://maps.water.noaa.gov/server/rest/services/rfc/rfc_based_5day_max_streamflow/FeatureServer/0?f=json",  # noqa: E501
+        timeout=10,
     )
     assert layer_attributes == {layer_name: [{"alias": "Field", "name": "field"}]}
 
@@ -1621,3 +1623,100 @@ def test_set_geojson_accepts_url_string():
     assert source["geojson"] == url
     # And not nested inside source.props (rule 6).
     assert "geojson" not in source.get("props", {})
+
+
+# Todos #001/#002/#003: ArcGIS attribute-fetch hardening.
+# Pin the three new behaviors (correct layer ID, timeout, raise_for_status).
+
+
+def test_arcgis_image_attributes_uses_layer_id_not_enumerate_index(mocker):
+    """Todo #001: services with non-contiguous layer IDs (e.g. [0, 5, 10]
+    after deletions) must hit /0, /5, /10 — NOT /0, /1, /2 (the loop
+    position). Pre-PR code used enumerate(layers); now uses
+    layer.get('id', index)."""
+    mock_get = mocker.patch("tethysapp.tethysdash.plugin_helpers.requests.get")
+    response = mock_get.return_value
+    response.raise_for_status.return_value = None
+    response.json.side_effect = [
+        # Service-info response — non-contiguous IDs.
+        {"layers": [
+            {"id": 0, "name": "first"},
+            {"id": 5, "name": "skip-to-5"},
+        ]},
+        # Per-layer field-info responses (one per layer).
+        {"fields": [{"name": "f0", "alias": "F0"}]},
+        {"fields": [{"name": "f5", "alias": "F5"}]},
+    ]
+
+    builder = LayerConfigurationBuilder("test", "ESRI Image and Map Service")
+    builder.set_source_properties(url="https://example.com/MapServer")
+    builder.get_layer_attributes()
+
+    # Three calls: 1 service-info + 2 per-layer.
+    assert mock_get.call_count == 3
+    fetched_urls = [call.args[0] for call in mock_get.call_args_list]
+    assert fetched_urls[1].endswith("/0?f=json"), fetched_urls
+    # The critical one — would be /1 with the buggy code.
+    assert fetched_urls[2].endswith("/5?f=json"), fetched_urls
+
+
+def test_arcgis_layer_names_passes_timeout(mocker):
+    """Todo #002: every requests.get must include timeout=10."""
+    mock_get = mocker.patch("tethysapp.tethysdash.plugin_helpers.requests.get")
+    mock_get.return_value.raise_for_status.return_value = None
+    mock_get.return_value.json.return_value = {"layers": []}
+    builder = LayerConfigurationBuilder("t", "ESRI Image and Map Service")
+    builder.set_source_properties(url="https://example.com/MapServer")
+    builder.get_layer_names()
+    # Single call with timeout kwarg.
+    assert mock_get.call_args.kwargs.get("timeout") == 10
+
+
+def test_arcgis_per_layer_4xx_raises_httperror_not_jsondecode(mocker):
+    """Todo #003: per-layer fetch must call raise_for_status() so a
+    404/500 with HTML body surfaces as HTTPError, not the
+    downstream JSONDecodeError that .json() would produce on HTML."""
+    mock_get = mocker.patch("tethysapp.tethysdash.plugin_helpers.requests.get")
+    # First call (service info) succeeds; second call (per-layer) 404s.
+    service_resp = mocker.MagicMock()
+    service_resp.raise_for_status.return_value = None
+    service_resp.json.return_value = {"layers": [{"id": 0, "name": "x"}]}
+    per_layer_resp = mocker.MagicMock()
+    per_layer_resp.raise_for_status.side_effect = requests.HTTPError(
+        "404 Not Found"
+    )
+    mock_get.side_effect = [service_resp, per_layer_resp]
+    builder = LayerConfigurationBuilder("t", "ESRI Image and Map Service")
+    builder.set_source_properties(url="https://example.com/MapServer")
+    with pytest.raises(requests.HTTPError, match="404"):
+        builder.get_layer_attributes()
+
+
+def test_arcgis_feature_service_passes_timeout(mocker):
+    """Todo #002 (continued): ESRI Feature Service path also gets timeout."""
+    mock_get = mocker.patch("tethysapp.tethysdash.plugin_helpers.requests.get")
+    mock_get.return_value.raise_for_status.return_value = None
+    mock_get.return_value.json.return_value = {"fields": []}
+    builder = LayerConfigurationBuilder("t", "ESRI Feature Service")
+    builder.set_source_properties(
+        url="https://example.com/FeatureServer", layer=0
+    )
+    builder.get_layer_attributes()
+    assert mock_get.call_args.kwargs.get("timeout") == 10
+
+
+def test_wms_attributes_passes_timeout(mocker):
+    """Todo #002 (continued): WMS path also gets timeout (XML response,
+    not JSON, but the same risk profile). Uses the same XML schema
+    fixture as test_layer_configuration_builder_WMS to avoid
+    re-crafting the parser-compatible shape."""
+    mock_get = mocker.patch("tethysapp.tethysdash.plugin_helpers.requests.get")
+    mock_get.return_value.raise_for_status.return_value = None
+    mock_get.return_value.text = '<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:topp="http://www.openplans.org/topp" xmlns:wfs="http://www.opengis.net/wfs/2.0" elementFormDefault="qualified" targetNamespace="http://www.openplans.org/topp"><xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="https://ahocevar.com/geoserver/schemas/gml/3.2.1/gml.xsd"/><xsd:complexType name="statesType"><xsd:complexContent><xsd:extension base="gml:AbstractFeatureType"><xsd:sequence><xsd:element maxOccurs="1" minOccurs="0" name="the_geom" nillable="true" type="gml:MultiSurfacePropertyType"/><xsd:element maxOccurs="1" minOccurs="0" name="STATE_NAME" nillable="true" type="xsd:string"/></xsd:sequence></xsd:extension></xsd:complexContent></xsd:complexType><xsd:element name="states" substitutionGroup="gml:AbstractFeature" type="topp:statesType"/></xsd:schema>'  # noqa: E501
+    builder = LayerConfigurationBuilder("t", "WMS")
+    builder.set_source_properties(
+        url="https://example.com/wms",
+        params={"LAYERS": "topp:states"},
+    )
+    builder.get_layer_attributes()
+    assert mock_get.call_args.kwargs.get("timeout") == 10


### PR DESCRIPTION
## Summary

Closes 3 pre-existing bugs in `LayerConfigurationBuilder`'s outbound HTTP fetches via a single new `_fetch_json(url, timeout=10)` helper. All flagged in `/ce:review` of plans 004 + 005, filed as deferred todos #001/#002/#003.

## Closes

| Todo | Issue |
|---|---|
| **#001** | `_get_arcgis_image_attributes` used `enumerate(layers)` index instead of `layer["id"]` — broke services with non-contiguous layer IDs |
| **#002** | All 5 `requests.get(...)` calls in 4 affected functions had no `timeout=` — slow upstream pinned worker threads indefinitely |
| **#003** | Per-layer ArcGIS fetch lacked `raise_for_status()` — HTML 4xx bodies surfaced as `JSONDecodeError` instead of `HTTPError` |

## Test plan

- [x] Python: 683 passed (+5 since plan 005)
- [x] Jest: 1706 passed (no frontend touched)
- [x] Playwright: deferred to end of PR-A → PR-B → PR-C batch (no frontend touched in any of these)

5 new tests + 2 updated assertions pin the new behavior:
- `test_arcgis_image_attributes_uses_layer_id_not_enumerate_index` (#001)
- `test_arcgis_layer_names_passes_timeout` (#002)
- `test_arcgis_per_layer_4xx_raises_httperror_not_jsondecode` (#003)
- `test_arcgis_feature_service_passes_timeout` (#002)
- `test_wms_attributes_passes_timeout` (#002, XML path)