### PR TITLE
fix(mcp): typed envelope for ValidationError on tool input (PR 1/2)

### DIFF
--- a/tethysapp/tethysdash/mcp/_input_validation_middleware.py
+++ b/tethysapp/tethysdash/mcp/_input_validation_middleware.py
@@ -1,0 +1,118 @@
+"""
+Server-protocol middleware that converts pydantic ValidationError raised
+during tool input validation into a structured tool-result envelope.
+
+Without this middleware, a hallucinated kwarg like
+``create_plotly_chart(..., height=80)`` causes pydantic's TypeAdapter to
+raise ``ValidationError`` inside ``Tool._run`` (FastMCP 3.2.x), which
+propagates out as an MCP-protocol error and produces a server traceback
+the chatbox-core engine cannot recover from cleanly.
+
+With this middleware in the FastMCP server's middleware stack, the same
+call returns a structured ``{"error": "...", "unexpected_kwargs": [...]}``
+envelope as a normal tool result. The chatbox-core engine forwards it to
+the LLM as tool input on the next conversation turn.
+
+# FastMCP 3.2.x-specific. Re-validate on FastMCP upgrade.
+See ``docs/plans/2026-05-08-001-fix-mcp-validation-and-streamable-http-migration-plan.md``
+Unit 1 for the full rationale and the spike that selected this mechanism.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import ValidationError
+
+from fastmcp.server.middleware.middleware import (
+    CallNext,
+    Middleware,
+    MiddlewareContext,
+)
+from fastmcp.tools.base import ToolResult
+import mcp.types as mt
+
+
+LOGGER = logging.getLogger("tethysdash.mcp")
+
+
+class InputValidationEnvelopeMiddleware(Middleware):
+    """Catch pydantic ValidationError on tool input and emit a typed envelope.
+
+    Aggregates multiple validation errors in one envelope so the LLM can fix
+    every hallucinated kwarg on a single retry instead of one-at-a-time.
+
+    The LLM-facing payload omits the tool name (the MCP protocol already
+    associates a tool result with the call that produced it; including the
+    name would also leak BM25-invisible tool names in some scenarios). The
+    server-side log line is the only place the tool name appears.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        try:
+            return await call_next(context)
+        except ValidationError as exc:
+            tool_name = getattr(context.message, "name", "<unknown>")
+            unexpected_kwargs, other_errors = _classify_errors(exc)
+
+            if unexpected_kwargs:
+                LOGGER.warning(
+                    "tool input rejected (unexpected kwargs): tool=%s kwargs=%s",
+                    tool_name,
+                    unexpected_kwargs,
+                )
+                return ToolResult(
+                    structured_content={
+                        "error": "invalid_args: unexpected keyword arguments",
+                        "unexpected_kwargs": unexpected_kwargs,
+                    }
+                )
+
+            LOGGER.warning(
+                "tool input rejected (validation error): tool=%s errors=%d",
+                tool_name,
+                len(other_errors),
+            )
+            return ToolResult(
+                structured_content={
+                    "error": "invalid_args: tool input failed validation",
+                    "details": _summarize_errors(other_errors),
+                }
+            )
+
+
+def _classify_errors(exc: ValidationError) -> tuple[list[str], list[dict[str, Any]]]:
+    """Split pydantic errors into (unexpected_kwargs, other_errors)."""
+    unexpected_kwargs: list[str] = []
+    other_errors: list[dict[str, Any]] = []
+    for err in exc.errors():
+        if err.get("type") == "unexpected_keyword_argument":
+            loc = err.get("loc") or ()
+            if loc:
+                unexpected_kwargs.append(str(loc[-1]))
+        else:
+            other_errors.append(err)
+    return unexpected_kwargs, other_errors
+
+
+def _summarize_errors(errors: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Strip pydantic error dicts to a stable, value-free summary.
+
+    Names + types only; no input values. Avoids leaking user-supplied or
+    LLM-generated content into the LLM-facing envelope.
+    """
+    summary: list[dict[str, Any]] = []
+    for err in errors:
+        loc = err.get("loc") or ()
+        summary.append(
+            {
+                "field": ".".join(str(p) for p in loc) if loc else None,
+                "type": err.get("type"),
+            }
+        )
+    return summary

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -46,6 +46,9 @@ from tethysapp.tethysdash.editable_schemas_plugin import (
 from tethysapp.tethysdash.plugin_registry_loader import (
     load_runtime_plugin_registry,
 )
+from tethysapp.tethysdash.mcp._input_validation_middleware import (
+    InputValidationEnvelopeMiddleware,
+)
 
 mcp = FastMCP(
     "TethysDash MCP Server",
@@ -76,6 +79,7 @@ mcp = FastMCP(
             ],
         ),
     ],
+    middleware=[InputValidationEnvelopeMiddleware()],
 )
 LOGGER = logging.getLogger("tethysdash.mcp")
 TETHYSDASH_BASE_URL = os.getenv("TETHYSDASH_BASE_URL", "http://localhost:8080/apps/tethysdash")

--- a/tethysapp/tethysdash/tests/mcp/test_tool_input_robustness.py
+++ b/tethysapp/tethysdash/tests/mcp/test_tool_input_robustness.py
@@ -1,0 +1,275 @@
+"""Contract tests for `InputValidationEnvelopeMiddleware`.
+
+Plan: ``docs/plans/2026-05-08-001-fix-mcp-validation-and-streamable-http-migration-plan.md``
+Unit 1.
+
+Verifies that an MCP tool called with one or more unexpected keyword
+arguments produces a structured ``{"error": ..., "unexpected_kwargs": [...]}``
+envelope instead of crashing inside FastMCP's pydantic input validation.
+
+Tests use FastMCP's in-memory ``FastMCPTransport`` so the full middleware
+stack runs in-process — direct function calls would bypass middleware and
+prove nothing about the wired-in path.
+
+The bug-report repro: ``create_plotly_chart(data=[...], height=80)`` —
+``height`` is not in the tool's signature; pydantic raised
+``ValidationError`` and the chatbox-core engine saw an MCP-protocol error.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+import pytest
+
+from fastmcp import Client
+from fastmcp.client.transports.memory import FastMCPTransport
+
+from tethysapp.tethysdash.mcp.tethysdash_mcp_server import mcp
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client() -> Client:
+    """In-memory FastMCP client wired through the live server's middleware."""
+    return Client(transport=FastMCPTransport(mcp))
+
+
+# A real UUID v4 — the per-source-type layer tools (T3) validate map_uuid
+# format, so any test that hits a layer tool needs a parseable UUID.
+MAP_UUID = "11111111-1111-4111-8111-111111111111"
+
+
+def _structured(result) -> dict:
+    """Pull the structured envelope out of a CallToolResult.
+
+    FastMCP returns ``ToolResult.structured_content`` for any tool whose
+    return value has dict-like shape; the in-memory client surfaces it
+    on ``result.structured_content``.
+    """
+    if result.structured_content is not None:
+        return result.structured_content
+    # Fallback: parse JSON text content.
+    text = "".join(
+        block.text for block in result.content if hasattr(block, "text")
+    )
+    return json.loads(text)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — middleware is invisible on valid calls
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_call_passes_through_unchanged(client):
+    """create_plotly_chart with valid kwargs returns the normal viz envelope."""
+    async with client:
+        result = await client.call_tool(
+            "create_plotly_chart",
+            {"data": [{"x": [1, 2], "y": [3, 4], "type": "scatter"}]},
+        )
+
+    payload = _structured(result)
+    assert "visualization" in payload, payload
+    assert payload["visualization"]["vizType"] == "plotly"
+    assert "error" not in payload
+    assert "unexpected_kwargs" not in payload
+
+
+async def test_canonical_short_kwarg_h_is_not_misclassified(client):
+    """`h=40` is a real kwarg on create_plotly_chart and must succeed.
+
+    Guards against fuzzy-matching regressions where the middleware might
+    mistake `h` for a typo of `height`.
+    """
+    async with client:
+        result = await client.call_tool(
+            "create_plotly_chart",
+            {"data": [{"x": [1], "y": [1]}], "h": 40},
+        )
+
+    payload = _structured(result)
+    assert "visualization" in payload, payload
+    assert payload["visualization"]["h"] == 40
+
+
+# ---------------------------------------------------------------------------
+# Error path — single + multi unexpected kwarg → structured envelope
+# ---------------------------------------------------------------------------
+
+
+async def test_bug_report_repro_unexpected_height_kwarg(client):
+    """The exact 2026-05-08 bug-report call shape — must not crash."""
+    async with client:
+        result = await client.call_tool(
+            "create_plotly_chart",
+            {"data": [{"x": [1], "y": [1]}], "height": 80},
+        )
+
+    payload = _structured(result)
+    assert payload["error"] == "invalid_args: unexpected keyword arguments"
+    assert payload["unexpected_kwargs"] == ["height"]
+    # Tool name must NOT be in the LLM-facing envelope (K5).
+    assert "tool" not in payload
+
+
+async def test_multiple_unexpected_kwargs_aggregate_in_one_envelope(client):
+    """All unexpected kwargs surface in one response, not one-at-a-time."""
+    async with client:
+        result = await client.call_tool(
+            "create_plotly_chart",
+            {
+                "data": [{"x": [1], "y": [1]}],
+                "height": 80,
+                "width": 200,
+                "scale": 1.5,
+            },
+        )
+
+    payload = _structured(result)
+    assert payload["error"] == "invalid_args: unexpected keyword arguments"
+    assert set(payload["unexpected_kwargs"]) == {"height", "width", "scale"}
+
+
+# ---------------------------------------------------------------------------
+# Uniformity — every always-visible tool inherits the envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name, valid_args",
+    [
+        ("create_plotly_chart", {"data": [{"x": [1], "y": [1]}]}),
+        ("create_data_table", {"data": [{"col": 1}]}),
+        (
+            "create_variable_input",
+            {"variable_name": "v", "input_type": "text"},
+        ),
+        ("create_map_visualization", {"name": "m"}),
+        ("list_available_visualizations", {}),
+        ("list_intake_plugins", {}),
+    ],
+)
+async def test_unexpected_kwarg_envelope_uniform_across_always_visible(
+    client, tool_name, valid_args
+):
+    """Adding a hallucinated kwarg to any always-visible tool gives an envelope."""
+    async with client:
+        result = await client.call_tool(
+            tool_name,
+            {**valid_args, "totally_made_up_kwarg": 42},
+        )
+
+    payload = _structured(result)
+    assert payload["error"] == "invalid_args: unexpected keyword arguments"
+    assert "totally_made_up_kwarg" in payload["unexpected_kwargs"]
+
+
+async def test_envelope_inherits_to_bm25_searchable_layer_tools(client):
+    """T3 per-source-type layer tools (BM25-searchable) inherit the envelope."""
+    async with client:
+        result = await client.call_tool(
+            "add_wms_layer",
+            {
+                "map_uuid": MAP_UUID,
+                "name": "wms-layer",
+                "url": "https://example.com/wms",
+                "wms_layers": "L1",
+                "totally_made_up_kwarg": 42,
+            },
+        )
+
+    payload = _structured(result)
+    assert payload["error"] == "invalid_args: unexpected keyword arguments"
+    assert payload["unexpected_kwargs"] == ["totally_made_up_kwarg"]
+
+
+# ---------------------------------------------------------------------------
+# Integration — middleware fires upstream of in-body try/except
+# ---------------------------------------------------------------------------
+
+
+async def test_envelope_fires_upstream_of_in_body_try_except(client):
+    """`add_dynamic_map_layer` has its own in-body JSONDecodeError envelope.
+
+    With an unexpected kwarg, the middleware's envelope must fire before the
+    function body runs at all — the in-body handler never sees the call.
+    """
+    async with client:
+        result = await client.call_tool(
+            "add_dynamic_map_layer",
+            {
+                "map_uuid": MAP_UUID,
+                "source": "ExamplePlugin",
+                "name": "x",
+                "totally_made_up_kwarg": 42,
+            },
+        )
+
+    payload = _structured(result)
+    # Middleware envelope shape (not the in-body "args is not valid JSON" shape).
+    assert payload["error"] == "invalid_args: unexpected keyword arguments"
+    assert payload["unexpected_kwargs"] == ["totally_made_up_kwarg"]
+
+
+# ---------------------------------------------------------------------------
+# Other ValidationError classes — wrong type for expected kwarg
+# ---------------------------------------------------------------------------
+
+
+async def test_wrong_type_for_expected_arg_returns_envelope(client):
+    """`data=42` is wrong type; envelope shape distinguishes from unexpected-kwarg."""
+    async with client:
+        result = await client.call_tool(
+            "create_plotly_chart",
+            {"data": 42},
+        )
+
+    payload = _structured(result)
+    # Different error class, different message — but still an envelope, not a crash.
+    assert payload["error"].startswith("invalid_args:")
+    # Wrong-type errors do NOT populate unexpected_kwargs.
+    assert "unexpected_kwargs" not in payload
+    # `details` carries the value-free summary.
+    assert "details" in payload
+    # No raw value content leaked into the envelope.
+    serialized = json.dumps(payload)
+    assert "42" not in serialized or '"42"' in serialized  # no bare int from input
+
+
+# ---------------------------------------------------------------------------
+# Server-side logging — names only, no values
+# ---------------------------------------------------------------------------
+
+
+async def test_log_line_includes_tool_name_and_kwarg_names_only(
+    client, caplog
+):
+    """The server log line names the tool and kwargs; never logs values."""
+    caplog.set_level(logging.WARNING, logger="tethysdash.mcp")
+
+    secret_value = "super-secret-token-do-not-leak"
+    async with client:
+        await client.call_tool(
+            "create_plotly_chart",
+            {
+                "data": [{"x": [1], "y": [1]}],
+                "auth_token": secret_value,
+            },
+        )
+
+    log_text = "\n".join(rec.message for rec in caplog.records)
+    assert "create_plotly_chart" in log_text
+    assert "auth_token" in log_text
+    assert secret_value not in log_text, (
+        "value content must never appear in the log line"
+    )


