### PR TITLE
feat(mcp): add GeoTIFF source type for map layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
     },
     "../lib/chatbox-core": {
       "name": "@aquaveo/chatbox-core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.30.0",
@@ -132,6 +132,9 @@
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
         "jsdom": "^25.0.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "styled-components": "^6.4.1",
         "vite": "^6.0.0",
         "vitest": "^3.2.4"
       },
@@ -8474,6 +8477,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
@@ -8757,10 +8770,182 @@
         "node": ">=18"
       }
     },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
       "cpu": [
         "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -8785,6 +8970,116 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
       "cpu": [
@@ -8805,6 +9100,28 @@
         "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.34.5",
       "cpu": [
@@ -8823,6 +9140,82 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -9755,6 +10148,166 @@
         "@parcel/watcher-win32-x64": "2.5.6"
       }
     },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.5.6",
       "cpu": [
@@ -9782,6 +10335,66 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -16286,6 +16899,20 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -21328,6 +21955,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plotly.js": {

--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -1501,6 +1501,56 @@ test("queryLayerFeatures PMTiles Vector", async () => {
   ]);
 });
 
+test("queryLayerFeatures PMTiles Vector includes configured layer name when source layer differs", async () => {
+  const coordinate = [0, 0];
+  const pixel = [639, 366];
+
+  const mockFeature = {
+    getType: () => "LineString",
+    getFlatCoordinates: () => [0, 0, 0, 1],
+    getProperties: () => ({
+      id: "building-123",
+    }),
+    get: () => "buildings",
+  };
+
+  const mockMap = {
+    getView: jest.fn(() => ({
+      getZoom: jest.fn(() => 10),
+    })),
+    forEachFeatureAtPixel: jest.fn((pixelArg, callback) => {
+      callback(mockFeature, {});
+    }),
+  };
+
+  const layerConfig = JSON.parse(JSON.stringify(layerConfigPMTilesVector));
+  layerConfig.configuration.props.name = "Vector Tiles Test";
+
+  const features = await queryLayerFeatures(
+    layerConfig,
+    mockMap,
+    coordinate,
+    pixel,
+  );
+
+  expect(features).toStrictEqual([
+    {
+      layerName: "buildings",
+      configuredLayerName: "Vector Tiles Test",
+      attributes: {
+        id: "building-123",
+      },
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [0, 0],
+          [0, 1],
+        ],
+      },
+    },
+  ]);
+});
+
 test("queryLayerFeatures PMTiles Vector Layer Name Mismatch", async () => {
   const coordinate = [0, 0];
   const pixel = [639, 366];

--- a/reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js
+++ b/reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js
@@ -82,6 +82,318 @@ describe("buildDashboardState", () => {
     const result = buildDashboardState([{ gridItems: [noUuid, plotItem] }]);
     expect(result.map((i) => i.uuid)).toEqual(["plot-1"]);
   });
+
+  // -- Map items expose a per-layer summary so the LLM can construct
+  // precise `/args/layers/N/...` patch paths instead of falling back to
+  // whole-array replacement. Metadata-only — names/indices/source-type,
+  // never persisted values (params, style, url, etc.) the LLM might
+  // copy verbatim.
+
+  test("emits per-layer summary for Map items with multiple layers", () => {
+    // Real persisted shape: name lives at configuration.props.name (set by
+    // LayerConfigurationBuilder). source_type at configuration.props.source.type.
+    // GeoJSON and WMS have no field_paths (GeoJSON's source shape is special;
+    // WMS has both, asserted in dedicated cases below). Use ESRI sources here
+    // so this case tests source_type plumbing without drowning in field_paths.
+    const map = {
+      uuid: "map-multi",
+      source: "Map",
+      args_string: JSON.stringify({
+        title: "Watersheds",
+        layers: [
+          {
+            configuration: {
+              props: {
+                name: "Gauges",
+                source: { type: "ESRI Image and Map Service" },
+              },
+            },
+          },
+          {
+            configuration: {
+              props: {
+                name: "Boundary",
+                source: { type: "ESRI Feature Service" },
+              },
+            },
+          },
+        ],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-multi");
+    expect(entry.layers.map((l) => ({ index: l.index, name: l.name, source_type: l.source_type }))).toEqual([
+      { index: 0, name: "Gauges", source_type: "ESRI Image and Map Service" },
+      { index: 1, name: "Boundary", source_type: "ESRI Feature Service" },
+    ]);
+  });
+
+  test("emits empty layers array for Map items with no layers", () => {
+    // mapItem fixture above has args.layers === [].
+    const result = buildDashboardState([{ id: "t1", gridItems: [mapItem] }]);
+    const entry = result.find((i) => i.uuid === "map-1");
+    expect(entry.layers).toEqual([]);
+  });
+
+  test("emits empty layers array for Map items missing the layers key", () => {
+    const map = {
+      uuid: "map-no-layers-key",
+      source: "Map",
+      args_string: JSON.stringify({ title: "Empty" }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-no-layers-key");
+    expect(entry.layers).toEqual([]);
+  });
+
+  test("layer with missing name → name: null, index still present", () => {
+    const map = {
+      uuid: "map-noname",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [
+          { configuration: { props: { source: { type: "WMS" } } } },
+        ],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-noname");
+    // index/name/source_type pinned; field_paths covered separately.
+    expect(entry.layers[0].index).toBe(0);
+    expect(entry.layers[0].name).toBe(null);
+    expect(entry.layers[0].source_type).toBe("WMS");
+  });
+
+  test("layer with missing source.type → source_type: null, no field_paths", () => {
+    // Without source_type the layer's internal shape is unknown; do not
+    // emit field_paths so the LLM does not patch into a structure we can't
+    // reason about.
+    const map = {
+      uuid: "map-notype",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [{ configuration: { props: { name: "Mystery" } } }],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-notype");
+    expect(entry.layers).toEqual([
+      { index: 0, name: "Mystery", source_type: null },
+    ]);
+  });
+
+  test("non-Map items do not get a layers field", () => {
+    const result = buildDashboardState(tabs);
+    const plot = result.find((i) => i.uuid === "plot-1");
+    const text = result.find((i) => i.uuid === "text-1");
+    const vi = result.find((i) => i.uuid === "vi-1");
+    expect(plot.layers).toBeUndefined();
+    expect(text.layers).toBeUndefined();
+    expect(vi.layers).toBeUndefined();
+  });
+
+  test("per-layer entries carry only metadata + path strings — no leaked persisted values", () => {
+    // The LLM is told to copy values verbatim from context. Persisted values
+    // (concrete URL, secret:layer, WHERE clauses, opacity numbers) must never
+    // appear in dashboard_state's per-layer payload. Path strings are fine —
+    // they're the authoritative metadata the LLM is meant to copy.
+    const map = {
+      uuid: "map-leak-check",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [
+          {
+            configuration: {
+              type: "ImageLayer",
+              layerVisibility: true,
+              props: {
+                name: "Sensitive",
+                opacity: 0.7,
+                source: {
+                  type: "WMS",
+                  props: {
+                    url: "https://secrets.example.com/wms",
+                    params: { LAYERS: "secret:layer", STYLES: "internal" },
+                  },
+                },
+              },
+              style: "https://secrets.example.com/style.json",
+            },
+          },
+        ],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-leak-check");
+    const blob = JSON.stringify(entry.layers);
+    // Concrete persisted values — must not leak.
+    expect(blob).not.toContain("secrets.example.com");
+    expect(blob).not.toContain("secret:layer");
+    expect(blob).not.toContain("internal");
+    expect(blob).not.toContain("0.7");
+  });
+
+  // -- Unit C: per-source field_paths so the LLM knows where deep fields
+  // (params, url, opacity, visible) actually live in the persisted shape.
+  // Without these, the LLM emits shorthand paths like `/args/layers/N/params`
+  // that RFC 6902 silently creates as unread keys (renderer reads
+  // configuration.props.source.props.params, not a top-level params).
+
+  test("ESRI Feature Service layer emits field_paths with absolute, index-substituted paths", () => {
+    const map = {
+      uuid: "map-esri-feat",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [
+          { configuration: { props: { name: "First", source: { type: "ESRI Image and Map Service" } } } },
+          { configuration: { props: { name: "Boundary", source: { type: "ESRI Feature Service" } } } },
+        ],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-esri-feat");
+    // Index 1 is the Feature Service layer.
+    expect(entry.layers[1].field_paths).toEqual({
+      url: "/args/layers/1/configuration/props/source/props/url",
+      params: "/args/layers/1/configuration/props/source/props/params",
+      opacity: "/args/layers/1/configuration/props/opacity",
+      visible: "/args/layers/1/configuration/layerVisibility",
+    });
+  });
+
+  test("WMS layer emits field_paths including url and params", () => {
+    const map = {
+      uuid: "map-wms",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [{ configuration: { props: { name: "WMS", source: { type: "WMS" } } } }],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-wms");
+    expect(entry.layers[0].field_paths.url).toBe(
+      "/args/layers/0/configuration/props/source/props/url",
+    );
+    expect(entry.layers[0].field_paths.params).toBe(
+      "/args/layers/0/configuration/props/source/props/params",
+    );
+  });
+
+  test("ESRI Image and Map Service layer emits params + url field_paths", () => {
+    const map = {
+      uuid: "map-esri-img",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [{ configuration: { props: { name: "Img", source: { type: "ESRI Image and Map Service" } } } }],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result.find((i) => i.uuid === "map-esri-img");
+    expect(entry.layers[0].field_paths.params).toBe(
+      "/args/layers/0/configuration/props/source/props/params",
+    );
+    expect(entry.layers[0].field_paths.url).toBe(
+      "/args/layers/0/configuration/props/source/props/url",
+    );
+  });
+
+  test("URL-only source types (KML, Image Tile, etc.) emit url but no params", () => {
+    const cases = ["KML", "Image Tile", "Vector Tile", "PMTiles Vector", "PMTiles Raster", "Static Image"];
+    for (const sourceType of cases) {
+      const map = {
+        uuid: `map-${sourceType.replace(/ /g, "-")}`,
+        source: "Map",
+        args_string: JSON.stringify({
+          layers: [{ configuration: { props: { name: "L", source: { type: sourceType } } } }],
+        }),
+      };
+      const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+      const entry = result[0];
+      expect(entry.layers[0].field_paths).toEqual(
+        expect.objectContaining({
+          url: "/args/layers/0/configuration/props/source/props/url",
+          opacity: "/args/layers/0/configuration/props/opacity",
+          visible: "/args/layers/0/configuration/layerVisibility",
+        }),
+      );
+      expect(entry.layers[0].field_paths.params).toBeUndefined();
+    }
+  });
+
+  test("source types with non-standard source props (GeoJSON, GeoTIFF) omit field_paths", () => {
+    // GeoJSON's data lives at source.geojson (not source.props.*) and
+    // GeoTIFF uses source.props.sources (an array, not a flat URL). Their
+    // shapes don't match the common url/params template; safer to emit no
+    // field_paths than to emit wrong ones.
+    for (const sourceType of ["GeoJSON", "GeoTIFF"]) {
+      const map = {
+        uuid: `map-${sourceType}`,
+        source: "Map",
+        args_string: JSON.stringify({
+          layers: [{ configuration: { props: { name: "L", source: { type: sourceType } } } }],
+        }),
+      };
+      const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+      const entry = result[0];
+      // Common per-layer paths (opacity, visible) are still emitted —
+      // those are layer-wrapper fields, not source-shape-dependent.
+      expect(entry.layers[0].field_paths).toEqual({
+        opacity: "/args/layers/0/configuration/props/opacity",
+        visible: "/args/layers/0/configuration/layerVisibility",
+      });
+      expect(entry.layers[0].field_paths.params).toBeUndefined();
+      expect(entry.layers[0].field_paths.url).toBeUndefined();
+    }
+  });
+
+  test("layer with null source_type omits field_paths entirely", () => {
+    const map = {
+      uuid: "map-no-type",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [{ configuration: { props: { name: "L" } } }],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const entry = result[0];
+    expect(entry.layers[0].field_paths).toBeUndefined();
+  });
+
+  test("field_paths values are paths only — they do NOT contain persisted runtime data", () => {
+    const map = {
+      uuid: "map-no-values",
+      source: "Map",
+      args_string: JSON.stringify({
+        layers: [
+          {
+            configuration: {
+              layerVisibility: false,
+              props: {
+                name: "Test",
+                opacity: 0.42,
+                source: {
+                  type: "WMS",
+                  props: {
+                    url: "https://hidden.example.com/wms",
+                    params: { LAYERS: "x:y", WHERE: "id = 99" },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      }),
+    };
+    const result = buildDashboardState([{ id: "t1", gridItems: [map] }]);
+    const fp = result[0].layers[0].field_paths;
+    // Each value is a path string, not the runtime value at that path.
+    expect(fp.url).toBe("/args/layers/0/configuration/props/source/props/url");
+    expect(fp.url).not.toContain("hidden.example.com");
+    expect(fp.params).toBe("/args/layers/0/configuration/props/source/props/params");
+    expect(fp.params).not.toContain("WHERE");
+    expect(fp.opacity).toBe("/args/layers/0/configuration/props/opacity");
+    expect(fp.opacity).not.toContain("0.42");
+  });
 });
 
 describe("buildEditablePathsBySource", () => {

--- a/reactapp/__tests__/components/visualizations/Map.test.js
+++ b/reactapp/__tests__/components/visualizations/Map.test.js
@@ -1561,6 +1561,68 @@ test("Map click attribute variables match field name and alias", async () => {
   expect(await screen.findByText("value3")).toBeInTheDocument();
 });
 
+test("Map click attribute variables fall back to configured PMTiles layer name", async () => {
+  mockedQueryLayerFeatures.mockResolvedValue([
+    {
+      attributes: { id: "building-123" },
+      geometry: { x: 10, y: 10 },
+      layerName: "buildings",
+      configuredLayerName: "Vector Tiles Test",
+    },
+  ]);
+  jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);
+  const popSetPosition = jest.spyOn(Overlay.prototype, "setPosition");
+
+  const layers = [
+    {
+      configuration: {
+        type: "ImageLayer",
+        props: {
+          name: "Vector Tiles Test",
+          source: {
+            type: "ESRI Image and Map Service",
+            props: { url: "some_url" },
+          },
+        },
+      },
+      attributeVariables: {
+        "Vector Tiles Test": { id: "selected_building_id" },
+      },
+    },
+  ];
+  const clickCoordinates = [10, 20];
+  const LoadedComponent = createLoadedComponent({
+    children: (
+      <MapContextProvider>
+        <TestingComponent
+          onMapClick={jest.fn()}
+          clickCoordinates={clickCoordinates}
+          mapProps={{
+            mapConfig: {},
+            viewConfig: {},
+            layers,
+            baseMap: null,
+            layerControl: false,
+          }}
+        />
+      </MapContextProvider>
+    ),
+  });
+  render(LoadedComponent);
+
+  expect(await screen.findByLabelText("Map Div")).toBeInTheDocument();
+  expect(await screen.findByText("Map Ready")).toBeInTheDocument();
+  await waitFor(() => {
+    expect(popSetPosition).toHaveBeenCalledWith(clickCoordinates);
+  });
+
+  await waitFor(async () => {
+    expect(await screen.findByTestId("input-variables")).toHaveTextContent(
+      JSON.stringify({ selected_building_id: "building-123" }),
+    );
+  });
+});
+
 test("Map click query error", async () => {
   mockedQueryLayerFeatures.mockRejectedValue("some error");
   jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -475,7 +475,7 @@ export async function queryLayerFeatures(layerInfo, map, coordinate, pixel) {
         LayerName,
       );
     } else if (sourceType === "PMTiles Vector") {
-      features = getVectorTileLayerFeatures(map, pixel);
+      features = getVectorTileLayerFeatures(map, pixel, LayerName);
     } else if (sourceType === "KML") {
       features = getKMLLayerFeatures(map, pixel, coordinate, LayerName);
     } else if (sourceType === "GeoTIFF") {
@@ -561,19 +561,23 @@ function getGeoTIFFPixelValues(map, pixel, LayerName, layerInfo, coordinate) {
   ];
 }
 
-function getVectorTileLayerFeatures(map, pixel) {
+function getVectorTileLayerFeatures(map, pixel, configuredLayerName) {
   const features = [];
   map.forEachFeatureAtPixel(pixel, function (feature, layer) {
     if (!feature) return;
     let featureLayerName = feature.get("layer");
-    features.push({
+    const featureInfo = {
       layerName: featureLayerName,
       attributes: feature.getProperties(),
       geometry: {
         type: toGeometry(feature).getType(),
         coordinates: toGeometry(feature).getCoordinates(),
       },
-    });
+    };
+    if (configuredLayerName && configuredLayerName !== featureLayerName) {
+      featureInfo.configuredLayerName = configuredLayerName;
+    }
+    features.push(featureInfo);
   });
   return features;
 }

--- a/reactapp/components/sidebar/chatboxStateBuilder.js
+++ b/reactapp/components/sidebar/chatboxStateBuilder.js
@@ -30,12 +30,118 @@ function extractTitle(args) {
   return typeof title === "string" ? title.slice(0, 120) : null;
 }
 
+// Common per-layer fields available regardless of source type. Templates
+// carry an "{N}" placeholder that extractMapLayers substitutes with the
+// layer's actual index, so the LLM gets a copy-paste-safe absolute JSON
+// Pointer rather than a relative fragment it has to assemble.
+const COMMON_FIELD_PATH_TEMPLATES = {
+  opacity: "/args/layers/{N}/configuration/props/opacity",
+  visible: "/args/layers/{N}/configuration/layerVisibility",
+};
+
+// Source-type-specific field paths. Only sources whose persisted shape
+// matches the standard `source.props.url` / `source.props.params` template
+// are listed here. GeoJSON (data at source.geojson) and GeoTIFF (sources
+// array at source.props.sources) deliberately omit shape-specific entries
+// — common paths still apply, but their internal shape is non-standard
+// and naming a wrong path is worse than naming none.
+const SOURCE_FIELD_PATH_TEMPLATES = {
+  "ESRI Image and Map Service": {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+    params: "/args/layers/{N}/configuration/props/source/props/params",
+  },
+  "ESRI Feature Service": {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+    params: "/args/layers/{N}/configuration/props/source/props/params",
+  },
+  WMS: {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+    params: "/args/layers/{N}/configuration/props/source/props/params",
+  },
+  KML: {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+  },
+  "Image Tile": {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+  },
+  "Vector Tile": {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+  },
+  "PMTiles Vector": {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+  },
+  "PMTiles Raster": {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+  },
+  "Static Image": {
+    url: "/args/layers/{N}/configuration/props/source/props/url",
+  },
+  // GeoJSON, GeoTIFF: common paths only — non-standard internal shape.
+  GeoJSON: {},
+  GeoTIFF: {},
+};
+
+function buildFieldPaths(sourceType, index) {
+  // null source_type → no field_paths emitted at all (caller omits the key).
+  if (typeof sourceType !== "string") return null;
+  const sourceSpecific = SOURCE_FIELD_PATH_TEMPLATES[sourceType];
+  if (sourceSpecific === undefined) {
+    // Unknown source type — emit common paths only. The LLM can still
+    // edit opacity/visibility without us having to recognize every plugin.
+    return substituteIndex(COMMON_FIELD_PATH_TEMPLATES, index);
+  }
+  return substituteIndex(
+    { ...COMMON_FIELD_PATH_TEMPLATES, ...sourceSpecific },
+    index,
+  );
+}
+
+function substituteIndex(templates, index) {
+  const out = {};
+  for (const [field, template] of Object.entries(templates)) {
+    out[field] = template.replace("{N}", String(index));
+  }
+  return out;
+}
+
+/**
+ * Per-layer summary for Map items. Names + indices + source-type + paths to
+ * common editable fields — never persisted values (params, style, url, etc.).
+ *
+ * Without per-layer info the LLM has no way to construct precise
+ * `/args/layers/N/...` patch paths. Without field_paths it knows the index
+ * and source type but doesn't know that, e.g., `params` is nested at
+ * `configuration.props.source.props.params`, not at `layer.params`. RFC 6902
+ * `add` to `/args/layers/N/params` silently creates a top-level field the
+ * renderer never reads — invisible failure.
+ */
+function extractMapLayers(args) {
+  const layers = Array.isArray(args?.layers) ? args.layers : [];
+  return layers.map((layer, index) => {
+    const sourceType =
+      typeof layer?.configuration?.props?.source?.type === "string"
+        ? layer.configuration.props.source.type
+        : null;
+    const entry = {
+      index,
+      name:
+        typeof layer?.configuration?.props?.name === "string"
+          ? layer.configuration.props.name
+          : null,
+      source_type: sourceType,
+    };
+    const fieldPaths = buildFieldPaths(sourceType, index);
+    if (fieldPaths) entry.field_paths = fieldPaths;
+    return entry;
+  });
+}
+
 /**
  * Build a compact dashboard-state snapshot the LLM can reason over when
  * emitting patch_visualization tool calls.
  *
  * @param {Array} tabs - TabContext tabs array
- * @returns {Array} per-item {uuid, source, vizType, title, tabId}
+ * @returns {Array} per-item {uuid, source, vizType, title, tabId, layers?}
  */
 export function buildDashboardState(tabs) {
   if (!Array.isArray(tabs)) return [];
@@ -52,13 +158,17 @@ export function buildDashboardState(tabs) {
         // anyway (reducer also guards on parse failure).
         continue;
       }
-      out.push({
+      const entry = {
         uuid: item.uuid,
         source: item.source || "",
         vizType: args?.vizType || null,
         title: extractTitle(args),
         tabId: tab.id,
-      });
+      };
+      if (item.source === "Map") {
+        entry.layers = extractMapLayers(args);
+      }
+      out.push(entry);
     }
   }
   return out;

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -120,8 +120,12 @@ export const Popup = ({
   aliases,
 }) => {
   const filteredLayerAttributes = layerAttributes.map((feature) => {
-    const omittedFields = omittedPopupAttributes[feature.layerName] || [];
-    const aliasMap = aliases[feature.layerName] || {};
+    const omittedFields =
+      omittedPopupAttributes[feature.layerName] ||
+      omittedPopupAttributes[feature.configuredLayerName] ||
+      [];
+    const aliasMap =
+      aliases[feature.layerName] || aliases[feature.configuredLayerName] || {};
     const filteredAttributes = Object.fromEntries(
       Object.entries(feature.attributes)
         .filter(([key]) => !omittedFields.includes(key))
@@ -473,15 +477,25 @@ const MapVisualization = ({
   const updateVariableInputsForFeature = (selectedFeature) => {
     const layerName = selectedFeature.layerName;
     const mapAttributeVariables = mapAttributeVariablesRef.current;
+    const configuredLayerName = selectedFeature.configuredLayerName;
+    const attributeVariableLayerName =
+      layerName && mapAttributeVariables[layerName]
+        ? layerName
+        : configuredLayerName && mapAttributeVariables[configuredLayerName]
+          ? configuredLayerName
+          : null;
 
     // for mapped variable inputs, get the selected feature values and set the variable inputs accordingly
-    if (layerName && mapAttributeVariables[layerName]) {
+    if (attributeVariableLayerName) {
       let updatedVariableInputs = {};
-      for (const layerAttributeOrAlias in mapAttributeVariables[layerName]) {
+      for (const layerAttributeOrAlias in mapAttributeVariables[
+        attributeVariableLayerName
+      ]) {
         // Try to derive both the alias and the original field name from attributeAliases
         let layerAttribute = layerAttributeOrAlias;
         let layerAttributeAlias = layerAttributeOrAlias;
-        const aliasMap = mapAttributeAliasesRef.current[layerName] || {};
+        const aliasMap =
+          mapAttributeAliasesRef.current[attributeVariableLayerName] || {};
         // If the aliasMap has a mapping for this key, set alias and try to find the original
         if (aliasMap[layerAttributeOrAlias]) {
           layerAttributeAlias = aliasMap[layerAttributeOrAlias];
@@ -497,7 +511,9 @@ const MapVisualization = ({
         }
 
         const variableInputName =
-          mapAttributeVariables[layerName][layerAttributeOrAlias];
+          mapAttributeVariables[attributeVariableLayerName][
+            layerAttributeOrAlias
+          ];
 
         const featureValue =
           selectedFeature.attributes[layerAttribute] ||
@@ -624,7 +640,9 @@ const MapVisualization = ({
           return false;
         }
         const omittedFields =
-          mapOmittedPopupAttributesRef.current[item.layerName] || [];
+          mapOmittedPopupAttributesRef.current[item.layerName] ||
+          mapOmittedPopupAttributesRef.current[item.configuredLayerName] ||
+          [];
         // Check if there is at least one attribute not omitted
         return Object.keys(item.attributes).some(
           (key) => !omittedFields.includes(key),

--- a/tethysapp/tethysdash/controllers.py
+++ b/tethysapp/tethysdash/controllers.py
@@ -1066,6 +1066,29 @@ def download_json(request, app_workspace):
 
 
 
+def _stream_with_logging(resp, api_path, method):
+    """Yield streaming response chunks; log any mid-stream exception.
+
+    `requests.post(stream=True)` returns immediately and chunks are read
+    when the consumer iterates. If Ollama drops the connection mid-stream
+    (ChunkedEncodingError, ProtocolError, IncompleteRead — common on long
+    generations like gpt-oss:120b), the exception fires here, after
+    _proxy_to_ollama has already returned. Without this wrapper, Django
+    logs only `Internal Server Error` via django.request middleware and no
+    traceback identifies the failing exception class.
+    """
+    try:
+        for chunk in resp.iter_content(chunk_size=4096):
+            yield chunk
+    except Exception:
+        logger.exception(
+            "Ollama proxy stream error on %s (method=%s)",
+            api_path,
+            method,
+        )
+        raise
+
+
 def _proxy_to_ollama(request, api_path, timeout=(10, 300)):
     # Read host/key from request headers (browser-managed credentials)
     host = (request.headers.get("X-Ollama-Host", "") or _DEFAULT_OLLAMA_HOST).rstrip("/")
@@ -1084,7 +1107,7 @@ def _proxy_to_ollama(request, api_path, timeout=(10, 300)):
                 url, headers=headers, stream=True, timeout=timeout
             )
         return StreamingHttpResponse(
-            resp.iter_content(chunk_size=4096),
+            _stream_with_logging(resp, api_path, request.method),
             content_type=resp.headers.get("Content-Type", "application/json"),
             status=resp.status_code,
         )

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -517,8 +517,8 @@ def create_map_visualization(
     """Create a geographic map on the dashboard.
 
     Simple usage: provide 'center' or 'markers' for a quick map.
-    For service layers (WMS, ESRI, GeoJSON, KML): call add_map_service_layer
-    with the returned map UUID after creating the map.
+    For service layers (WMS, ESRI, GeoJSON, KML, GeoTIFF, etc.): call
+    add_map_service_layer with the returned map UUID after creating the map.
     """
     map_uuid = str(uuid.uuid4())
     LOGGER.info("create_map_visualization: uuid=%s, center=%s, markers=%s",
@@ -580,7 +580,11 @@ def create_map_visualization(
             "h": h,
         },
         "map_uuid": map_uuid,
-        "message": f"Map created (uuid: {map_uuid}). Use add_map_service_layer with this UUID to add WMS, ESRI, GeoJSON, or other service layers.",
+        "message": (
+            f"Map created (uuid: {map_uuid}). Use add_map_service_layer with "
+            "this UUID to add WMS, ESRI, GeoJSON, GeoTIFF, or other service "
+            "layers."
+        ),
     }
 
 
@@ -754,6 +758,7 @@ VALID_SOURCE_TYPES = [
     "Vector Tile",
     "PMTiles Vector",
     "PMTiles Raster",
+    "GeoTIFF",
     "Static Image",
 ]
 
@@ -806,9 +811,9 @@ def _resolve_esri_layer_name(url: str, layer_id: Optional[str]) -> Optional[str]
 @mcp.tool(
     name="add_map_service_layer",
     description=(
-        "Add a WMS, ESRI, GeoJSON, KML, Static Image, or tile service layer "
-        "to an existing map created by create_map_visualization. Supports "
-        "legend, style, popup configuration, attribute aliases, opacity, "
+        "Add a WMS, ESRI, GeoJSON, KML, GeoTIFF, Static Image, or tile "
+        "service layer to an existing map created by create_map_visualization. "
+        "Supports legend, style, popup configuration, attribute aliases, opacity, "
         "and zoom limits via optional advanced parameters. When the layer "
         "comes from a feature lookup, fetch the layer name and bounding "
         "box from a data-source tool first, then pass them through to "
@@ -821,11 +826,13 @@ def add_map_service_layer(
     source_type: Annotated[str, Field(description=(
         "Layer source type. One of: WMS, ESRI Image and Map Service, "
         "ESRI Feature Service, GeoJSON, KML, Image Tile, Vector Tile, "
-        "PMTiles Vector, PMTiles Raster, Static Image"
+        "PMTiles Vector, PMTiles Raster, GeoTIFF, Static Image"
     ))],
     name: Annotated[str, Field(description="Display name for the layer in the layer control")],
     url: Annotated[Optional[str], Field(description=(
-        "Service URL. Required for all source types except GeoJSON."
+        "Service URL. Required for all source types except GeoJSON. For "
+        "GeoTIFF, this may be a Cloud Optimized GeoTIFF URL; advanced callers "
+        "may instead pass source_props={'sources': [{'url': ...}]}."
     ))] = None,
     layer_id: Annotated[Optional[str], Field(description=(
         "Layer identifier within the service. "
@@ -883,7 +890,7 @@ def add_map_service_layer(
         "against the source-type's available_source_properties allowlist; "
         "unknown keys are rejected. Use this for source props beyond the "
         "first-class flat parameters (e.g., projection on Image Tile, "
-        "tileSize on PMTiles)."
+        "tileSize on PMTiles, or sources on GeoTIFF)."
     ))] = None,
     layer_props: Annotated[Optional[Union[Dict[str, Any], str]], Field(description=(
         "Advanced layer-level properties (opacity, minResolution, "
@@ -1030,6 +1037,29 @@ def add_map_service_layer(
     elif source_type == "PMTiles Raster":
         if not url:
             return {"error": "source_type 'PMTiles Raster' requires 'url' parameter"}
+    elif source_type == "GeoTIFF":
+        geotiff_sources = (
+            source_props.get("sources") if isinstance(source_props, dict) else None
+        )
+        if geotiff_sources is not None:
+            if not isinstance(geotiff_sources, list) or not any(
+                isinstance(source, dict) and source.get("url")
+                for source in geotiff_sources
+            ):
+                return {
+                    "error": (
+                        "source_type 'GeoTIFF' requires source_props.sources "
+                        "to be a non-empty list of source dictionaries with "
+                        "a 'url' value"
+                    )
+                }
+        elif not url:
+            return {
+                "error": (
+                    "source_type 'GeoTIFF' requires either 'url' or "
+                    "source_props={'sources': [{'url': ...}]}"
+                )
+            }
     elif source_type == "Static Image":
         # Static Image needs url + projection + imageExtent; the latter two
         # come through the `params` kwarg today (no dedicated flat params yet
@@ -1129,6 +1159,10 @@ def add_map_service_layer(
 
     elif source_type in ("PMTiles Vector", "PMTiles Raster"):
         _flat_source_props = {"url": url}
+
+    elif source_type == "GeoTIFF":
+        if not (isinstance(source_props, dict) and source_props.get("sources")):
+            _flat_source_props = {"sources": [{"url": url}]}
 
     elif source_type == "Static Image":
         _flat_source_props = {"url": url}
@@ -1670,11 +1704,19 @@ def patch_visualization(
 
 @mcp.tool(
     name="create_variable_input",
-    description="Create an interactive variable input that other visualizations can reference with ${variable_name} syntax",
+    description=(
+        "Create an interactive variable input that other visualizations can "
+        "reference with ${variable_name} syntax. Use the exact variable_name "
+        "requested by the user; do not rename it or add suffixes unless the "
+        "user explicitly asks."
+    ),
     tags=["visualization", "dashboard", "variable"],
 )
 def create_variable_input(
-    variable_name: Annotated[str, Field(description="Variable name used in ${...} references by other visualizations")],
+    variable_name: Annotated[str, Field(description=(
+        "Exact variable name used in ${...} references by other visualizations. "
+        "Preserve the user's requested snake_case identifier exactly."
+    ))],
     variable_type: Annotated[str, Field(description=(
         "Input type: 'text', 'number', 'checkbox', 'date', 'dropdown', "
         "'slider', 'date-range', or 'csv-uploader'"
@@ -1702,12 +1744,15 @@ def create_variable_input(
         "text", "number", "checkbox", "date",
         "dropdown", "slider", "date-range", "csv-uploader",
     ]
-    if variable_type not in valid_types:
-        return {"error": f"Invalid variable_type '{variable_type}'. Must be one of: {valid_types}"}
-
     # Coerce string options to list (LLMs may pass "A,B,C" instead of ["A","B","C"])
     if isinstance(options, str):
         options = [o.strip() for o in options.split(",")]
+
+    if variable_type == "text" and options:
+        variable_type = "dropdown"
+
+    if variable_type not in valid_types:
+        return {"error": f"Invalid variable_type '{variable_type}'. Must be one of: {valid_types}"}
 
     # Validate type-specific requirements
     if variable_type == "dropdown" and not options:
@@ -2303,7 +2348,11 @@ def list_available_visualizations() -> Dict[str, Any]:
                 "type": "map",
                 "name": "Map",
                 "tool": "create_map_visualization",
-                "description": "OpenLayers map. Supports WMS, GeoJSON, KML, ESRI services, Image/Vector tiles, PMTiles, Static Image",
+                "description": (
+                    "OpenLayers map. Supports WMS, GeoJSON, KML, ESRI "
+                    "services, Image/Vector tiles, PMTiles, GeoTIFF, "
+                    "Static Image"
+                ),
                 "prefer_native": True,
             },
             {

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -1411,8 +1411,9 @@ def _check_r5c_array_collision(patches):
                 f"multiple add/remove ops target the same array parent {parent!r} "
                 f"(op indices {indices}). RFC 6902 applies ops sequentially so "
                 f"array indices shift after each op — this produces incorrect "
-                f"results. Emit a single `replace` on {parent!r} carrying the "
-                f"intended final array instead."
+                f"results. Split the changes into separate turns so each turn "
+                f"applies to a stable index, or use the appropriate create/"
+                f"remove tool for new and deleted entries."
             )
     return None
 
@@ -1420,6 +1421,8 @@ def _check_r5c_array_collision(patches):
 def _check_layer_construction_boundary(source, patches):
     """R9/R10: Map layer construction is reserved for add_map_service_layer.
 
+    Reject `add`/`replace` at /args/layers (whole array — the LLM's wrong-
+    shape escape that produced the duplicate-layer bug).
     Reject `add` at /args/layers/- or /args/layers/N (creates new layer).
     Reject `replace` at /args/layers/N (replaces whole layer object).
     Allow field-level ops under an existing layer (e.g., /args/layers/N/visible).
@@ -1431,6 +1434,18 @@ def _check_layer_construction_boundary(source, patches):
     for i, op in enumerate(patches):
         op_name = op.get("op")
         path = op.get("path", "")
+        # Whole-array path. Catch this before the per-index branches so the
+        # error names the more general failure mode (writing the entire
+        # layers array vs. constructing a single new layer).
+        if op_name in ("add", "replace") and path == "/args/layers":
+            return (
+                f"op {i} `{op_name}` at '/args/layers' would replace the "
+                f"whole layers array, which is not permitted via "
+                f"patch_visualization. To add a new layer use "
+                f"`add_map_service_layer`. To modify an existing layer's "
+                f"fields, patch under '/args/layers/N/...'. To remove a "
+                f"layer, use a `remove` op at '/args/layers/N'."
+            )
         if op_name == "add":
             if path == "/args/layers/-" or _BARE_LAYER_INDEX.match(path):
                 return (

--- a/tethysapp/tethysdash/plugin_helpers.py
+++ b/tethysapp/tethysdash/plugin_helpers.py
@@ -511,6 +511,17 @@ available_source_properties = {
             "tileSize": "Tile Size (e.g., 256, 512)",
         },
     },
+    "GeoTIFF": {
+        "required": {
+            "sources": (
+                "List of GeoTIFF source dictionaries. Each source must include "
+                "a URL to a Cloud Optimized GeoTIFF."
+            ),
+        },
+        "optional": {
+            "attributions": "Attributions",
+        },
+    },
     "Static Image": {
         "required": {
             "url": "Image URL",
@@ -551,6 +562,7 @@ class LayerConfigurationBuilder:
                 - 'Vector Tile'
                 - 'PMTiles Vector'
                 - 'PMTiles Raster'
+                - 'GeoTIFF'
                 - 'Static Image'
 
         Raises:
@@ -572,6 +584,7 @@ class LayerConfigurationBuilder:
             "KML": "VectorLayer",
             "PMTiles Vector": "VectorTileLayer",
             "PMTiles Raster": "WebGLTile",
+            "GeoTIFF": "WebGLTile",
             "Static Image": "ImageLayer",
         }
 

--- a/tethysapp/tethysdash/tests/fixtures/source_properties_options.json
+++ b/tethysapp/tethysdash/tests/fixtures/source_properties_options.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Snapshots of reactapp/components/map/utilities.js's sourcePropertiesOptions and layerPropertiesOptions top-level keys. The JS-side guard at reactapp/__tests__/scripts/sourcePropertiesOptionsDrift.test.js asserts JS keys equal these lists. The Python-side guard at tethysapp/tethysdash/tests/mcp/test_source_metadata_drift.py asserts plugin_helpers.available_source_properties keys (and LAYER_PROPERTIES_ALLOWLIST keys) are a superset of these lists (excluding deferred entries). When adding a JS key: update this file, then update the corresponding Python structure to match.",
-  "deferred_in_backend": ["GeoTIFF"],
+  "deferred_in_backend": [],
   "source_types": [
     "ESRI Feature Service",
     "ESRI Image and Map Service",

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -1,4 +1,4 @@
-"""Contract tests for add_map_service_layer across all 9 source types.
+"""Contract tests for add_map_service_layer across all source types.
 
 Validates: layer_update return shape, correct OpenLayers layer type,
 required source props per source type, GeoJSON placement, ESRI
@@ -792,6 +792,75 @@ class TestPMTilesRaster:
 
 
 # ---------------------------------------------------------------------------
+# GeoTIFF
+# ---------------------------------------------------------------------------
+
+class TestGeoTIFF:
+    """GeoTIFF source type contract tests."""
+
+    def test_geotiff_returns_layer_update_shape(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoTIFF",
+            name="GeoTIFF Layer",
+            url="https://example.com/dem.tif",
+        )
+        assert_layer_update(result, expected_uuid=MAP_UUID)
+
+    def test_geotiff_layer_type_is_webgl_tile(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoTIFF",
+            name="GeoTIFF Layer",
+            url="https://example.com/dem.tif",
+        )
+        config = _get_configuration(result)
+        assert config["type"] == "WebGLTile"
+
+    def test_geotiff_source_props_from_flat_url(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoTIFF",
+            name="GeoTIFF Layer",
+            url="https://example.com/dem.tif",
+        )
+        source = _get_source(result)
+        assert source["type"] == "GeoTIFF"
+        assert source["props"]["sources"] == [
+            {"url": "https://example.com/dem.tif"}
+        ]
+
+    def test_geotiff_source_props_sources_array(self):
+        sources = [
+            {
+                "url": "https://example.com/dem.tif",
+                "bands": [1],
+                "nodata": -9999,
+            }
+        ]
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoTIFF",
+            name="GeoTIFF Layer",
+            source_props={"sources": sources},
+        )
+        source = _get_source(result)
+        assert source["props"]["sources"] == sources
+
+    def test_geotiff_variable_url_preserved_in_sources(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoTIFF",
+            name="GeoTIFF Layer",
+            url="https://example.com/${dem_date}/dem.tif",
+        )
+        source = _get_source(result)
+        assert source["props"]["sources"] == [
+            {"url": "https://example.com/${dem_date}/dem.tif"}
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Cross-cutting: queryable flag
 # ---------------------------------------------------------------------------
 
@@ -841,6 +910,7 @@ class TestAllSourceTypesReturnLayerUpdate:
         "Vector Tile": dict(url="https://x.com/tiles/{z}/{x}/{y}.pbf"),
         "PMTiles Vector": dict(url="https://x.com/data.pmtiles"),
         "PMTiles Raster": dict(url="https://x.com/data.pmtiles"),
+        "GeoTIFF": dict(url="https://x.com/dem.tif"),
         "Static Image": dict(
             url="https://x.com/image.png",
             params={"projection": "EPSG:4326", "imageExtent": "0,0,10,10"},
@@ -859,6 +929,7 @@ class TestAllSourceTypesReturnLayerUpdate:
         "Vector Tile": dict(urls="https://x.com/tiles/{z}/{x}/{y}.pbf"),
         "PMTiles Vector": dict(url="https://x.com/data.pmtiles"),
         "PMTiles Raster": dict(url="https://x.com/data.pmtiles"),
+        "GeoTIFF": dict(sources=[{"url": "https://x.com/dem.tif"}]),
         "Static Image": dict(
             url="https://x.com/image.png",
             projection="EPSG:4326",
@@ -896,6 +967,9 @@ class TestAllSourceTypesReturnLayerUpdate:
 
     def test_pmtiles_raster_returns_layer_update(self):
         self._assert_source_type_returns_layer_update("PMTiles Raster")
+
+    def test_geotiff_returns_layer_update(self):
+        self._assert_source_type_returns_layer_update("GeoTIFF")
 
     def test_static_image_returns_layer_update(self):
         self._assert_source_type_returns_layer_update("Static Image")
@@ -1007,6 +1081,23 @@ class TestErrors:
             map_uuid=MAP_UUID,
             source_type="PMTiles Raster",
             name="PMTiles Raster No URL",
+        )
+        assert "error" in result
+
+    def test_geotiff_without_url_or_sources_returns_error(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoTIFF",
+            name="GeoTIFF No Source",
+        )
+        assert "error" in result
+
+    def test_geotiff_empty_sources_returns_error(self):
+        result = add_map_service_layer(
+            map_uuid=MAP_UUID,
+            source_type="GeoTIFF",
+            name="GeoTIFF Empty Source",
+            source_props={"sources": []},
         )
         assert "error" in result
 

--- a/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
+++ b/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
@@ -766,6 +766,136 @@ class TestLayerConstructionBoundary:
         # Hint is only emitted by the Map-specific check
         assert "add_map_service_layer" not in result["error"]
 
+    # -- Whole-array `/args/layers` ops: regression coverage for the
+    # bug where an LLM emitted a single `replace` at `/args/layers` with
+    # a multi-element array, bypassing the layer-construction boundary
+    # and producing a duplicate layer. The path-equality match (not the
+    # `/args/layers/N` regex) is what closes the escape.
+
+    def test_replace_whole_layers_array_rejected(self):
+        """`replace` at the whole-array path /args/layers — the escape that
+        produced the Colorado RFC Boundary duplicate. Must be rejected."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers",
+                "value": [
+                    {"name": "existing", "configuration": {"props": {"source": {"type": "GeoJSON"}}}},
+                    {"name": "existing", "configuration": {"props": {"source": {"type": "GeoJSON", "props": {"params": {"WHERE": "x"}}}}}},
+                ],
+            }],
+        )
+        assert "error" in result
+        assert "whitelist_rejected" in result["error"]
+
+    def test_add_whole_layers_array_rejected(self):
+        """`add` at /args/layers replaces the array (RFC 6902 add-to-existing-key
+        is replacement). Same escape vector as `replace`. Must be rejected."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "add",
+                "path": "/args/layers",
+                "value": [{"name": "x"}],
+            }],
+        )
+        assert "error" in result
+        assert "whitelist_rejected" in result["error"]
+
+    def test_whole_layers_array_rejection_lists_canonical_recovery_actions(self):
+        """The rejection envelope must redirect the LLM to the right tool/path
+        for each canonical layer-edit action. Per the mcp-error-envelopes
+        discipline: each error class maps to one recovery action; this one
+        carries the three actions actually available (add / edit / remove).
+        Reorder via patch is intentionally not supported — R5c rejects single-
+        op `move` within an indexed array because remove+add shifts indices."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers",
+                "value": [{"name": "x"}],
+            }],
+        )
+        err = result.get("error", "")
+        # Add a new layer -> add_map_service_layer
+        assert "add_map_service_layer" in err
+        # Edit a layer field -> /args/layers/N/...
+        assert "/args/layers/N/" in err or "/args/layers/N" in err
+        # Remove a layer -> remove op
+        assert "remove" in err
+
+    def test_whole_layers_array_rejection_does_not_use_not_found(self):
+        """Negative assertion per mcp-error-envelopes: this is a
+        whitelist_rejected error class, not a not-found class. Mixing
+        vocabulary causes the LLM to retry the wrong way."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers",
+                "value": [],
+            }],
+        )
+        err = result.get("error", "")
+        assert "not found" not in err.lower()
+
+    # -- Happy-path regression pins for the actions the LLM should reach for
+    # instead of whole-array replacement. Existing precedents are spread
+    # across TestHappyPath / TestR5cArrayCollision; pinning them here keeps
+    # the boundary contract self-contained.
+
+    def test_deep_layer_field_replace_still_allowed(self):
+        """The exact path the Colorado RFC Boundary prompt should have
+        produced: replace `/args/layers/N/...source/.../params/WHERE`."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers/0/configuration/props/source/props/params/WHERE",
+                "value": "rfc_name = 'Colorado Basin'",
+            }],
+        )
+        assert "patch_update" in result, result
+
+    def test_remove_at_layer_index_still_allowed(self):
+        """Remove a whole layer by index — the documented deletion path."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{"op": "remove", "path": "/args/layers/1"}],
+        )
+        assert "patch_update" in result, result
+
+    def test_single_op_move_within_layers_rejected_by_r5c(self):
+        """Single-op `move` between layer indices is intentionally rejected
+        — RFC 6902 `move` is `remove + add`, which shifts indices ambiguously
+        within the same indexed array. R5c catches this before reaching the
+        layer-construction boundary; the rejection message must NOT recommend
+        `replace` on `/args/layers` as a recovery (that's the new banned
+        escape this PR closes)."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "move",
+                "from": "/args/layers/0",
+                "path": "/args/layers/2",
+            }],
+        )
+        assert "error" in result
+        # R5c regression message — must not advertise the banned escape.
+        err = result["error"]
+        assert "single `replace`" not in err
+        assert "single 'replace'" not in err
+        assert "replace on '/args/layers'" not in err
+
 
 # ---------------------------------------------------------------------------
 # Return envelope shape

--- a/tethysapp/tethysdash/tests/mcp/test_variable_input_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_variable_input_contracts.py
@@ -140,6 +140,40 @@ class TestDropdown:
         assert isinstance(args["variable_options_source"], list)
         assert args["variable_options_source"] == ["Red", "Green", "Blue"]
 
+    def test_options_imply_dropdown_when_type_omitted(self):
+        """LLMs often say "dropdown" but omit the optional variable_type arg."""
+        result = create_variable_input(
+            variable_name="dem_version",
+            options=["20190610", "20210611", "20211215", "20240614"],
+            initial_value="20240614",
+        )
+        assert_variable_input_viz(result)
+        args = result["visualization"]["args"]
+        assert args["variable_name"] == "dem_version"
+        assert args["initial_value"] == "20240614"
+        assert args["variable_options_source"] == [
+            "20190610",
+            "20210611",
+            "20211215",
+            "20240614",
+        ]
+
+    def test_string_options_imply_dropdown_when_type_omitted(self):
+        """Comma-separated options should also imply dropdown if type is omitted."""
+        result = create_variable_input(
+            variable_name="dem_version",
+            options="20190610, 20210611, 20211215, 20240614",
+            initial_value="20240614",
+        )
+        assert_variable_input_viz(result)
+        args = result["visualization"]["args"]
+        assert args["variable_options_source"] == [
+            "20190610",
+            "20210611",
+            "20211215",
+            "20240614",
+        ]
+
     def test_dropdown_requires_options(self):
         """Dropdown without options should return an error."""
         result = create_variable_input(

--- a/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
+++ b/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
@@ -1512,6 +1512,10 @@ RENDERER_LAYER_TYPE_BY_SOURCE = {
     "Image Tile": ("TileLayer", {"url": "https://example.com/{z}/{x}/{y}.png"}),
     "KML": ("VectorLayer", {"url": "https://example.com/file.kml"}),
     "PMTiles Raster": ("WebGLTile", {"url": "https://example.com/raster.pmtiles"}),
+    "GeoTIFF": (
+        "WebGLTile",
+        {"sources": [{"url": "https://example.com/dem.tif"}]},
+    ),
     "PMTiles Vector": (
         "VectorTileLayer",
         {"url": "https://example.com/vector.pmtiles"},
@@ -1582,6 +1586,18 @@ def test_pmtiles_raster_layer_type_is_webgl_tile():
     builder.set_source_properties(url="https://example.com/raster.pmtiles")
     config = builder.build()
     assert config["configuration"]["type"] == "WebGLTile"
+
+
+def test_geotiff_source_props_shape():
+    """GeoTIFF source props match the UI's saved sources-array shape."""
+    builder = LayerConfigurationBuilder("dem", "GeoTIFF")
+    sources = [{"url": "https://example.com/dem.tif"}]
+    builder.set_source_properties(sources=sources)
+    config = builder.build()
+    source = config["configuration"]["props"]["source"]
+    assert config["configuration"]["type"] == "WebGLTile"
+    assert source["type"] == "GeoTIFF"
+    assert source["props"]["sources"] == sources
 
 
 def test_geojson_lives_at_source_geojson_not_props():


### PR DESCRIPTION
## Summary

- Adds **GeoTIFF** to the MCP source allowlist, the backend layer builder, and the OpenLayers/WebGLTile renderer so the chatbox can create Cloud Optimized GeoTIFF layers from a flat URL or an explicit `source_props.sources` array.
- Variable URL templates (e.g., `${dem_version}`) are preserved literally end-to-end so runtime variable interpolation can re-resolve the layer URL when an input changes.
- `create_variable_input` infers `variable_type=dropdown` when `options` are supplied but `variable_type` stays at the default `text` — common LLM omission, deterministic fallback that matches user intent.
- Bumps the linked `@aquaveo/chatbox-core` (`lib/chatbox-core`) from 0.3.0 → 0.4.0 (removes capability-based tool gating in the engine, required for the new tool to remain visible across providers).

## Files

- MCP: `tethysapp/tethysdash/mcp/tethysdash_mcp_server.py`
- Builder: `tethysapp/tethysdash/plugin_helpers.py`
- Renderer: `reactapp/components/map/utilities.js`, `reactapp/components/visualizations/Map.js`
- Tests: `test_layer_contracts.py`, `test_plugin_helpers.py`, `test_variable_input_contracts.py`, `utilities.test.js`, `Map.test.js`
- Lockfile: `package-lock.json`

## Test plan

- [ ] MCP contract suite green: `.venv-test/bin/python -m pytest tethysapp/tethysdash/tests/mcp/ --no-cov -q` (416 / 416 locally)
- [ ] GeoTIFF unit tests: `PATH="$(pwd)/.venv-test/bin:$PATH" .venv-test/bin/python -m pytest tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py -k geotiff --no-cov -q`
- [ ] Frontend Jest for map utilities + Map.js: `npx jest reactapp/__tests__/components/map/ reactapp/__tests__/components/visualizations/Map.test.js` (156 / 156 locally)
- [ ] Smoke: in the chatbox, create a Map and add a GeoTIFF layer with a variable URL like `https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/n38w112/USGS_13_n38w112_${dem_version}.tif`; verify the persisted layer carries the literal placeholder string and the layer renders once the variable has a value.

## Solution doc

`docs/solutions/integration-issues/geotiff-mcp-layer-variable-url-tool-availability-2026-05-06.md`