### PR TITLE
feat(viz): derive OL style.color for GeoTIFF layers at render time

### DIFF
--- a/reactapp/__tests__/components/visualizations/Map.test.js
+++ b/reactapp/__tests__/components/visualizations/Map.test.js
@@ -35,7 +35,10 @@ jest.mock("components/map/ModuleLoader", () => {
 });
 
 // eslint-disable-next-line
-import MapVisualization, { Popup } from "components/visualizations/Map";
+import MapVisualization, {
+  Popup,
+  deriveGeoTIFFRenderConfig,
+} from "components/visualizations/Map";
 // eslint-disable-next-line
 import { createJsonStyleFunction } from "components/map/ModuleLoader";
 
@@ -656,6 +659,162 @@ test("Map GeoTIFF with default legend emits a ramp colorbar from sourceProps met
   // Layer name is used as the legend title for the colorbar entry
   // (line 357: `title: layer.configuration?.props?.name`).
   expect(screen.getByText("Ramp Raster Layer")).toBeInTheDocument();
+});
+
+// Plan 006: Renderer-side derivation of OL `style.color` for GeoTIFF
+// layers persisted via MCP (which only carries rampName/rampMin/rampMax).
+// Modal-saved layers persist `style.color` explicitly and take precedence.
+// The synthesis is exercised through the pure `deriveGeoTIFFRenderConfig`
+// helper — `Map.js`'s auto-legend block is a single call site for it, and
+// the helper's behavior is the load-bearing piece. Renderer-level
+// integration is covered by the existing GeoTIFF auto-legend test above.
+
+const buildGeoTIFFConfig = ({ sources, style } = {}) => ({
+  type: "WebGLTile",
+  props: {
+    name: "Ramp Raster Layer",
+    source: {
+      type: "GeoTIFF",
+      props: {
+        sources: sources ?? [{ url: "https://example.com/ramp.tif" }],
+      },
+      rampName: "viridis",
+      rampMin: "0",
+      rampMax: "100",
+    },
+  },
+  ...(style !== undefined ? { style } : {}),
+});
+
+describe("deriveGeoTIFFRenderConfig (Plan 006)", () => {
+  test("#1 synthesizes interpolate style.color when layer has no explicit style", () => {
+    const layerConfiguration = buildGeoTIFFConfig();
+    const result = deriveGeoTIFFRenderConfig({
+      layerConfiguration,
+      rampSource: layerConfiguration.props.source,
+    });
+
+    expect(result.style?.color).toBeDefined();
+    expect(result.style.color[0]).toBe("interpolate");
+    expect(result.style.color[1]).toEqual(["linear"]);
+    expect(result.style.color[2]).toEqual(["band", 1]);
+    // First stop value === rampMin (0), last stop value === rampMax (100).
+    expect(result.style.color[3]).toBe(0);
+    expect(result.style.color[result.style.color.length - 2]).toBe(100);
+    // Stop hex values match the viridis ramp shape.
+    expect(result.style.color[result.style.color.length - 1]).toMatch(
+      /^#[0-9a-f]{6}$/i,
+    );
+  });
+
+  test("#2 explicit style.color is preserved (precedence over synthesis)", () => {
+    const explicitColor = [
+      "interpolate",
+      ["linear"],
+      ["band", 1],
+      0,
+      "#000000",
+      100,
+      "#ffffff",
+    ];
+    const layerConfiguration = buildGeoTIFFConfig({
+      style: { color: explicitColor },
+    });
+    const result = deriveGeoTIFFRenderConfig({
+      layerConfiguration,
+      rampSource: layerConfiguration.props.source,
+    });
+
+    // Explicit value preserved verbatim — synthesis must not overwrite.
+    expect(result).toBe(layerConfiguration);
+    expect(result.style.color).toEqual(explicitColor);
+  });
+
+  test("#3 hasNodata wraps interpolate in a `case` expression", () => {
+    const layerConfiguration = buildGeoTIFFConfig({
+      sources: [{ url: "https://example.com/ramp.tif", nodata: -9999 }],
+    });
+    const result = deriveGeoTIFFRenderConfig({
+      layerConfiguration,
+      rampSource: layerConfiguration.props.source,
+    });
+
+    expect(result.style.color[0]).toBe("case");
+    expect(result.style.color[3][0]).toBe("interpolate");
+  });
+
+  test("#4 nodata empty string is treated as absent", () => {
+    const layerConfiguration = buildGeoTIFFConfig({
+      sources: [{ url: "https://example.com/ramp.tif", nodata: "" }],
+    });
+    const result = deriveGeoTIFFRenderConfig({
+      layerConfiguration,
+      rampSource: layerConfiguration.props.source,
+    });
+
+    expect(result.style.color[0]).toBe("interpolate");
+  });
+
+  test("#5 missing sources array still synthesizes (hasNodata=false)", () => {
+    const layerConfiguration = {
+      type: "WebGLTile",
+      props: {
+        name: "Ramp Raster Layer",
+        source: {
+          type: "GeoTIFF",
+          props: {},
+          rampName: "viridis",
+          rampMin: "0",
+          rampMax: "100",
+        },
+      },
+    };
+    const result = deriveGeoTIFFRenderConfig({
+      layerConfiguration,
+      rampSource: layerConfiguration.props.source,
+    });
+
+    expect(result.style.color[0]).toBe("interpolate");
+  });
+
+  test("#6 upstream layerConfiguration is not mutated by synthesis", () => {
+    const layerConfiguration = buildGeoTIFFConfig();
+    Object.freeze(layerConfiguration);
+    Object.freeze(layerConfiguration.props);
+    Object.freeze(layerConfiguration.props.source);
+
+    // Synthesis must shallow-clone — frozen object writes would throw.
+    expect(() =>
+      deriveGeoTIFFRenderConfig({
+        layerConfiguration,
+        rampSource: layerConfiguration.props.source,
+      }),
+    ).not.toThrow();
+
+    // Original has no `style` key — derivation lives only on the returned
+    // shallow-cloned config.
+    expect(layerConfiguration.style).toBeUndefined();
+  });
+
+  test("#7 synthesis throw falls through to original configuration", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const layerConfiguration = buildGeoTIFFConfig();
+    // Force buildGeoTIFFStyleColor to throw with non-finite rampMin while
+    // still satisfying the outer auto-legend guard (rampMin !== undefined).
+    layerConfiguration.props.source.rampMin = "not-a-number";
+
+    const result = deriveGeoTIFFRenderConfig({
+      layerConfiguration,
+      rampSource: layerConfiguration.props.source,
+    });
+
+    // Original config returned unchanged; warning logged.
+    expect(result).toBe(layerConfiguration);
+    expect(result.style).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
 });
 
 test("Map ESRI with default legend", async () => {

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -19,6 +19,7 @@ import {
 } from "components/map/utilities";
 import PropTypes from "prop-types";
 import { COLOR_RAMPS } from "components/map/colorRamps";
+import { buildGeoTIFFStyleColor } from "components/map/geoTIFFStyle";
 import { getBaseMapLayer } from "components/visualizations/utilities";
 import useRuntimeLayerFetcher from "components/visualizations/runtimeLayerFetcher";
 import {
@@ -112,6 +113,46 @@ const StyledCloser = styled.a`
 const StyledContent = styled.div`
   margin-top: 1rem;
 `;
+
+// Derive an OL `style.color` interpolate expression for a GeoTIFF layer
+// when the persisted configuration carries `rampName/rampMin/rampMax` but
+// no explicit `style.color`. Modal-saved layers persist `style.color`
+// directly and take precedence (this returns the original config when
+// `style.color` is already present). Shallow-clones to avoid mutating the
+// upstream layers prop. Callers must pre-validate that `rampSource` is a
+// GeoTIFF with a known ramp + finite-ish min/max — the inner helper still
+// throws on bad input, and we fall through to the original config in that
+// case so the auto-legend pipeline keeps working.
+export function deriveGeoTIFFRenderConfig({ layerConfiguration, rampSource }) {
+  if (layerConfiguration?.style?.color) {
+    return layerConfiguration;
+  }
+  try {
+    const sources = rampSource.props?.sources;
+    const hasNodata = Array.isArray(sources)
+      ? sources.some((s) => s?.nodata !== undefined && s.nodata !== "")
+      : false;
+    const derivedColor = buildGeoTIFFStyleColor({
+      rampName: rampSource.rampName,
+      rampMin: rampSource.rampMin,
+      rampMax: rampSource.rampMax,
+      hasNodata,
+    });
+    return {
+      ...layerConfiguration,
+      style: {
+        ...(layerConfiguration.style || {}),
+        color: derivedColor,
+      },
+    };
+  } catch (err) {
+    console.warn(
+      `Failed to derive GeoTIFF style.color for layer "${layerConfiguration?.props?.name}":`,
+      err,
+    );
+    return layerConfiguration;
+  }
+}
 
 export const Popup = ({
   layerAttributes,
@@ -404,7 +445,12 @@ const MapVisualization = ({
                   rampMax: rampSource.rampMax,
                   title: layer.configuration?.props?.name,
                 });
-                newMapLayers.push(layer.configuration);
+                newMapLayers.push(
+                  deriveGeoTIFFRenderConfig({
+                    layerConfiguration: layer.configuration,
+                    rampSource,
+                  }),
+                );
                 continue;
               }
               // If the layer has a style JSON, pass it as legend metadata


### PR DESCRIPTION
## Summary

Closes the partial-fix gap discovered in the smoke test of merged PRs #106 (plan 004) and #107 (plan 005). GeoTIFF layers persisted via the MCP `add_map_service_layer` tool carry `rampName/rampMin/rampMax` at source-top-level but no explicit `configuration.style.color`, so OL's WebGLTile rendered tiles as raw band values (gray) until the user manually re-saved through the Edit modal.

This adds **`deriveGeoTIFFRenderConfig`** — a pure helper colocated with the auto-legend call site in `Map.js` — that:

- Synthesizes `style.color` via the existing pure helper `buildGeoTIFFStyleColor` when absent.
- Preserves explicit `style.color` (modal-saved layers continue to take precedence).
- Shallow-clones the configuration so the upstream layers prop is never mutated.
- Falls through to the original config with a `console.warn` if synthesis throws on bad input.

The `hasNodata` predicate mirrors `MapLayer.js:394-396` exactly. Persists nothing — `rampName/rampMin/rampMax` remain the single source of truth; `style.color` is derived at render time only.

## Test plan

- [x] `npx jest reactapp/__tests__/components/visualizations/Map.test.js` — 42/42 pass, including 7 new scenarios under `describe("deriveGeoTIFFRenderConfig (Plan 006)")` covering synthesis-on-absence, explicit-color precedence, hasNodata wrapping, hasNodata empty-string, missing-sources array, mutation safety against frozen configs, and synthesis-throw fallback.
- [x] User smoke-tested locally: GeoTIFF layer added via MCP renders colored on first paint, no manual modal re-save needed.
- [x] Helper test extraction verified: WebGLTile dynamic import doesn't resolve in jest, so the planned `Map.prototype.addLayer` spy approach was infeasible. Direct helper testing is cleaner and gives stronger guarantees.

## Plan

`docs/plans/2026-05-07-006-feat-geotiff-style-color-derivation-plan.md` (lightweight, single unit, JS-only, single subrepo).

## Out of scope

- Synthesis for non-GeoTIFF source types (WMS, ImageTile) — today's bug is GeoTIFF-specific.
- Backporting to existing modal-saved layers — they already have explicit `style.color` persisted.
- Adding `rampName/rampMin/rampMax` to the JS `sourcePropertiesOptions` registry (deferred from plan 005).