### PR DESCRIPTION
## Summary

Convert pydantic `ValidationError` raised during MCP tool input validation into a structured tool-result envelope instead of letting it propagate as an MCP-protocol error and produce a server traceback. Adds a FastMCP server-protocol middleware on `on_call_tool` that catches `ValidationError`, classifies entries, and returns `{"error": "invalid_args: ...", "unexpected_kwargs": [...]}` so the chatbox-core engine can forward it to the LLM as recoverable tool input.

Triggered by the 2026-05-08 bug report: an image-generation prompt caused the LLM to call `create_plotly_chart(data=[...], height=80)` — `height` is not in the tool's signature, pydantic crashed inside `Tool._run`, no recovery surface.

## What changed

| File | Change |
|---|---|
| `tethysapp/tethysdash/mcp/_input_validation_middleware.py` | New — `InputValidationEnvelopeMiddleware` |
| `tethysapp/tethysdash/mcp/tethysdash_mcp_server.py` | Register middleware via `FastMCP(middleware=[...])` (+4 lines) |
| `tethysapp/tethysdash/tests/mcp/test_tool_input_robustness.py` | New — 14 parametrized tests covering happy path, single + multi unexpected kwarg, canonical-short-kwarg disambiguation (`h=40`), uniformity across always-visible tools, BM25-searchable layer tools (T3), upstream-of-in-body-try/except integration, wrong-type-for-expected, and log-content hygiene |

