### PR TITLE
fix(dashboard): scroll the dashboard column so bottom-row resize handles stay reachable

### DIFF
--- a/reactapp/views/Dashboard.js
+++ b/reactapp/views/Dashboard.js
@@ -14,7 +14,15 @@ function DashboardView(dashboardProps) {
           <DashboardHeader />
           <DashboardLayoutAlerts />
           <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
-            <div style={{ flex: 1, minWidth: 0}}>
+            {/*
+              minHeight: 0 lets the flex child shrink below its content's
+              intrinsic size; without it the column grows to fit the
+              grid, the parent's overflow:hidden clips bottom-row tiles,
+              and their bottom-right resize handles become unreachable.
+              overflowY: auto then scrolls when the grid is taller than
+              the visible area.
+            */}
+            <div style={{ flex: 1, minWidth: 0, minHeight: 0, overflowY: "auto" }}>
               <DashboardTabs />
             </div>
             <ChatSidebar />


### PR DESCRIPTION
## Summary

In editing mode, when the user added enough tiles for the grid to exceed the visible dashboard height, **bottom-row tiles became unresizable**. The bottom-right \`.react-resizable-handle-se\` was clipped out of view; only the top-right options menu remained visible on those tiles, and the user reported "the resize icon is always on the right upper portion."

## Cause

\`views/Dashboard.js:17\` wrapped \`<DashboardTabs />\` in:

\`\`\`jsx
<div style={{ flex: 1, minWidth: 0 }}>
\`\`\`

Two missing properties:
- **No \`minHeight: 0\`** — flex children default to \`min-height: auto\`, so the column grew with its content instead of being bounded by the row's allocated height.
- **No \`overflowY: auto\`** — content above viewport had nowhere to scroll.

The parent row at line 16 has \`overflow: hidden\`, so the grid's overflow was clipped. Bottom-row tiles' resize handles (which sit at the **bottom-right** of each tile) ended up below the visible area, while the top-right \`StyledButtonDiv\` options menu in \`DashboardItem.js\` remained visible — explaining the user's "resize icon is always on the right upper portion" report.

## Fix

Two-prop change to the dashboard column:

\`\`\`jsx
<div style={{ flex: 1, minWidth: 0, minHeight: 0, overflowY: "auto" }}>
\`\`\`

The tab bar scrolls with the content. A sticky-tabs polish would require restructuring \`DashboardTabs\`'s \`react-bootstrap\` Tabs wrapper (TabContent → \`flex: 1; min-height: 0; overflow: auto\`) and is left for a follow-up.

## Test plan

- [x] \`npm test -- Dashboard.test.js components/dashboard/\` — 99/99 passing
- [ ] **Manual / Playwright (real browser)**: in editing mode, add 10+ tiles so the grid extends below the viewport; confirm the dashboard column scrolls and the bottom tile's bottom-right resize handle is reachable after scroll. JSDOM has no layout engine, so this regression class is only catchable in a real browser — an e2e test for it is the right follow-up.
- [ ] Confirm \`ChatSidebar\` is unaffected by the layout change (sibling flex item, not in the new scroll container).

## Why no Jest test in this PR

JSDOM doesn't compute layout, so the visibility/clipping behavior at the heart of this bug isn't observable in unit tests. A Jest assertion against a presence-of-\`overflowY\` style on the wrapper would be a tautological "the prop is set" check — adds noise without catching real regressions. The right guard is a Playwright e2e test asserting handle reachability after scroll.