### PR TITLE
feat(mcp): per-source-type arg-routing templates for add_map_service_layer (T2)

### DIFF
--- a/reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js
+++ b/reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js
@@ -10,6 +10,7 @@ import {
   buildDashboardState,
   buildEditablePathsBySource,
   buildValueHintsBySource,
+  buildMapLayerArgRouting,
   buildDeltaSummary,
   buildPatchContext,
 } from "../../../components/sidebar/chatboxStateBuilder";
@@ -513,6 +514,189 @@ describe("buildValueHintsBySource", () => {
   });
 });
 
+describe("buildMapLayerArgRouting", () => {
+  // Plan 2026-05-07-005 (T2). Per-source-type arg-routing templates
+  // injected into the system message so the LLM knows WHICH ARG
+  // carries WHICH KEY before calling add_map_service_layer.
+  // Closes the LLM-routing failure-mode class structurally — today's
+  // GeoTIFF auto-legend bug had rampName/rampMin/rampMax landing in
+  // `style` instead of `source_props` (silent semantic failure).
+
+  const ALL_SOURCE_TYPES = [
+    "WMS",
+    "ESRI Image and Map Service",
+    "ESRI Feature Service",
+    "GeoJSON",
+    "KML",
+    "Image Tile",
+    "Vector Tile",
+    "PMTiles Vector",
+    "PMTiles Raster",
+    "GeoTIFF",
+    "Static Image",
+  ];
+
+  const NO_PARAMS_TYPES = [
+    "GeoJSON",
+    "KML",
+    "Image Tile",
+    "Vector Tile",
+    "PMTiles Vector",
+    "PMTiles Raster",
+  ];
+
+  test("returns {} when no Map item is in the dashboard_state", () => {
+    // Plotly-only dashboard — no map-layer routing relevant.
+    const items = [
+      { uuid: "p", source: "Inline Plotly", title: null },
+      { uuid: "v", source: "Variable Input", title: null },
+    ];
+    expect(buildMapLayerArgRouting(items)).toEqual({});
+  });
+
+  test("returns {} for empty / missing items", () => {
+    expect(buildMapLayerArgRouting([])).toEqual({});
+    expect(buildMapLayerArgRouting(undefined)).toEqual({});
+    expect(buildMapLayerArgRouting(null)).toEqual({});
+  });
+
+  test("emits all 11 source-type templates when a Map is present", () => {
+    const items = [{ uuid: "m", source: "Map", title: "x" }];
+    const routing = buildMapLayerArgRouting(items);
+    expect(Object.keys(routing).sort()).toEqual(
+      [...ALL_SOURCE_TYPES].sort(),
+    );
+  });
+
+  test("each entry has source_props (string array), params (array or null), ambiguity_warnings (array)", () => {
+    const items = [{ uuid: "m", source: "Map", title: "x" }];
+    const routing = buildMapLayerArgRouting(items);
+    for (const sourceType of ALL_SOURCE_TYPES) {
+      const entry = routing[sourceType];
+      expect(entry).toBeDefined();
+      // source_props: array of string field names.
+      expect(Array.isArray(entry.source_props)).toBe(true);
+      for (const k of entry.source_props) expect(typeof k).toBe("string");
+      // params: array of strings, or null when source type doesn't accept params.
+      if (entry.params !== null) {
+        expect(Array.isArray(entry.params)).toBe(true);
+        for (const k of entry.params) expect(typeof k).toBe("string");
+      }
+      // ambiguity_warnings: array of strings.
+      expect(Array.isArray(entry.ambiguity_warnings)).toBe(true);
+      for (const w of entry.ambiguity_warnings) expect(typeof w).toBe("string");
+    }
+  });
+
+  test("GeoTIFF entry routes ramp keys to source_props with style-vs-source_props warning", () => {
+    const routing = buildMapLayerArgRouting([
+      { uuid: "m", source: "Map", title: "x" },
+    ]);
+    const entry = routing["GeoTIFF"];
+    expect(entry.source_props).toEqual(
+      expect.arrayContaining([
+        "sources",
+        "attributions",
+        "bands",
+        "nodata",
+        "min",
+        "max",
+        "rampName",
+        "rampMin",
+        "rampMax",
+      ]),
+    );
+    expect(entry.params).toBeNull();
+    // The load-bearing warning — the bug this plan fixes.
+    const warnings = entry.ambiguity_warnings.join(" ");
+    expect(warnings).toMatch(/source_props/);
+    expect(warnings).toMatch(/style/);
+    expect(warnings).toMatch(/legend/);
+  });
+
+  test("WMS entry routes STYLES/TIME to params, with style-vs-params warning", () => {
+    const routing = buildMapLayerArgRouting([
+      { uuid: "m", source: "Map", title: "x" },
+    ]);
+    const entry = routing["WMS"];
+    expect(entry.params).toEqual(
+      expect.arrayContaining(["LAYERS", "STYLES", "TIME"]),
+    );
+    const warnings = entry.ambiguity_warnings.join(" ");
+    expect(warnings).toMatch(/STYLES/);
+    expect(warnings).toMatch(/params/);
+  });
+
+  test("ESRI Image and Map Service routes LAYERS/LAYERDEFS/TIME/mosaicRule to params", () => {
+    const routing = buildMapLayerArgRouting([
+      { uuid: "m", source: "Map", title: "x" },
+    ]);
+    const entry = routing["ESRI Image and Map Service"];
+    expect(entry.params).toEqual(
+      expect.arrayContaining(["LAYERS", "LAYERDEFS", "TIME", "mosaicRule"]),
+    );
+  });
+
+  test("ESRI Feature Service routes WHERE/TIME to params", () => {
+    const routing = buildMapLayerArgRouting([
+      { uuid: "m", source: "Map", title: "x" },
+    ]);
+    const entry = routing["ESRI Feature Service"];
+    expect(entry.params).toEqual(expect.arrayContaining(["WHERE", "TIME"]));
+  });
+
+  test("source types that do not support params have params=null and a warning saying so", () => {
+    const routing = buildMapLayerArgRouting([
+      { uuid: "m", source: "Map", title: "x" },
+    ]);
+    for (const sourceType of NO_PARAMS_TYPES) {
+      const entry = routing[sourceType];
+      expect(entry.params).toBeNull();
+      const warnings = entry.ambiguity_warnings.join(" ");
+      // Should mention that params is rejected/not supported for these.
+      expect(warnings).toMatch(/params/i);
+    }
+  });
+
+  test("Static Image routes projection/imageExtent to params", () => {
+    const routing = buildMapLayerArgRouting([
+      { uuid: "m", source: "Map", title: "x" },
+    ]);
+    const entry = routing["Static Image"];
+    expect(entry.params).toEqual(
+      expect.arrayContaining(["projection", "imageExtent"]),
+    );
+  });
+
+  test("templates contain no concrete URL or SQL example values (workspace memory)", () => {
+    // Per workspace memory: "no concrete example values in MCP tool
+    // descriptions — LLMs copy them verbatim". The risk class is
+    // example *data* (URLs, query strings, IDs) that the LLM persists
+    // instead of resolving to the user's real values. Configuration
+    // directives like `legend='default'` are NOT the risk — they are
+    // the literal arg value the LLM should pass verbatim.
+    //
+    // Pin: no URL hosts, no SQL example clauses with field names, no
+    // ESRI service paths.
+    const routing = buildMapLayerArgRouting([
+      { uuid: "m", source: "Map", title: "x" },
+    ]);
+    const blob = JSON.stringify(routing);
+    expect(blob).not.toContain("https://");
+    expect(blob).not.toContain("http://");
+    expect(blob).not.toContain("FeatureServer");
+    expect(blob).not.toContain("MapServer");
+    // Field-name'd SQL example like `rfc_name = 'Colorado'` (capitalized
+    // value indicates a proper noun, the data-value risk class) would
+    // match. A directive like `legend='default'` (lowercase value) would
+    // not — directives are the literal arg value the LLM should pass
+    // verbatim, not example data. Case-sensitive on the value start.
+    expect(blob).not.toMatch(/[a-z_]+\s*=\s*'[A-Z]/);
+    expect(blob).not.toMatch(/SELECT /i);
+  });
+});
+
+
 describe("buildPatchContext", () => {
   test("returns null when no patchable items are in the dashboard", () => {
     // Empty dashboard, no variable inputs set — nothing useful to say.
@@ -533,6 +717,24 @@ describe("buildPatchContext", () => {
     // Map basemap hints must flow into the full patch context so the LLM
     // can pick a correct URL instead of guessing a label like "imagery".
     expect(ctx.value_hints_by_source.Map["/args/baseMap"]).toBeDefined();
+    // Plan 2026-05-07-005 (T2): map_layer_arg_routing flows when a Map
+    // is present so the LLM knows which arg holds which key for
+    // add_map_service_layer.
+    expect(ctx.map_layer_arg_routing).toBeDefined();
+    expect(ctx.map_layer_arg_routing["GeoTIFF"]).toBeDefined();
+  });
+
+  test("map_layer_arg_routing is empty/absent when dashboard has no Map", () => {
+    // A Plotly + Variable Input dashboard — no map layers possible.
+    // map_layer_arg_routing should be empty (or absent — implementation
+    // choice; test for {} since buildPatchContext threads helper output
+    // verbatim).
+    const ctx = buildPatchContext(
+      [{ id: "t", gridItems: [plotItem, variableInputItem] }],
+      {},
+    );
+    expect(ctx).not.toBeNull();
+    expect(ctx.map_layer_arg_routing).toEqual({});
   });
 
   test("includes the plot's /args/inlineData prefix so the LLM can infer /args/inlineData/layout/title", () => {

--- a/reactapp/components/sidebar/chatboxStateBuilder.js
+++ b/reactapp/components/sidebar/chatboxStateBuilder.js
@@ -256,6 +256,165 @@ export function buildValueHintsBySource(items) {
   return out;
 }
 
+// ---------------------------------------------------------------------------
+// Plan 2026-05-07-005 (T2): per-source-type arg-routing templates.
+//
+// `add_map_service_layer` exposes overlapping dict-typed args (source_props,
+// style, params, legend, popup_options, attribute_variables, layer_props).
+// Smaller LLMs categorize source-type-specific keys into the wrong arg
+// (observed: rampName/rampMin/rampMax landed in `style` instead of
+// `source_props` for GeoTIFF — silent semantic failure since the renderer
+// reads from source.<key>, not configuration.style.<key>).
+//
+// These templates name WHICH ARG should carry WHICH KEY for each source
+// type. Hand-curated rather than registry-derived because the JS-side
+// `sourcePropertiesOptions` registry in reactapp/components/map/utilities.js
+// is currently lossy (e.g., GeoTIFF ramp fields exist in Python's
+// `available_source_properties` but not in JS).
+//
+// Drift sources (canonical):
+//   - tethysapp/tethysdash/plugin_helpers.py::available_source_properties
+//   - tethysapp/tethysdash/mcp/tethysdash_mcp_server.py::add_map_service_layer
+//
+// When a new source-type field is added to either canonical source, add
+// it here too. The templates use field NAMES + types + brief routing
+// notes — never concrete example values (workspace memory:
+// "no concrete example values in MCP tool descriptions — LLMs copy them
+// verbatim"; same applies to system-message payload content).
+//
+// When T3 ships (per-source-type tool split, e.g., add_geotiff_layer,
+// add_wms_layer, ...), these templates become obsolete — delete this
+// helper and its tests then.
+// ---------------------------------------------------------------------------
+
+const _MAP_LAYER_ARG_ROUTING_TEMPLATES = {
+  WMS: {
+    source_props: ["url", "attributions", "projection"],
+    params: ["LAYERS", "STYLES", "TIME"],
+    ambiguity_warnings: [
+      "STYLES (the WMS SLD style name) goes in `params`, NOT in the `style` arg.",
+      "`style` is for inline OL feature styling (rules/default keys); WMS rendering uses params.STYLES.",
+      "LAYERS is normally set via the flat `wms_layers` argument, not via params directly.",
+    ],
+  },
+  "ESRI Image and Map Service": {
+    source_props: ["url", "attributions", "projection"],
+    params: ["LAYERS", "LAYERDEFS", "TIME", "mosaicRule"],
+    ambiguity_warnings: [
+      "LAYERS / LAYERDEFS / TIME / mosaicRule all go in `params`, NOT in the `style` arg.",
+      "LAYERDEFS is a string-keyed dict of per-layer SQL filters, e.g. {layer_id_string: where_clause}.",
+      "LAYERS accepts directive-prefixed forms (show:/hide:/include:/exclude:) plus bare integer lists; bare lists are canonicalized to `show:` form.",
+    ],
+  },
+  "ESRI Feature Service": {
+    source_props: ["url", "attributions"],
+    params: ["WHERE", "TIME"],
+    ambiguity_warnings: [
+      "WHERE (the SQL filter clause) goes in `params`, NOT in the `style` arg.",
+      "Required `layer` (integer index) is set via the flat `layer_id` argument, not source_props directly.",
+    ],
+  },
+  GeoJSON: {
+    source_props: [],
+    params: null,
+    ambiguity_warnings: [
+      "GeoJSON does not accept a `params` argument — supplying it is rejected (invalid_source_params).",
+      "Inline geometry uses the flat `geojson` arg; hosted GeoJSON URL uses the flat `geojson_url` arg.",
+      "`attributions` is not yet supported in the source_props allowlist for GeoJSON.",
+    ],
+  },
+  KML: {
+    source_props: ["url", "attributions", "projection"],
+    params: null,
+    ambiguity_warnings: [
+      "KML does not accept a `params` argument — supplying it is rejected (invalid_source_params).",
+    ],
+  },
+  "Image Tile": {
+    source_props: ["url", "attributions", "projection"],
+    params: null,
+    ambiguity_warnings: [
+      "Image Tile does not accept a `params` argument — supplying it is rejected (invalid_source_params).",
+      "Tile URL templates contain {z}/{x}/{y} placeholders, passed through verbatim by the producer.",
+    ],
+  },
+  "Vector Tile": {
+    source_props: ["url", "urls", "attributions", "projection"],
+    params: null,
+    ambiguity_warnings: [
+      "Vector Tile does not accept a `params` argument — supplying it is rejected (invalid_source_params).",
+      "Multi-URL templates can be supplied via source_props.urls (array form) — the flat `url` arg is single-URL only.",
+    ],
+  },
+  "PMTiles Vector": {
+    source_props: ["url", "attributions", "tileSize"],
+    params: null,
+    ambiguity_warnings: [
+      "PMTiles Vector does not accept a `params` argument — supplying it is rejected (invalid_source_params).",
+    ],
+  },
+  "PMTiles Raster": {
+    source_props: ["url", "attributions", "tileSize"],
+    params: null,
+    ambiguity_warnings: [
+      "PMTiles Raster does not accept a `params` argument — supplying it is rejected (invalid_source_params).",
+    ],
+  },
+  GeoTIFF: {
+    source_props: [
+      "sources",
+      "attributions",
+      "bands",
+      "nodata",
+      "min",
+      "max",
+      "rampName",
+      "rampMin",
+      "rampMax",
+    ],
+    params: null,
+    ambiguity_warnings: [
+      "Auto-legend keys (rampName / rampMin / rampMax) and band-control keys (bands / nodata / min / max) ALL go in `source_props`, NOT in the `style` arg.",
+      "`style` is for inline OL feature styling (rules/default keys); raster auto-legends use source_props plus legend='default'.",
+      "GeoTIFF does not accept a `params` argument — supplying it is rejected (invalid_source_params).",
+      "rampName values are the keys of the COLOR_RAMPS catalog (e.g., the names shown in the Style tab of the Edit Visualization modal).",
+    ],
+  },
+  "Static Image": {
+    source_props: ["url", "attributions"],
+    params: ["projection", "imageExtent"],
+    ambiguity_warnings: [
+      "Static Image's `params` carries projection + imageExtent (flat keys onto source.props per the Static Image builder convention).",
+      "imageExtent is a comma-separated bounding-box string, not a numeric array.",
+    ],
+  },
+};
+
+/**
+ * Plan 2026-05-07-005 (T2). Returns a per-source-type arg-routing
+ * template object the LLM consults before calling
+ * ``add_map_service_layer``. Each entry names which keys go in
+ * ``source_props``, which (if any) go in ``params``, and the
+ * highest-impact ambiguity zones to avoid.
+ *
+ * Gated on the dashboard containing a Map item — same gate-on-presence
+ * pattern as ``buildValueHintsBySource``. When no Map is present, returns
+ * ``{}`` to keep the system-message payload lean.
+ *
+ * Returned templates use field NAMES + types + brief routing notes.
+ * Never concrete example values (workspace memory: "no concrete example
+ * values ... LLMs copy them verbatim").
+ *
+ * @param {Array<{source?: string}>} items - dashboard_state entries
+ * @returns {Object} per-source-type routing object, or {} when no Map
+ */
+export function buildMapLayerArgRouting(items) {
+  if (!Array.isArray(items)) return {};
+  const sources = new Set(items.map((i) => i?.source).filter(Boolean));
+  if (!sources.has("Map")) return {};
+  return _MAP_LAYER_ARG_ROUTING_TEMPLATES;
+}
+
 /**
  * Build the full system-message payload for the chatbox beforeFirstMessage
  * injection. Returns null if there is nothing useful to inject — either
@@ -280,6 +439,10 @@ export function buildPatchContext(tabs, variableInputValues, pluginEditablePaths
     dashboard_state: dashboardState,
     editable_paths_by_source: editablePathsBySource,
     value_hints_by_source: buildValueHintsBySource(dashboardState),
+    // Plan 2026-05-07-005 (T2): per-source-type arg-routing for
+    // add_map_service_layer. Empty {} when no Map is in the dashboard
+    // (keeps the system-message payload lean for non-Map workflows).
+    map_layer_arg_routing: buildMapLayerArgRouting(dashboardState),
     variable_input_values: variableInputValues || {},
   };
 }


### PR DESCRIPTION
## Summary

Closes the LLM-routing failure-mode class structurally. `add_map_service_layer` exposes overlapping dict-typed args (`source_props`, `style`, `params`, `legend`, `popup_options`, `attribute_variables`, `layer_props`). Smaller LLMs categorize source-type-specific keys into the wrong arg — observed today: `rampName/rampMin/rampMax` landed in `style` instead of `source_props` for GeoTIFF. Server accepted (style is permissive); persisted shape didn't match the renderer's read path; silent semantic failure.

Per the audit's tiered recommendation (T1=per-failure rejection, T2=structural injection, T3=per-source-type tool split), **T2** is the proactive structural fix. Sibling pattern to plan `2026-05-07-002` Unit B's `field_paths_by_source` injection for `patch_visualization` (same `beforeFirstMessage` hook, parallel structure).

## What changes

- New `_MAP_LAYER_ARG_ROUTING_TEMPLATES` const in `chatboxStateBuilder.js`, hand-curated entries for all 11 source types. Each entry has `source_props` (array), `params` (array or null), `ambiguity_warnings` (array of brief routing notes — `style`-vs-`source_props`-vs-`params` confusion zones).
- `buildMapLayerArgRouting(items)` helper, gated on Map presence (mirrors `buildValueHintsBySource`).
- Wired into `buildPatchContext` as `map_layer_arg_routing`. Flows through the existing `beforeFirstMessage` system-message hook — no new system message (avoids the Ollama Cloud strict-role-alternation hazard).

## Why hand-curated, not registry-derived

The JS `sourcePropertiesOptions` registry is currently lossy for the GeoTIFF ramp fields (Python `plugin_helpers.py` has them post PR #106; JS hasn't been brought to parity). Module-level comment cites the canonical Python sources for drift awareness.

## Discipline

Templates use field NAMES + types + brief routing notes only. No concrete example values (workspace memory: *"no concrete example values in MCP tool descriptions — LLMs copy them verbatim"*; same applies to system-message payloads).

## Cleanup commitment

When T3 (per-source-type tool split — separate brainstorm + plan) ships, `_MAP_LAYER_ARG_ROUTING_TEMPLATES` and its helper become obsolete. Delete then.

## Test plan

- [x] `npx jest reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js` — **54 / 54** (11 new `TestBuildMapLayerArgRouting` cases + 2 new `buildPatchContext` integration assertions).
- [x] Broader Jest regression: 85/85 sidebar + DashboardLayoutPatch.
- [x] Smoke test: re-ran the GeoTIFF prompt that originally surfaced today's bug; LLM correctly routed `rampName/rampMin/rampMax` to `source_props` (no longer in `style`); persistence at `source.<key>` (PR #106 routing) works as designed; auto-legend renders.

## Known follow-up — separate plan, next session

OL WebGLTile needs an explicit `configuration.style.color` interpolation expression for the **tile** (not just the legend) to render with the color ramp. PR #106 + this PR together correctly persist `rampName/rampMin/rampMax` at `source.<key>`; the renderer needs to derive the interpolate expression from those keys when `style.color` is absent. Tracked as plan `2026-05-07-006` (next session).

## Plan

`docs/plans/2026-05-07-005-feat-mcp-arg-routing-templates-plan.md`