**No breaking changes.** Tool signatures unchanged. `tools/list` content unchanged. `always_visible` set unchanged. The middleware is a no-op on valid calls (verified by happy-path tests + the smoke result below).

## Mechanism — selected via spike against installed FastMCP (3.2.3)

Three avenues were considered; the spike confirmed:

- ✅ **Server middleware** (`fastmcp.server.middleware.middleware.Middleware` with `on_call_tool` hook, registered via `FastMCP(middleware=[...])`) — clean interception around tool execution
- ❌ `strict_input_validation=False` flag — would only shift the error from pydantic to Python `TypeError`, not deliver a structured envelope
- ❌ Per-tool `extra="ignore"` ConfigDict — silent-drop semantics, observability-hostile (rejected by R4)

Code carries `# FastMCP 3.2.x-specific. Re-validate on FastMCP upgrade.`

## Envelope shape

```python
# Unexpected kwargs (the bug-report class):
{"error": "invalid_args: unexpected keyword arguments",
 "unexpected_kwargs": ["height", "width", "scale"]}

# Other validation errors (wrong type for expected, missing required, etc.):
{"error": "invalid_args: tool input failed validation",
 "details": [{"field": "data", "type": "list_type"}]}
```

The envelope **omits the tool name** from the LLM-facing payload (the MCP protocol already associates a result with the call that produced it; including it would leak BM25-invisible tool names). Tool name appears only in the server log line. The log line records **kwarg names only — never values** (no PII / token leak risk).

