### PR TITLE
fix(mcp): validate UUID-typed tool args at the patch-tool boundary

### DIFF
--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -633,6 +633,50 @@ _LAYER_PROP_BUILDER_METHODS = {
 }
 
 
+def _validate_uuid_arg(
+    value: Any, arg_name: str, returned_by_tool: str
+) -> Optional[str]:
+    """Validate that ``value`` is a well-formed UUID string.
+
+    Plan 2026-05-07-002 Unit A. Some LLMs (observed: gemma4:31b) emit
+    Mustache-style template placeholders like ``{{last_map_uuid}}`` for
+    chained tool args, expecting the host framework to substitute the
+    prior tool's return value. MCP doesn't do this. Without validation
+    the literal string passes through and the layer/patch is silently
+    dropped downstream when the dispatcher can't find a matching grid
+    item.
+
+    Returns ``None`` on success or a structured error string the caller
+    wraps in ``{"error": ...}``. The string is always prefixed
+    ``invalid_uuid:`` so the chatbox engine's ``toolErrorCheck`` routes
+    it through the existing repair-loop machinery without further wiring.
+
+    The fix-hint names the originating create_* tool so the LLM has a
+    concrete recovery action to take on the next round.
+    """
+    # Defensive: Pydantic types this as ``str`` but null inputs from a
+    # JSON-stringified payload could slip past in edge cases.
+    if not isinstance(value, str):
+        return (
+            f"invalid_uuid: {arg_name} must be a UUID string returned by "
+            f"{returned_by_tool}. Tool arguments are not template-substituted; "
+            f"pass the literal UUID from the prior tool result."
+        )
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError):
+        # Truncate at 80 chars so error logs don't bloat for adversarial
+        # inputs while still showing the LLM what shape was rejected.
+        offending = value if len(value) <= 80 else value[:77] + "..."
+        return (
+            f"invalid_uuid: {arg_name} must be a UUID string returned by "
+            f"{returned_by_tool}. You provided {offending!r}, which is not "
+            f"a valid UUID. Tool arguments are not template-substituted; "
+            f"pass the literal UUID from the prior tool result."
+        )
+    return None
+
+
 def _validate_advanced_layer_dicts(
     *,
     source_type: str,
@@ -912,6 +956,14 @@ def add_map_service_layer(
     parameters and returns a layer_update result (not a visualization).
     The chatbox dispatches this as a tethysdash:update-visualization event.
     """
+    # Plan 2026-05-07-002 Unit A: reject template placeholders / malformed
+    # UUIDs at the boundary so the LLM gets an actionable error instead of
+    # building a layer that gets silently dropped at dispatch.
+    uuid_error = _validate_uuid_arg(
+        map_uuid, "map_uuid", "create_map_visualization"
+    )
+    if uuid_error:
+        return {"error": uuid_error}
     LOGGER.info(
         "add_map_service_layer: map_uuid=%s, source_type=%s, name=%s",
         map_uuid, source_type, name,
@@ -1649,8 +1701,20 @@ def patch_visualization(
     and the reducer applies client-side via rfc6902.
 
     Returns `{error: "..."}` with a structured error class prefix on failure:
-    `invalid_envelope`, `whitelist_rejected`.
+    `invalid_envelope`, `whitelist_rejected`, `invalid_uuid`.
     """
+    # Plan 2026-05-07-002 Unit A: reject template placeholders / malformed
+    # UUIDs before any other work. Cheapest reject; most actionable error
+    # for the LLM (the prior tool's create_* return value is the recovery
+    # source of truth).
+    uuid_error = _validate_uuid_arg(
+        target_uuid,
+        "target_uuid",
+        "the create_* tool that returned this UUID",
+    )
+    if uuid_error:
+        return {"error": uuid_error}
+
     # Dict-coercion pattern (see docs/solutions/best-practices/mcp-tool-dict-parameter-coercion)
     if isinstance(patches, str):
         try:
@@ -2008,6 +2072,14 @@ def add_dynamic_map_layer(
     fetch failures surface through Map.js's existing visualization-error
     path (no new error handling here).
     """
+    # Plan 2026-05-07-002 Unit A: same UUID validation as
+    # add_map_service_layer — reject template placeholders / malformed UUIDs
+    # at the boundary.
+    uuid_error = _validate_uuid_arg(
+        map_uuid, "map_uuid", "create_map_visualization"
+    )
+    if uuid_error:
+        return {"error": uuid_error}
     LOGGER.info(
         "add_dynamic_map_layer: map_uuid=%s, source=%s, name=%s",
         map_uuid, source, name,

--- a/tethysapp/tethysdash/tests/mcp/test_coercion.py
+++ b/tethysapp/tethysdash/tests/mcp/test_coercion.py
@@ -18,7 +18,10 @@ from tethysapp.tethysdash.tests.mcp.test_visualization_contracts import (
 )
 
 
-TEST_MAP_UUID = "coercion-test-uuid-1234"
+# Stable real UUID v4 used by every coercion test below.
+# Plan 2026-05-07-002 added UUID-format validation to add_map_service_layer;
+# the prior fake "coercion-test-uuid-1234" string would now be rejected.
+TEST_MAP_UUID = "22222222-2222-4222-8222-222222222222"
 
 
 # ---------------------------------------------------------------------------

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -20,7 +20,12 @@ from tethysapp.tethysdash.tests.mcp.test_visualization_contracts import (
 )
 
 
-MAP_UUID = "test-map-uuid-1234"
+# Stable real UUID v4 used by every layer-contract test below.
+# Plan 2026-05-07-002 added UUID-format validation to add_map_service_layer
+# and add_dynamic_map_layer; the prior fake "test-map-uuid-1234" string
+# would now be rejected at the new validator. The literal value here is
+# arbitrary — fixtures only care that it parses as a UUID.
+MAP_UUID = "11111111-1111-4111-8111-111111111111"
 
 
 # ---------------------------------------------------------------------------
@@ -2311,3 +2316,129 @@ class TestValidateAdvancedLayerDicts:
         result = self._call(popup_options={"omit": ["bad shape"]})
         assert result is not None
         assert "omit" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Plan 2026-05-07-002 Unit A: UUID format validation on map_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestUuidValidationAddMapServiceLayer:
+    """`map_uuid` must be a well-formed UUID string. The literal placeholder
+    `{{last_map_uuid}}` (and other Mustache-style template forms) that some
+    LLMs emit for chained tool args must be rejected with a structured
+    `invalid_uuid:` envelope so the LLM gets an in-band fix-hint and retries
+    with the actual UUID returned by `create_map_visualization`.
+    """
+
+    def _real_uuid_call(self, **overrides):
+        kwargs = dict(
+            map_uuid="33333333-3333-4333-8333-333333333333",
+            source_type="WMS",
+            name="Layer",
+            url="https://example.com/wms",
+            wms_layers="ws:layer",
+        )
+        kwargs.update(overrides)
+        return add_map_service_layer(**kwargs)
+
+    def test_valid_uuid_v4_lowercase_accepted(self):
+        result = self._real_uuid_call(map_uuid="11111111-1111-4111-8111-111111111111")
+        assert "error" not in result, result
+        assert "layer_update" in result
+
+    def test_valid_uuid_uppercase_accepted(self):
+        # uuid.UUID is case-insensitive — caps form must work.
+        result = self._real_uuid_call(map_uuid="11111111-1111-4111-8111-111111111111".upper())
+        assert "error" not in result, result
+        assert "layer_update" in result
+
+    def test_template_placeholder_rejected(self):
+        result = self._real_uuid_call(map_uuid="{{last_map_uuid}}")
+        assert "error" in result
+        err = result["error"]
+        assert err.startswith("invalid_uuid:"), err
+        assert "map_uuid" in err
+        assert "create_map_visualization" in err
+        # Hint about templating — the LLM must learn this is not a templating engine.
+        assert "template" in err.lower() or "literal" in err.lower()
+        # Must NOT collide with the whitelist_rejected error class.
+        assert "whitelist_rejected" not in err
+
+    def test_dollar_brace_placeholder_rejected(self):
+        result = self._real_uuid_call(map_uuid="${last_map_uuid}")
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_empty_string_rejected(self):
+        result = self._real_uuid_call(map_uuid="")
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_garbage_string_rejected(self):
+        result = self._real_uuid_call(map_uuid="not-a-uuid")
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_uuid_with_extra_hex_digit_rejected(self):
+        result = self._real_uuid_call(
+            map_uuid="11111111-1111-4111-8111-111111111111a"  # 33 hex chars
+        )
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_uuid_with_surrounding_whitespace_rejected(self):
+        # Strict canonical form — caller must trim before passing.
+        result = self._real_uuid_call(
+            map_uuid=" 11111111-1111-4111-8111-111111111111 "
+        )
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_validation_runs_before_other_checks(self):
+        # A payload with both a malformed map_uuid AND a missing required
+        # field (e.g., wms_layers) should report the UUID error first —
+        # it's the more actionable issue for the LLM.
+        result = add_map_service_layer(
+            map_uuid="{{last_map_uuid}}",
+            source_type="WMS",
+            name="Layer",
+            url="https://example.com/wms",
+            # wms_layers omitted — would normally produce its own error.
+        )
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+
+class TestUuidValidationAddDynamicMapLayer:
+    """`add_dynamic_map_layer` shares the same `map_uuid` contract — same
+    helper, same rejection envelope.
+    """
+
+    def test_template_placeholder_rejected(self):
+        # Minimal-args call; we only care about the map_uuid validator.
+        result = add_dynamic_map_layer(
+            map_uuid="{{last_map_uuid}}",
+            source="some_intake_plugin",
+            name="Layer",
+        )
+        assert "error" in result
+        err = result["error"]
+        assert err.startswith("invalid_uuid:")
+        assert "map_uuid" in err
+
+    def test_valid_uuid_passes_validation(self):
+        # The plugin source itself may not exist (we don't care for this
+        # test); we only assert that the UUID validator does NOT fire.
+        # If it gets past the UUID validator, any subsequent error must
+        # NOT be invalid_uuid:.
+        result = add_dynamic_map_layer(
+            map_uuid="11111111-1111-4111-8111-111111111111",
+            source="some_intake_plugin",
+            name="Layer",
+        )
+        if "error" in result:
+            assert not result["error"].startswith("invalid_uuid:"), (
+                "UUID validator must accept a real UUID; the error came from "
+                "elsewhere in the tool body. " + result["error"]
+            )

--- a/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
+++ b/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
@@ -1323,3 +1323,72 @@ class TestRejectionTelemetry:
         assert (
             spy.call_args.kwargs["reason"] == "resolution_failure_or_unknown_source"
         )
+
+
+# ---------------------------------------------------------------------------
+# Plan 2026-05-07-002 Unit A: UUID format validation on target_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestUuidValidationTargetUuid:
+    """`target_uuid` must be a well-formed UUID string. Same family as the
+    map_uuid validation in test_layer_contracts.py — same helper, same
+    rejection envelope shape (`invalid_uuid:` prefix), same fix-hint
+    template referencing the originating create_* tool.
+    """
+
+    def _valid_patch(self, target_uuid):
+        return patch_visualization(
+            target_uuid=target_uuid,
+            source="Inline Plotly",
+            patches=[
+                {"op": "replace", "path": "/args/inlineData/layout/title", "value": "X"},
+            ],
+        )
+
+    def test_valid_uuid_accepted(self):
+        result = self._valid_patch("11111111-1111-4111-8111-111111111111")
+        assert "error" not in result, result
+        assert "patch_update" in result
+
+    def test_uppercase_uuid_accepted(self):
+        result = self._valid_patch("11111111-1111-4111-8111-111111111111".upper())
+        assert "error" not in result, result
+
+    def test_template_placeholder_rejected(self):
+        result = self._valid_patch("{{last_map_uuid}}")
+        assert "error" in result
+        err = result["error"]
+        assert err.startswith("invalid_uuid:"), err
+        assert "target_uuid" in err
+        # Hint should reference create_* tools as the source of truth for UUIDs.
+        assert "create_" in err
+        assert "template" in err.lower() or "literal" in err.lower()
+        assert "whitelist_rejected" not in err
+
+    def test_dollar_brace_placeholder_rejected(self):
+        result = self._valid_patch("${last_plot_uuid}")
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_empty_string_rejected(self):
+        result = self._valid_patch("")
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_garbage_rejected(self):
+        result = self._valid_patch("not-a-uuid")
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")
+
+    def test_validation_runs_before_envelope_validation(self):
+        # An envelope with both a malformed target_uuid AND a malformed
+        # patches array should report the UUID error first (cheap reject,
+        # most actionable for the LLM).
+        result = patch_visualization(
+            target_uuid="{{last_map_uuid}}",
+            source="Inline Plotly",
+            patches="not a list",  # would normally trigger invalid_envelope
+        )
+        assert "error" in result
+        assert result["error"].startswith("invalid_uuid:")


### PR DESCRIPTION
## Summary

Server-side half of plan `2026-05-07-002`. Closes a silent-drop failure mode where LLMs (observed: gemma4:31b) emit Mustache-style `{{last_map_uuid}}` placeholders for chained tool args, expecting host-side substitution that MCP doesn't perform. The literal placeholder passes through, the layer/patch envelope is built with a bad UUID, the chatbox dispatcher fails to find a matching grid item, and the result is silently dropped — user sees an unstyled map and the LLM reporting "Done!".

This adds a single `_validate_uuid_arg` helper (uses stdlib `uuid.UUID()`, no regex) wired as the first call in three patch tools:

- `add_map_service_layer` (`map_uuid`)
- `add_dynamic_map_layer` (`map_uuid`)
- `patch_visualization` (`target_uuid`)

On rejection, returns a structured `{error: "invalid_uuid: ..."}` envelope with a clear fix-hint naming the offending value, the originating `create_*` tool, and the literal-UUID expectation.

## Pairing with chatbox-core

The chatbox-core half is [Aquaveo/chatbox-core PR #15](https://github.com/Aquaveo/chatbox-core/pull/15) (merged) — engine-side closed-vocabulary `{{last_<type>_uuid}}` substitution against the engine's authoritative tool-return state, bumped to 0.5.0. Together:

- Engine resolves the 5 known placeholder forms pre-dispatch when a corresponding UUID is tracked.
- This server-side validator catches everything else (other placeholder forms, malformed UUIDs, empty strings) at the protocol boundary with a structured fix-hint that teaches the LLM the right shape via in-band error feedback.

The server-side validator works for **every** MCP client (Claude Desktop, Cursor, future hosts) consuming the TethysDash server — chatbox-core is just the convenience layer for the common case.

## Files

- `tethysapp/tethysdash/mcp/tethysdash_mcp_server.py` — new `_validate_uuid_arg` helper, wired into 3 tools.
- `tethysapp/tethysdash/tests/mcp/test_layer_contracts.py` — `MAP_UUID` fixture updated from fake string to real UUID v4 (the new validator would have rejected the prior fixture). New `TestUuidValidationAddMapServiceLayer` (9 cases), `TestUuidValidationAddDynamicMapLayer` (2 cases).
- `tethysapp/tethysdash/tests/mcp/test_patch_visualization.py` — new `TestUuidValidationTargetUuid` (7 cases).
- `tethysapp/tethysdash/tests/mcp/test_coercion.py` — `TEST_MAP_UUID` fixture updated similarly.

## Test plan

- [x] `.venv-test/bin/python -m pytest tethysapp/tethysdash/tests/mcp/ --no-cov -q` — **445 / 445** (18 new validation cases + the 2 fixture-update no-regression).
- [x] `npm test` — **1724 / 1724** (full Jest suite, consuming freshly-built chatbox-core 0.5.0 `dist/`).
- [x] Smoke test with the originating gemma4:31b prompt — both layers now appear on the map; server log shows `add_map_service_layer: map_uuid=<real-uuid>` (substituted by the engine) instead of `map_uuid={{last_map_uuid}}`.

## Plan

`docs/plans/2026-05-07-002-fix-uuid-validation-and-template-substitution-plan.md`