### PR TITLE
fix(mcp): coerce replace->add on Map layer paths and surface patch failures

### DIFF
--- a/reactapp/__tests__/components/dashboard/DashboardLayoutPatch.test.js
+++ b/reactapp/__tests__/components/dashboard/DashboardLayoutPatch.test.js
@@ -305,6 +305,91 @@ describe("handleUpdateVisualization — apply_patch", () => {
     expect(map.layerControl).toBe(true);
   });
 
+  test("emits tethysdash:patch-rejected when rfc6902 fails", async () => {
+    // Plan 2026-05-07-001 Unit B: silent-failure UX gap — failed patches
+    // must surface a chat-visible event so the user sees the failure.
+    await renderWithDashboard(makeDashboard([plotItem]));
+    const events = [];
+    const onReject = (e) => events.push(e.detail);
+    window.addEventListener("tethysdash:patch-rejected", onReject);
+    try {
+      await dispatchUpdate({
+        batch: true,
+        operation: "apply_patch",
+        patches: [
+          {
+            uuid: "plot-1",
+            source: "Inline Plotly",
+            ops: [{ op: "replace", path: "/args/inlineData/nonexistent/foo", value: "x" }],
+          },
+        ],
+      });
+    } finally {
+      window.removeEventListener("tethysdash:patch-rejected", onReject);
+    }
+    expect(events.length).toBe(1);
+    expect(events[0].uuid).toBe("plot-1");
+    expect(events[0].path).toBe("/args/inlineData/nonexistent/foo");
+    // rfc6902 surfaces the error class as `name`; we forward it verbatim.
+    expect(events[0].errorClass).toBe("MissingError");
+  });
+
+  test("partial failure emits one event per failed UUID; successful UUIDs do not emit", async () => {
+    await renderWithDashboard(makeDashboard([plotItem, mapItem]));
+    const events = [];
+    const onReject = (e) => events.push(e.detail);
+    window.addEventListener("tethysdash:patch-rejected", onReject);
+    try {
+      await dispatchUpdate({
+        batch: true,
+        operation: "apply_patch",
+        patches: [
+          {
+            uuid: "plot-1",
+            source: "Inline Plotly",
+            ops: [{ op: "replace", path: "/args/inlineData/nonexistent/foo", value: "x" }],
+          },
+          {
+            uuid: "map-1",
+            source: "Map",
+            ops: [{ op: "replace", path: "/args/layerControl", value: true }],
+          },
+        ],
+      });
+    } finally {
+      window.removeEventListener("tethysdash:patch-rejected", onReject);
+    }
+    expect(events.length).toBe(1);
+    expect(events[0].uuid).toBe("plot-1");
+    // Sibling patch still applied (existing partial-batch tolerance).
+    const items = getTabGridItems();
+    const map = JSON.parse(items.find((i) => i.uuid === "map-1").args_string);
+    expect(map.layerControl).toBe(true);
+  });
+
+  test("clean apply does not emit tethysdash:patch-rejected", async () => {
+    await renderWithDashboard(makeDashboard([plotItem]));
+    const events = [];
+    const onReject = (e) => events.push(e.detail);
+    window.addEventListener("tethysdash:patch-rejected", onReject);
+    try {
+      await dispatchUpdate({
+        batch: true,
+        operation: "apply_patch",
+        patches: [
+          {
+            uuid: "plot-1",
+            source: "Inline Plotly",
+            ops: [{ op: "replace", path: "/args/inlineData/layout/title", value: "OK" }],
+          },
+        ],
+      });
+    } finally {
+      window.removeEventListener("tethysdash:patch-rejected", onReject);
+    }
+    expect(events.length).toBe(0);
+  });
+
   test("no patches field → no-op", async () => {
     await renderWithDashboard(makeDashboard([plotItem]));
     await dispatchUpdate({

--- a/reactapp/__tests__/components/sidebar/ChatSidebar.test.js
+++ b/reactapp/__tests__/components/sidebar/ChatSidebar.test.js
@@ -6,7 +6,7 @@
  * not-yet-loaded state produce no DOM. Mirrors the edit-modal's
  * visibility — the chatbox is an editor tool.
  */
-import { render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import ChatSidebar from "components/sidebar/ChatSidebar";
 import {
   AppContext,
@@ -43,6 +43,14 @@ function renderWithContexts({ editable, pluginEditablePaths = {} }) {
   );
 }
 
+function dispatchPatchRejected(detail) {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent("tethysdash:patch-rejected", { detail }),
+    );
+  });
+}
+
 describe("ChatSidebar permission gate (R11)", () => {
   test("mounts the chatbox when editable is true", () => {
     const { queryByTestId } = renderWithContexts({ editable: true });
@@ -59,6 +67,139 @@ describe("ChatSidebar permission gate (R11)", () => {
   test("renders nothing when editable is undefined (permission still loading)", () => {
     const { queryByTestId, container } = renderWithContexts({ editable: undefined });
     expect(queryByTestId("chatbox-stub")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("ChatSidebar patch-rejected banner (plan 2026-05-07-001 Unit B)", () => {
+  test("renders nothing initially when no events have fired", () => {
+    const { queryByTestId } = renderWithContexts({ editable: true });
+    expect(queryByTestId("patch-rejected-banner")).toBeNull();
+  });
+
+  test("renders a banner entry when tethysdash:patch-rejected fires", () => {
+    const { queryByTestId } = renderWithContexts({ editable: true });
+    dispatchPatchRejected({
+      uuid: "abcdef12-1234-5678-9abc-def012345678",
+      path: "/args/layers/1/configuration/props/source/props/params",
+      errorClass: "MissingError",
+      opIndex: 0,
+    });
+    const banner = queryByTestId("patch-rejected-banner");
+    expect(banner).not.toBeNull();
+    // Banner content names the failure: error class, path, and uuid prefix.
+    const text = banner.textContent;
+    expect(text).toContain("MissingError");
+    expect(text).toContain(
+      "/args/layers/1/configuration/props/source/props/params",
+    );
+    expect(text).toContain("abcdef12");
+  });
+
+  test("subsequent events accumulate into the banner", () => {
+    const { queryAllByTestId } = renderWithContexts({ editable: true });
+    dispatchPatchRejected({
+      uuid: "11111111-1111-1111-1111-111111111111",
+      path: "/args/layers/0/configuration/props/source/props/params",
+      errorClass: "MissingError",
+      opIndex: 0,
+    });
+    dispatchPatchRejected({
+      uuid: "22222222-2222-2222-2222-222222222222",
+      path: "/args/layers/2/configuration/props/opacity",
+      errorClass: "TestError",
+      opIndex: 1,
+    });
+    expect(queryAllByTestId("patch-rejected-entry").length).toBe(2);
+  });
+
+  test("caps the number of visible entries", () => {
+    const { queryAllByTestId } = renderWithContexts({ editable: true });
+    // Fire more than the cap — older entries should drop off.
+    for (let i = 0; i < 12; i++) {
+      dispatchPatchRejected({
+        uuid: `0000000${i}-0000-0000-0000-000000000000`,
+        path: `/args/layers/${i}/configuration/props/opacity`,
+        errorClass: "MissingError",
+        opIndex: 0,
+      });
+    }
+    const entries = queryAllByTestId("patch-rejected-entry");
+    // Exact cap is an implementation detail; pin "fewer than dispatched".
+    expect(entries.length).toBeLessThan(12);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  test("dismiss button removes a single entry", () => {
+    const { queryAllByTestId, queryAllByLabelText } = renderWithContexts({
+      editable: true,
+    });
+    dispatchPatchRejected({
+      uuid: "11111111-1111-1111-1111-111111111111",
+      path: "/args/layers/0/x",
+      errorClass: "MissingError",
+      opIndex: 0,
+    });
+    dispatchPatchRejected({
+      uuid: "22222222-2222-2222-2222-222222222222",
+      path: "/args/layers/1/y",
+      errorClass: "MissingError",
+      opIndex: 0,
+    });
+    expect(queryAllByTestId("patch-rejected-entry").length).toBe(2);
+    const closeButtons = queryAllByLabelText(/dismiss patch failure/i);
+    expect(closeButtons.length).toBe(2);
+    act(() => {
+      fireEvent.click(closeButtons[0]);
+    });
+    expect(queryAllByTestId("patch-rejected-entry").length).toBe(1);
+  });
+
+  test("listener is cleaned up on unmount", () => {
+    // Spy on add/remove so we can verify the cleanup function actually ran.
+    // Comparing call shapes (event name + handler reference) catches the case
+    // where the addEventListener returns successfully but the cleanup never
+    // calls removeEventListener (or calls it with the wrong args).
+    const adds = [];
+    const removes = [];
+    const origAdd = window.addEventListener;
+    const origRemove = window.removeEventListener;
+    window.addEventListener = function (type, handler, options) {
+      if (type === "tethysdash:patch-rejected") {
+        adds.push(handler);
+      }
+      return origAdd.call(this, type, handler, options);
+    };
+    window.removeEventListener = function (type, handler, options) {
+      if (type === "tethysdash:patch-rejected") {
+        removes.push(handler);
+      }
+      return origRemove.call(this, type, handler, options);
+    };
+    try {
+      const { unmount } = renderWithContexts({ editable: true });
+      expect(adds.length).toBe(1);
+      unmount();
+      // Cleanup must remove the SAME handler reference that was added.
+      expect(removes.length).toBe(1);
+      expect(removes[0]).toBe(adds[0]);
+    } finally {
+      window.addEventListener = origAdd;
+      window.removeEventListener = origRemove;
+    }
+  });
+
+  test("does not render banner when editable is false (viewer mode)", () => {
+    const { queryByTestId, container } = renderWithContexts({
+      editable: false,
+    });
+    dispatchPatchRejected({
+      uuid: "11111111-1111-1111-1111-111111111111",
+      path: "/args/x",
+      errorClass: "MissingError",
+      opIndex: 0,
+    });
+    expect(queryByTestId("patch-rejected-banner")).toBeNull();
     expect(container.firstChild).toBeNull();
   });
 });

--- a/reactapp/components/dashboard/DashboardLayout.js
+++ b/reactapp/components/dashboard/DashboardLayout.js
@@ -153,6 +153,22 @@ const DashboardLayout = ({ tabId, gridItems, shouldLoad }) => {
     // args in `{args: ...}` before rfc6902 apply, then unwrap on save. This
     // way the path the LLM emits, the path the server whitelist validates,
     // and the path rfc6902 resolves against are all identical.
+    // Surface a patch-failure to anyone listening (chat sidebar banner etc.).
+    // detail carries enough to identify the failed entry without leaking
+    // persisted values. Caps the number of dispatched ops to keep the
+    // payload small even when an envelope contained many ops.
+    function emitPatchRejected(uuid, errorClass, path, opIndex) {
+      try {
+        window.dispatchEvent(
+          new CustomEvent("tethysdash:patch-rejected", {
+            detail: { uuid, errorClass, path, opIndex },
+          }),
+        );
+      } catch {
+        // Best-effort: never let a failed event dispatch crash the reducer.
+      }
+    }
+
     function applyPatchToGridItem(target, ops, uuid) {
       let args;
       try {
@@ -162,6 +178,7 @@ const DashboardLayout = ({ tabId, gridItems, shouldLoad }) => {
           "[DashboardLayout] apply_patch: failed to parse args_string for uuid",
           uuid,
         );
+        emitPatchRejected(uuid, "ParseError", null, null);
         return null;
       }
       // JSON deep-clone + atomic apply: all ops succeed or we discard the
@@ -176,6 +193,16 @@ const DashboardLayout = ({ tabId, gridItems, shouldLoad }) => {
           uuid,
           errors,
         );
+        // Surface the FIRST error per UUID — covers the common case (single
+        // failing op) without spamming the chat with one banner per op.
+        const firstIdx = errors.findIndex((err) => err !== null);
+        const firstErr = errors[firstIdx];
+        emitPatchRejected(
+          uuid,
+          firstErr?.name || "ApplyError",
+          ops[firstIdx]?.path ?? null,
+          firstIdx,
+        );
         return null;
       }
       // Defense-in-depth: an op like {op:"remove", path:"/args"} would leave
@@ -189,6 +216,7 @@ const DashboardLayout = ({ tabId, gridItems, shouldLoad }) => {
           uuid,
           "— refusing to persist `undefined`",
         );
+        emitPatchRejected(uuid, "ArgsRootRemoved", "/args", null);
         return null;
       }
       return { ...target, args_string: JSON.stringify(draft.args) };

--- a/reactapp/components/sidebar/ChatSidebar.js
+++ b/reactapp/components/sidebar/ChatSidebar.js
@@ -1,4 +1,4 @@
-import { memo, useCallback, useContext, useMemo } from "react";
+import { memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import {
   AppContext,
@@ -43,6 +43,13 @@ const DELTA_MAX_UUIDS = 30;
 const DELTA_BLOCK_RE = /\n\n\[in-turn delta\]\n[\s\S]*$/;
 
 const SIDEBAR_WIDTH = 360;
+
+// Cap on patch-rejected entries shown in the banner. Older entries drop off
+// FIFO so the banner doesn't grow unbounded across a long debugging session.
+// Plan 2026-05-07-001 Unit B: silent-failure UX gap — failed patches must
+// surface to the user so the chatbox's confident "Done!" message is not the
+// last word.
+const PATCH_REJECTED_BANNER_CAP = 5;
 
 const Wrapper = styled.div`
   width: ${(props) => (props.$isOpen ? `${SIDEBAR_WIDTH}px` : "0px")};
@@ -94,6 +101,45 @@ const Content = styled.div`
   height: 0;
 `;
 
+const PatchRejectedBanner = styled.div`
+  flex-shrink: 0;
+  min-width: ${SIDEBAR_WIDTH}px;
+  background: #fff8e1;
+  border-bottom: 1px solid #f0d68a;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  color: #5a4400;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const PatchRejectedEntry = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  line-height: 1.3;
+`;
+
+const PatchRejectedBody = styled.div`
+  flex: 1;
+  word-break: break-all;
+`;
+
+const PatchRejectedDismiss = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #7a5c00;
+  padding: 0 4px;
+  font-size: 0.85rem;
+  line-height: 1;
+  flex-shrink: 0;
+  &:hover {
+    color: #3d2e00;
+  }
+`;
+
 function ChatSidebar() {
   // `?? {}` matches the pattern in components/layout/Header.js:287 — callers
   // that mount the sidebar outside the required providers (e.g., isolated
@@ -126,6 +172,46 @@ function ChatSidebar() {
     () => variableInputValues,
     [variableInputValues],
   );
+
+  // Plan 2026-05-07-001 Unit B: chat-sidebar-visible feedback when a patch
+  // dispatch fails inside `applyPatchToGridItem` (rfc6902 errors etc.).
+  // Without this banner, the chatbox shows the LLM's confident "Done!"
+  // message and the user has no signal that nothing actually changed.
+  const [patchRejections, setPatchRejections] = useState([]);
+  useEffect(() => {
+    function onPatchRejected(e) {
+      const detail = e?.detail;
+      if (!detail || typeof detail !== "object") return;
+      const entry = {
+        // A unique key for React; the same UUID can fail multiple times,
+        // so combine with a monotonic counter via Date.now() + Math.random()
+        // (collision-resistant enough for a chat-banner UI).
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        uuid: typeof detail.uuid === "string" ? detail.uuid : "(unknown)",
+        path: typeof detail.path === "string" ? detail.path : "(no path)",
+        errorClass:
+          typeof detail.errorClass === "string"
+            ? detail.errorClass
+            : "ApplyError",
+        opIndex: typeof detail.opIndex === "number" ? detail.opIndex : null,
+      };
+      setPatchRejections((prev) => {
+        const next = [...prev, entry];
+        // FIFO cap — drop oldest entries when over the limit.
+        return next.length > PATCH_REJECTED_BANNER_CAP
+          ? next.slice(next.length - PATCH_REJECTED_BANNER_CAP)
+          : next;
+      });
+    }
+    window.addEventListener("tethysdash:patch-rejected", onPatchRejected);
+    return () => {
+      window.removeEventListener("tethysdash:patch-rejected", onPatchRejected);
+    };
+  }, []);
+
+  const dismissPatchRejection = useCallback((id) => {
+    setPatchRejections((prev) => prev.filter((e) => e.id !== id));
+  }, []);
 
   // Snapshot of current dashboard visualizations + the editable-path
   // whitelist for every source present. Rebuilt on every tabs /
@@ -245,6 +331,30 @@ function ChatSidebar() {
           <BsXLg size={14} />
         </CloseButton>
       </Header>
+      {patchRejections.length > 0 && (
+        <PatchRejectedBanner data-testid="patch-rejected-banner" role="alert">
+          {patchRejections.map((entry) => (
+            <PatchRejectedEntry
+              key={entry.id}
+              data-testid="patch-rejected-entry"
+            >
+              <PatchRejectedBody>
+                <strong>Patch failed:</strong> {entry.errorClass}
+                {" · "}
+                <code>{entry.path}</code>
+                {" · "}
+                <span title={entry.uuid}>{entry.uuid.slice(0, 8)}</span>
+              </PatchRejectedBody>
+              <PatchRejectedDismiss
+                aria-label="Dismiss patch failure"
+                onClick={() => dismissPatchRejection(entry.id)}
+              >
+                <BsXLg size={10} />
+              </PatchRejectedDismiss>
+            </PatchRejectedEntry>
+          ))}
+        </PatchRejectedBanner>
+      )}
       <Content>
         <Chatbox
           csrfToken={csrf}

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -1362,6 +1362,58 @@ def _coerce_known_values(source: str, patches: List[Dict[str, Any]]) -> None:
                 op["value"] = BASE_MAPS.get(value, value)
 
 
+def _coerce_replace_to_add_on_layer_paths(
+    source: str, patches: List[Dict[str, Any]]
+) -> None:
+    """Op-level normalization: ``replace`` -> ``add`` for Map layer-internal
+    paths whose leaf segment is an object key (not an array index).
+
+    RFC 6902 ``replace`` requires the target to exist; ``add`` creates if
+    missing or replaces if present. For object-key paths these are
+    functionally identical when the target exists. LLMs frequently emit
+    ``replace`` for fields they want to "set" but that may be absent on
+    layers created without them (e.g., ``params`` on an ESRI Feature
+    Service layer created without filters).
+
+    Bounded to:
+      * ``Map`` source only — non-Map sources have their own internal
+        shapes and the missing-target failure mode hasn't surfaced there.
+      * Path under ``/args/layers/N/...`` (depth >= 4 segments) — the
+        layer-construction boundary already rejects bare-index and
+        whole-array forms before this runs, so any remaining ``replace``
+        on Map at this depth is targeting a field within an existing
+        layer.
+      * Leaf segment is not a numeric index or ``-`` — those are JSON
+        Pointer markers for arrays, where ``add`` and ``replace`` differ
+        materially (insert vs substitute). Coercing them would change the
+        semantics of legitimate array-element edits.
+
+    Mutates ``patches`` in-place. No I/O, no telemetry — silent
+    transformation that matches sibling value-coercion precedent.
+
+    Sibling to ``_coerce_known_values`` in this module; both are called
+    from ``patch_visualization`` after validation, before returning the
+    envelope.
+    """
+    if source != "Map":
+        return
+    for op in patches:
+        if op.get("op") != "replace":
+            continue
+        path = op.get("path", "")
+        if not path.startswith("/args/layers/"):
+            continue
+        segments = path.split("/")
+        # ``"/args/layers/0/x".split("/")`` -> ``["", "args", "layers", "0", "x"]``;
+        # length 5 means one segment past ``/args/layers/N``.
+        if len(segments) < 5:
+            continue
+        leaf = segments[-1]
+        if leaf == "-" or leaf.isdigit():
+            continue
+        op["op"] = "add"
+
+
 def _validate_patch_envelope_shape(patches):
     """R1/R2: structural validation.
 
@@ -1684,6 +1736,13 @@ def patch_visualization(
     # Value coercions that mirror the create tools (e.g., baseMap shorthand).
     # Run AFTER validation so shape rules apply to the pre-coercion value.
     _coerce_known_values(source, patches)
+
+    # Op-level coercion: replace -> add for Map layer-internal paths.
+    # Runs after the boundary check (so bare-index `replace` is already
+    # rejected and never reaches this point) and after value coercion (so
+    # the value rules apply to the pre-coercion shape if any field-specific
+    # rules ever target an op-coerced path in the future).
+    _coerce_replace_to_add_on_layer_paths(source, patches)
 
     LOGGER.info(
         "patch_visualization: target_uuid=%s source=%s ops=%d description=%s",

--- a/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
+++ b/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
@@ -191,6 +191,191 @@ class TestValueCoercion:
 
 
 # ---------------------------------------------------------------------------
+# Op-level coercion — replace -> add for Map layer-internal paths
+# ---------------------------------------------------------------------------
+
+
+class TestOpCoercion:
+    """`replace` -> `add` on Map paths under /args/layers/N/... where the leaf
+    is an object key (not an array index).
+
+    RFC 6902 `replace` requires the target to exist; `add` creates if missing
+    or replaces if present. For object-key paths these are functionally
+    identical when the target exists. LLMs frequently emit `replace` for
+    fields they want to "set" but that may be absent on layers created
+    without them (e.g., `params` on an ESRI Feature Service layer). Coercing
+    at the patch-tool boundary closes that asymmetry without inspecting
+    values for shape correctness — same posture as TestValueCoercion above,
+    extended from value-level to op-level symmetry.
+    """
+
+    def test_replace_at_deep_object_key_path_is_coerced(self):
+        """Positive coerce: the prompt-from-the-bug case."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers/0/configuration/props/source/props/params",
+                "value": {"WHERE": "rfc_name = 'Colorado Basin'"},
+            }],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "add"
+        assert result["patch_update"]["ops"][0]["path"] == (
+            "/args/layers/0/configuration/props/source/props/params"
+        )
+        assert result["patch_update"]["ops"][0]["value"] == {
+            "WHERE": "rfc_name = 'Colorado Basin'"
+        }
+
+    def test_replace_at_deeper_nested_object_key_path_is_coerced(self):
+        """Deeper than one level past `/args/layers/N`."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers/2/configuration/props/source/props/params/WHERE",
+                "value": "x = 1",
+            }],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "add"
+
+    def test_add_op_passes_through_unchanged(self):
+        """Identity passthrough: existing `add` ops are not mangled."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "add",
+                "path": "/args/layers/0/configuration/props/opacity",
+                "value": 0.5,
+            }],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "add"
+
+    def test_remove_op_passes_through_unchanged(self):
+        """Identity passthrough: `remove` is not coerced."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "remove",
+                "path": "/args/layers/0/configuration/props/opacity",
+            }],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "remove"
+
+    def test_test_op_passes_through_unchanged(self):
+        """Identity passthrough: `test` is not coerced."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "test",
+                "path": "/args/layers/0/configuration/props/opacity",
+                "value": 0.5,
+            }],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "test"
+
+    def test_non_map_source_replace_is_not_coerced(self):
+        """Scope guard: only Map source is coerced. Plotly etc. unaffected."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Inline Plotly",
+            patches=[{
+                "op": "replace",
+                "path": "/args/inlineData/layout/title",
+                "value": "X",
+            }],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "replace"
+
+    def test_replace_at_non_layer_map_path_is_not_coerced(self):
+        """Scope guard: paths under Map that aren't /args/layers/N/... pass through.
+        /args/baseMap, /args/layerControl, /args/map_extent, /args/mapDrawing
+        are layer-array-siblings, not layer-internals, and they always exist
+        on a created Map (no missing-target failure mode)."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{"op": "replace", "path": "/args/layerControl", "value": False}],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "replace"
+
+    def test_replace_with_numeric_leaf_segment_is_not_coerced(self):
+        """Scope guard: leaf is an array index (e.g., GeoTIFF sources/0).
+        `add /N` shifts; `replace /N` substitutes — different semantics.
+        Coercion would corrupt the patch, so it must not fire."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers/0/configuration/props/source/props/sources/0",
+                "value": {"url": "https://example.com/cog.tif"},
+            }],
+        )
+        assert "patch_update" in result, result
+        assert result["patch_update"]["ops"][0]["op"] == "replace"
+
+    def test_replace_with_dash_leaf_segment_is_not_coerced(self):
+        """Scope guard: `-` is the JSON Pointer 'append' marker for arrays.
+        Coercion must not fire — same reasoning as numeric leaves."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers/0/configuration/props/source/props/sources/-",
+                "value": {"url": "https://example.com/cog.tif"},
+            }],
+        )
+        # This particular path may also fail for other reasons (replace at `-`
+        # is unusual), but we only assert that coercion did NOT change `op`.
+        # If the result has patch_update, the op must still be `replace`;
+        # if there's an error, it's an unrelated rejection — coercion is
+        # silent transformation, not a rejection.
+        if "patch_update" in result:
+            assert result["patch_update"]["ops"][0]["op"] == "replace"
+
+    def test_multi_op_envelope_coerces_per_op(self):
+        """One coerce-eligible replace + one ineligible — each handled correctly."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[
+                {
+                    "op": "replace",
+                    "path": "/args/layers/0/configuration/props/opacity",
+                    "value": 0.5,
+                },
+                {
+                    "op": "replace",
+                    "path": "/args/baseMap",
+                    "value": (
+                        "https://server.arcgisonline.com/arcgis/rest/services/"
+                        "World_Imagery/MapServer"
+                    ),
+                },
+            ],
+        )
+        assert "patch_update" in result, result
+        # First op: under /args/layers/N/... → coerced to add.
+        assert result["patch_update"]["ops"][0]["op"] == "add"
+        # Second op: /args/baseMap → not under /args/layers/, untouched.
+        assert result["patch_update"]["ops"][1]["op"] == "replace"
+
+
+# ---------------------------------------------------------------------------
 # Value-shape validation — contract parity between create and patch paths
 # ---------------------------------------------------------------------------
 
@@ -872,6 +1057,24 @@ class TestLayerConstructionBoundary:
             patches=[{"op": "remove", "path": "/args/layers/1"}],
         )
         assert "patch_update" in result, result
+
+    def test_replace_at_bare_layer_index_still_rejected_after_op_coercion(self):
+        """Regression pin: the boundary check runs BEFORE op coercion, so
+        a `replace` at /args/layers/N (bare index) is still rejected even
+        though plan 2026-05-07-001 introduces a generic replace->add coercion
+        for Map paths. The boundary's bare-index rejection must not be
+        bypassed by treating the op as `add` after the fact."""
+        result = patch_visualization(
+            target_uuid=_fresh_uuid(),
+            source="Map",
+            patches=[{
+                "op": "replace",
+                "path": "/args/layers/0",
+                "value": {"name": "smuggled new layer"},
+            }],
+        )
+        assert "error" in result
+        assert "whitelist_rejected" in result["error"]
 
     def test_single_op_move_within_layers_rejected_by_r5c(self):
         """Single-op `move` between layer indices is intentionally rejected


### PR DESCRIPTION
## Summary

Two-unit follow-up to PR #102's predecessor (plan `2026-05-06-002`). Closes the wrong-op LLM failure mode that the per-layer `field_paths` injection exposed by giving the LLM the right path, plus the silent-failure UX gap that made the bug invisible until devtools were open.

### Unit A — Server-side `replace` → `add` coercion

When the LLM patches a Map layer field that doesn't yet exist (e.g., `params` on a layer created without a WHERE filter), it picks `replace` because the user said "Update". RFC 6902 `replace` requires the target to exist; `rfc6902` raises `MissingError` and the patch is silently dropped.

For object-key paths, `add` and `replace` are functionally identical when the target exists — and `add` additionally creates if missing. New helper `_coerce_replace_to_add_on_layer_paths` coerces `replace` → `add` for Map ops at depth ≥ 4 under `/args/layers/N/...` whose leaf segment is not a numeric index or `-`.

- Bounded to `Map` source.
- Runs after `_check_layer_construction_boundary` so bare-index / whole-array paths are still rejected (regression pin added).
- Numeric-leaf and `-`-leaf paths skipped (different array semantics).
- Sibling to `_coerce_known_values` (value-level coercion); same call-site pattern.
- Op-level normalization, not value repair — on the other side of the workspace memory's "no detectors / no repair" bright line.

### Unit B — Client-side patch-failure surface

`applyPatchToGridItem` previously logged `console.warn` and returned `null` on rfc6902 errors. The user saw the LLM's confident "Done!" and an unchanged dashboard.

- `DashboardLayout` now dispatches a `tethysdash:patch-rejected` window event with `{uuid, errorClass, path, opIndex}` whenever `applyPatchToGridItem` fails. Partial-batch tolerance preserved.
- `ChatSidebar` listens, accumulates rejections (FIFO, cap 5), and renders a styled banner above the chatbox with each entry's error class, path, and uuid prefix. Entries are individually dismissable.

## Test plan

- [ ] MCP contract suite: `.venv-test/bin/python -m pytest tethysapp/tethysdash/tests/mcp/ --no-cov -q` (427/427 locally; 10 new `TestOpCoercion` cases + boundary regression pin)
- [ ] Sidebar + DashboardLayout Jest: `npx jest reactapp/__tests__/components/sidebar/ reactapp/__tests__/components/dashboard/DashboardLayoutPatch.test.js` (73/73 locally; 7 new ChatSidebar banner cases + 3 new patch-rejected event cases)
- [ ] Smoke: two-turn prompt — (1) create a Map + Colorado RFC Boundary layer with no WHERE filter; (2) "Update params.WHERE to rfc_name = 'Colorado Basin'". Confirmed locally: server log shows a single `patch_visualization` call, the WHERE clause appears in the Edit Visualization modal, no duplicate layer.

## Plan

`docs/plans/2026-05-07-001-fix-patch-replace-coerce-and-surface-failures-plan.md`