## Tests

- `pytest tethysapp/tethysdash/tests/mcp/ --no-cov -q` → **529 passed** (515 prior + 14 new), no regressions
- The exact bug-report shape (`create_plotly_chart(data=..., height=80)`) is covered by `test_bug_report_repro_unexpected_height_kwarg` and produces the structured envelope with **no traceback**
- Integration test confirms the middleware fires upstream of `add_dynamic_map_layer`'s in-body `JSONDecodeError` envelope (no double-handling)
- Log-content hygiene test verifies kwarg names appear but raw values do not

## Manual smoke result — Outcome D ("bug condition did not recur")

Replayed an image-gen prompt against `gpt-oss:20b` end-to-end through the chatbox UI:

> "please create a dashboard of my favorite digimon agumon and its evolutions, only use images, so each grid item is an image"

The LLM produced a **syntactically valid** `create_plotly_chart` call this time — all valid kwargs (`data, layout, config, h`); `images` nested inside `layout.images`; no top-level `height`. The validation middleware was a **no-op** on this run:

- Server log: zero `ValidationError` tracebacks
- Server log: zero `tool input rejected` WARNING lines from the middleware
- Confirms the wiring is correct AND the envelope path is not triggered by valid calls

The bug condition is intermittent / non-deterministic against this model+prompt combo. **Recoverability is verified via unit tests but was not directly observed in smoke** because the trigger didn't fire.

### Secondary finding (out of scope for this PR, but worth noting)

The LLM's syntactically-valid call produced functionally bad output: empty plotly trace `data: []`, image URLs stuffed into `layout.images`, dashboard renders empty placeholders. **This is the user-visible failure mode that description-tightening would address** — the previous plan draft deferred description-tightening pending an LLM eval harness, but a single manual replay of this prompt is enough to demonstrate the failure class. Strong signal to revisit the deferral before or alongside PR 2. Not blocking this PR.

## Phased delivery

This is **PR 1 of 2** per the plan's phased delivery decision (document-review 2026-05-08):

- **PR 1 (this PR):** validation envelope, transport-agnostic, ships against the existing SSE transport, no localStorage URL impact
- **PR 2 (follow-up):** `/sse` → `/mcp` Streamable HTTP migration, env-driven CORS with auto-derived `ALLOW_CREDENTIALS`, R12 SSE-patch security fix (currently reflects any origin with `allow-credentials: true`), R13 default `host="127.0.0.1"`, CLAUDE.md updates, CHANGELOG entry, default-URL strings

## Plan reference

`docs/plans/2026-05-08-001-fix-mcp-validation-and-streamable-http-migration-plan.md` — see Phased Delivery, Unit 1, and the Open Questions resolution block for the full rationale.

## Test plan

- [x] Unit tests pass — 529 / 529 MCP contract tests
- [x] No traceback on bug-report shape — verified via `test_bug_report_repro_unexpected_height_kwarg`
- [x] Manual smoke against `gpt-oss:20b` — Outcome D documented above
- [ ] CI passes