### PR TITLE
feat(mcp): /sse → /mcp Streamable HTTP migration + env-driven CORS + loopback default (PR 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+## Unreleased
+
+### Breaking changes
+
+- **MCP server default transport: `/sse` → `/mcp`.** The TethysDash in-app
+  MCP server (`tethysapp.tethysdash.mcp.tethysdash_mcp_server`) now defaults
+  to **Streamable HTTP at `http://localhost:9001/mcp`** instead of the
+  legacy SSE transport at `/sse`. This matches the modern MCP-client default
+  (MCP Playground, `@aquaveo/chatbox-core`) and brings TethysDash in line
+  with the sibling `nrds-mcps` server, which migrated on 2026-05-02.
+
+  **Action required for users with existing `/sse`-suffixed chatbox MCP
+  server URLs in localStorage:**
+
+  - **Recommended:** update the saved URL from `http://localhost:9001/sse`
+    to `http://localhost:9001/mcp` in the chatbox settings panel.
+  - **Temporary fallback:** set `MCP_TRANSPORT=sse` in the environment
+    where you launch the MCP server. The legacy SSE endpoint will remain
+    available behind this opt-in for the migration window. The fallback
+    will be removed in a future release.
+
+- **MCP server default host binding: `0.0.0.0` → `127.0.0.1` (loopback
+  only).** Aligns with the long-standing `CLAUDE.md` guidance that the
+  server "must run localhost-bound or behind an authenticated reverse
+  proxy." Set `MCP_HOST=0.0.0.0` (or a specific bind address) for
+  deployments that wrap the MCP server behind such a proxy.
+
+### Security
+
+- **Reflected-origin CORS bug in the SSE compat path is fixed.** The
+  legacy `_patch_sse_transport_for_cors` previously emitted
+  `access-control-allow-origin: <reflected origin>` AND
+  `access-control-allow-credentials: true` for ANY OPTIONS preflight,
+  regardless of `ALLOWED_ORIGINS`. The corrected version (mirroring
+  `mcp/nrds_mcps/nextgen_mcp/mcp_server.py`) now reflects an origin only
+  when it is in `ALLOWED_ORIGINS`, and gates the credentials header on a
+  successful match. Users on the streamable-http default path are
+  unaffected (the patch is invoked only when `MCP_TRANSPORT=sse`).
+
+### Added
+
+- **`ALLOWED_ORIGINS` and `ALLOW_CREDENTIALS` are now env-driven.**
+  `ALLOWED_ORIGINS` parses a comma-separated list (default `*`);
+  `ALLOW_CREDENTIALS` is auto-derived from it (`False` when origins is
+  `["*"]`, `True` otherwise) so a misconfigured deploy cannot produce the
+  CORS-spec-forbidden combination of wildcard origin + credentialed
+  responses. Empty / malformed input falls back to `["*"]`, never silent
+  lockdown.
+- **`InputValidationEnvelopeMiddleware`** (shipped 2026-05-08, PR #110):
+  pydantic `ValidationError` on tool input now produces a structured
+  `{"error": "invalid_args: ...", "unexpected_kwargs": [...]}` envelope
+  instead of crashing inside `Tool._run` and propagating as an MCP-protocol
+  error. The chatbox-core engine forwards the envelope to the LLM as
+  recoverable tool input.
+
+## References
+
+- Plan: `docs/plans/2026-05-08-001-fix-mcp-validation-and-streamable-http-migration-plan.md`
+- Sibling-server precedent: `docs/solutions/best-practices/mcp-streamable-http-transport-and-cors-env-vars-2026-05-02.md`
+- Client-side counterpart: `docs/solutions/best-practices/mcp-transport-selection-and-fallback-2026-04-23.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ TethysDash includes an MCP (Model Context Protocol) server that allows LLMs to c
 
 ### MCP Server Architecture
 
-- **`tethysdash_mcp_server.py`** — FastMCP server with SSE transport (port 9001). Uses `BM25SearchTransform` for tool discovery with an `always_visible` set of core tools.
+- **`tethysdash_mcp_server.py`** — FastMCP server. Default transport is **Streamable HTTP at `http://localhost:9001/mcp`** (`MCP_TRANSPORT=streamable-http`); legacy SSE at `/sse` is opt-in via `MCP_TRANSPORT=sse` for users with `/sse`-suffixed localStorage configs migrating to the new endpoint. Default host is `127.0.0.1` (loopback only); set `MCP_HOST=0.0.0.0` for deployments behind an authenticated reverse proxy. CORS is env-driven via `ALLOWED_ORIGINS` (default `*`); `ALLOW_CREDENTIALS` is auto-derived (`False` on wildcard, `True` otherwise — coupling prevents the `allow_credentials=True` + `allow_origins=["*"]` spec violation). Uses `BM25SearchTransform` for tool discovery with an `always_visible` set of core tools.
 - **Engine** (`lib/chatbox-core/engine/index.js`) — Generic tool-use conversation loop that connects to MCP servers, streams LLM responses, and accumulates tool results.
 - **Chatbox** (`lib/chatbox-core/components/Chatbox.jsx`) — Dispatches visualization specs as DOM events that `DashboardLayout.js` handles.
 

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -11,7 +11,13 @@ DOM events that DashboardLayout.js handles.
 Usage:
     python -m tethysapp.tethysdash.mcp.tethysdash_mcp_server
 
-Connects to chatbox via MCP SSE transport on port 9001.
+Connects to chatbox via MCP Streamable HTTP transport on port 9001 by
+default (path: ``/mcp``). Set ``MCP_TRANSPORT=sse`` for the legacy SSE
+compat path during the migration window. Default host binding is
+loopback (``127.0.0.1``); override with ``MCP_HOST`` for deployments
+behind an authenticated reverse proxy. CORS is env-driven via
+``ALLOWED_ORIGINS`` (default wildcard); see plan
+``docs/plans/2026-05-08-001-fix-mcp-validation-and-streamable-http-migration-plan.md``.
 """
 
 import logging
@@ -85,6 +91,28 @@ LOGGER = logging.getLogger("tethysdash.mcp")
 TETHYSDASH_BASE_URL = os.getenv("TETHYSDASH_BASE_URL", "http://localhost:8080/apps/tethysdash")
 
 
+def _parse_allowed_origins() -> List[str]:
+    """Read ALLOWED_ORIGINS from env (comma-separated). Defaults to wildcard.
+
+    Mirrors mcp/nrds_mcps/nextgen_mcp/mcp_server.py::_parse_allowed_origins
+    exactly — drift between sibling MCP servers' CORS handling is a
+    maintenance hazard. Production deployments behind a known origin
+    should set this explicitly via ALLOWED_ORIGINS=https://example.com[,...].
+    Empty / malformed values fall back to the wildcard (no silent lockdown).
+    """
+    raw = os.getenv("ALLOWED_ORIGINS", "*").strip()
+    if not raw or raw == "*":
+        return ["*"]
+    parsed = [o.strip() for o in raw.split(",") if o.strip()]
+    return parsed or ["*"]
+
+
+ALLOWED_ORIGINS = _parse_allowed_origins()
+# CORS spec forbids `allow_credentials=True` together with `allow_origins=["*"]`.
+# Auto-derive so a misconfigured deploy can't produce the spec violation.
+ALLOW_CREDENTIALS = ALLOWED_ORIGINS != ["*"]
+
+
 def _patch_sse_transport_for_cors():
     """Monkey-patch SseServerTransport.handle_post_message to handle OPTIONS.
 
@@ -92,6 +120,17 @@ def _patch_sse_transport_for_cors():
     handle_post_message, including CORS preflight OPTIONS (which have no
     Content-Type). This patch intercepts OPTIONS and returns 200 with
     CORS headers before the SDK's validation runs.
+
+    Origin handling mirrors mcp/nrds_mcps's corrected version: when
+    ``ALLOWED_ORIGINS != ["*"]``, only origins in the allowlist receive
+    CORS approval, and ``access-control-allow-credentials`` is gated on
+    a successful origin match. Without this gating, the patch is a
+    reflected-origin CORS vulnerability (any origin can issue authenticated
+    cross-site requests).
+
+    Invoked from `__main__` only when `MCP_TRANSPORT=sse`; the streamable-
+    http path uses the regular Starlette `CORSMiddleware` in `CORS_MIDDLEWARE`
+    and never reaches this code.
     """
     from mcp.server.sse import SseServerTransport
 
@@ -100,13 +139,19 @@ def _patch_sse_transport_for_cors():
     async def patched_handle(self, scope, receive, send):
         if scope.get("method") == "OPTIONS":
             origin = dict(scope.get("headers", [])).get(b"origin", b"").decode()
+            if ALLOWED_ORIGINS == ["*"]:
+                allow_origin = "*"
+            else:
+                allow_origin = origin if origin in ALLOWED_ORIGINS else ""
             headers = {
-                "access-control-allow-origin": origin or "*",
                 "access-control-allow-methods": "GET, POST, OPTIONS",
                 "access-control-allow-headers": "content-type, x-csrftoken, authorization",
-                "access-control-allow-credentials": "true",
                 "access-control-max-age": "86400",
             }
+            if allow_origin:
+                headers["access-control-allow-origin"] = allow_origin
+            if ALLOW_CREDENTIALS and allow_origin and allow_origin != "*":
+                headers["access-control-allow-credentials"] = "true"
             response = StarletteResponse(status_code=200, headers=headers)
             await response(scope, receive, send)
             return
@@ -114,13 +159,12 @@ def _patch_sse_transport_for_cors():
 
     SseServerTransport.handle_post_message = patched_handle
 
-_patch_sse_transport_for_cors()
-
 
 CORS_MIDDLEWARE = [
     Middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=ALLOWED_ORIGINS,
+        allow_credentials=ALLOW_CREDENTIALS,
         allow_methods=["*"],
         allow_headers=["*"],
     ),
@@ -3384,10 +3428,31 @@ def _configure_logging():
 if __name__ == "__main__":
     _configure_logging()
     port = int(os.getenv("TETHYSDASH_MCP_PORT", "9001"))
-    LOGGER.info(f"Starting TethysDash MCP Server on 0.0.0.0:{port} with SSE transport")
+    # R13: default to loopback binding (CLAUDE.md says the MCP server "must
+    # run localhost-bound or behind an authenticated reverse proxy"). The
+    # MCP_HOST override exists for production deploys that wrap this server
+    # behind such a proxy.
+    host = os.getenv("MCP_HOST", "127.0.0.1")
+    # R5/R6: default to Streamable HTTP at /mcp (FastMCP's default
+    # streamable_http_path). MCP_TRANSPORT=sse opts back into the legacy
+    # SSE transport during the migration window for users with /sse
+    # localStorage URLs (see plan Open Questions → SSE compat path).
+    transport = os.getenv("MCP_TRANSPORT", "streamable-http")
+    if transport == "sse":
+        # K3: SSE compat path — invoke the (R12-corrected) monkey-patch only
+        # when SSE is actually selected. On the streamable-http default path,
+        # the patch is never applied; CORS_MIDDLEWARE handles preflight.
+        _patch_sse_transport_for_cors()
+        endpoint = f"http://{host}:{port}/sse"
+    else:
+        endpoint = f"http://{host}:{port}/mcp"
+    LOGGER.info(
+        "Starting TethysDash MCP Server on %s:%d with %s transport at %s",
+        host, port, transport, endpoint,
+    )
     mcp.run(
-        transport="sse",
-        host="0.0.0.0",
+        transport=transport,
+        host=host,
         port=port,
         middleware=CORS_MIDDLEWARE,
     )

--- a/tethysapp/tethysdash/tests/mcp/test_transport_and_cors.py
+++ b/tethysapp/tethysdash/tests/mcp/test_transport_and_cors.py
@@ -1,0 +1,333 @@
+"""Contract tests for the env-driven transport + CORS configuration.
+
+Plan: ``docs/plans/2026-05-08-001-fix-mcp-validation-and-streamable-http-migration-plan.md``
+Unit 2 (R5-R7, R12, R13).
+
+Verifies:
+
+- ``_parse_allowed_origins`` parses ``ALLOWED_ORIGINS`` env-var correctly,
+  falls back to ``["*"]`` on empty / malformed input (no silent lockdown)
+- ``ALLOW_CREDENTIALS`` is auto-derived from ``ALLOWED_ORIGINS``
+  (``False`` when origins is wildcard, ``True`` otherwise)
+- Streamable-HTTP CORS preflight returns the right headers under each
+  origins-config regime (wildcard, allowlist with matching origin,
+  allowlist with non-matching origin)
+- Streamable-HTTP responds at ``/mcp`` (FastMCP's default
+  ``streamable_http_path``)
+
+Live SSE-transport tests (compat path + R12 reflected-origin fix) are
+exercised by the manual smoke; this file covers what's testable in
+process via Starlette's TestClient.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from starlette.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# `_parse_allowed_origins` — pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reload_server_module(monkeypatch):
+    """Reload the server module so its module-level constants pick up env vars.
+
+    `_parse_allowed_origins`, `ALLOWED_ORIGINS`, and `ALLOW_CREDENTIALS` are
+    resolved at import time. Tests that vary `ALLOWED_ORIGINS` need to
+    monkeypatch the env BEFORE the (re-)import.
+    """
+
+    def _reload():
+        import tethysapp.tethysdash.mcp.tethysdash_mcp_server as mod
+
+        return importlib.reload(mod)
+
+    return _reload
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        (None, ["*"]),
+        ("*", ["*"]),
+        ("", ["*"]),
+        ("  ", ["*"]),
+        (", ,", ["*"]),  # malformed → wildcard, NOT silent lockdown
+        ("https://example.com", ["https://example.com"]),
+        (
+            "https://a.example,https://b.example",
+            ["https://a.example", "https://b.example"],
+        ),
+        (
+            "  https://a.example  ,  https://b.example  ",
+            ["https://a.example", "https://b.example"],
+        ),
+    ],
+)
+def test_parse_allowed_origins(monkeypatch, env_value, expected):
+    if env_value is None:
+        monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+    else:
+        monkeypatch.setenv("ALLOWED_ORIGINS", env_value)
+
+    from tethysapp.tethysdash.mcp.tethysdash_mcp_server import _parse_allowed_origins
+
+    assert _parse_allowed_origins() == expected
+
+
+def test_allow_credentials_auto_derived_from_origins(
+    monkeypatch, reload_server_module
+):
+    """ALLOW_CREDENTIALS is False on wildcard, True otherwise."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "*")
+    mod = reload_server_module()
+    assert mod.ALLOWED_ORIGINS == ["*"]
+    assert mod.ALLOW_CREDENTIALS is False
+
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://example.com")
+    mod = reload_server_module()
+    assert mod.ALLOWED_ORIGINS == ["https://example.com"]
+    assert mod.ALLOW_CREDENTIALS is True
+
+
+def test_malformed_origins_fall_back_to_wildcard_not_lockdown(
+    monkeypatch, reload_server_module
+):
+    """Per the nrds-mcps doc's load-bearing detail: malformed env → wildcard.
+
+    A typo'd ``ALLOWED_ORIGINS=", ,"`` must NOT collapse to ``[]`` (which
+    would silently reject every origin with no warning). It must fall back
+    to ``["*"]``.
+    """
+    monkeypatch.setenv("ALLOWED_ORIGINS", ", ,")
+    mod = reload_server_module()
+    assert mod.ALLOWED_ORIGINS == ["*"]
+    assert mod.ALLOW_CREDENTIALS is False
+
+
+# ---------------------------------------------------------------------------
+# Streamable-HTTP CORS preflight via Starlette TestClient
+# ---------------------------------------------------------------------------
+
+
+def _build_http_app(origins: list[str]):
+    """Construct a Starlette app for a fresh server module with the given origins."""
+    from starlette.middleware import Middleware
+    from starlette.middleware.cors import CORSMiddleware
+
+    cors = [
+        Middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_credentials=origins != ["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+    ]
+    from tethysapp.tethysdash.mcp.tethysdash_mcp_server import mcp
+
+    return mcp.http_app(transport="streamable-http", middleware=cors)
+
+
+def test_streamable_http_cors_preflight_with_wildcard_origins():
+    """ALLOWED_ORIGINS=["*"] → preflight succeeds, no credentials reflected."""
+    app = _build_http_app(["*"])
+    with TestClient(app) as client:
+        response = client.options(
+            "/mcp",
+            headers={
+                "origin": "https://anywhere.example",
+                "access-control-request-method": "POST",
+            },
+        )
+
+    assert response.status_code in (200, 204)
+    assert response.headers.get("access-control-allow-origin") == "*"
+    # CORS spec: credentials cannot be combined with wildcard origin.
+    assert response.headers.get("access-control-allow-credentials") != "true"
+
+
+def test_streamable_http_cors_preflight_with_matching_specific_origin():
+    """An origin in ALLOWED_ORIGINS gets credentials: true."""
+    app = _build_http_app(["https://approved.example"])
+    with TestClient(app) as client:
+        response = client.options(
+            "/mcp",
+            headers={
+                "origin": "https://approved.example",
+                "access-control-request-method": "POST",
+            },
+        )
+
+    assert response.status_code in (200, 204)
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "https://approved.example"
+    )
+    assert response.headers.get("access-control-allow-credentials") == "true"
+
+
+def test_streamable_http_cors_preflight_with_non_matching_origin_denied():
+    """An origin not in ALLOWED_ORIGINS does not receive CORS approval.
+
+    The load-bearing security check is that ``access-control-allow-origin``
+    is NOT reflected back to the attacker. (Starlette's CORSMiddleware emits
+    ``allow-credentials: true`` globally even on rejected preflights, but
+    that is harmless without a matching ``allow-origin`` — browsers won't
+    honor credentialed requests without both headers.)
+    """
+    app = _build_http_app(["https://approved.example"])
+    with TestClient(app) as client:
+        response = client.options(
+            "/mcp",
+            headers={
+                "origin": "https://attacker.example",
+                "access-control-request-method": "POST",
+            },
+        )
+
+    # CORSMiddleware rejects with 400 for non-allowed origins.
+    assert response.status_code == 400
+    # Critical: no origin reflection.
+    assert response.headers.get("access-control-allow-origin") not in (
+        "https://attacker.example",
+        "*",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streamable-HTTP path resolution — trailing-slash regression guard
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# SSE compat-path security: R12 reflected-origin CORS regression
+# ---------------------------------------------------------------------------
+
+
+async def _invoke_sse_patched_handler(scope: dict) -> tuple[int, dict[str, str]]:
+    """Helper: invoke the patched SseServerTransport.handle_post_message.
+
+    Captures the ASGI response status + headers without spinning up a
+    real HTTP server.
+    """
+    from mcp.server.sse import SseServerTransport
+
+    captured: dict = {}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            captured["status"] = message["status"]
+            captured["headers"] = {
+                k.decode().lower(): v.decode()
+                for k, v in message.get("headers", [])
+            }
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    transport_instance = SseServerTransport.__new__(SseServerTransport)
+    await SseServerTransport.handle_post_message(
+        transport_instance, scope, receive, send
+    )
+    return captured.get("status"), captured.get("headers", {})
+
+
+def _options_scope(origin: str) -> dict:
+    return {
+        "type": "http",
+        "method": "OPTIONS",
+        "headers": [(b"origin", origin.encode())],
+        "path": "/messages/",
+        "query_string": b"",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sse_patch_does_not_reflect_attacker_origin_with_allowlist(
+    monkeypatch, reload_server_module
+):
+    """R12 — pre-fix bug: patch reflected ANY origin and emitted credentials.
+
+    With ALLOWED_ORIGINS set to a specific allowlist, an OPTIONS preflight
+    from an off-list origin must NOT receive `access-control-allow-origin:
+    <attacker>` and must NOT receive `access-control-allow-credentials: true`.
+    """
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://approved.example")
+    mod = reload_server_module()
+    mod._patch_sse_transport_for_cors()
+
+    status, headers = await _invoke_sse_patched_handler(
+        _options_scope("https://attacker.example")
+    )
+
+    assert status == 200
+    assert headers.get("access-control-allow-origin", "") != "https://attacker.example"
+    assert headers.get("access-control-allow-origin", "") != "*"
+    assert headers.get("access-control-allow-credentials") != "true"
+
+
+@pytest.mark.asyncio
+async def test_sse_patch_reflects_matching_origin_and_emits_credentials(
+    monkeypatch, reload_server_module
+):
+    """An origin in ALLOWED_ORIGINS gets the reflection + credentials."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://approved.example")
+    mod = reload_server_module()
+    mod._patch_sse_transport_for_cors()
+
+    status, headers = await _invoke_sse_patched_handler(
+        _options_scope("https://approved.example")
+    )
+
+    assert status == 200
+    assert headers.get("access-control-allow-origin") == "https://approved.example"
+    assert headers.get("access-control-allow-credentials") == "true"
+
+
+@pytest.mark.asyncio
+async def test_sse_patch_with_wildcard_origins_no_credentials(
+    monkeypatch, reload_server_module
+):
+    """Wildcard origins → reflect `*`, but NEVER emit credentials (CORS spec)."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "*")
+    mod = reload_server_module()
+    mod._patch_sse_transport_for_cors()
+
+    status, headers = await _invoke_sse_patched_handler(
+        _options_scope("https://anywhere.example")
+    )
+
+    assert status == 200
+    assert headers.get("access-control-allow-origin") == "*"
+    assert headers.get("access-control-allow-credentials") != "true"
+
+
+# ---------------------------------------------------------------------------
+# Streamable-HTTP path resolution — trailing-slash regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_streamable_http_responds_at_mcp_path():
+    """FastMCP's default streamable_http_path is /mcp; verify the route exists.
+
+    A POST without a session is expected to 4xx (auth/protocol error), but the
+    point is that the route is REACHABLE — neither 404 nor 307 to a different
+    path. Catches a regression where the path arg drifted.
+    """
+    app = _build_http_app(["*"])
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            headers={"content-type": "application/json"},
+            content="{}",
+        )
+
+    # Any non-404/non-redirect status proves the route is mounted.
+    assert response.status_code != 404
+    assert response.status_code not in (301, 302, 307, 308)


### PR DESCRIPTION
## Summary

Migrate the in-app TethysDash MCP server from legacy SSE at `/sse` to **Streamable HTTP at `/mcp`** by default, mirroring the sibling `nrds-mcps` migration (2026-05-02). Modern MCP clients (MCP Playground, `@aquaveo/chatbox-core` when URL is ambiguous) default to Streamable HTTP — keeping `/sse` as our default forced every browser client to know about a legacy endpoint.

PR 2 of 2 in the validation + transport plan. PR 1 (validation envelope, #110) merged earlier; this PR is independent of Unit 1's behavior.

## Companion change

**Aquaveo/chatbox-core#16** — updates `DEFAULT_MCP_SERVER_URL`, `MCPServerPanel` placeholder, and README so new chatbox-core users see `/mcp` as the suggested default. The two PRs together close the migration loop on both ends.

## What changed

### Server bootstrap (Unit 2)

| Behavior | Before | After |
|---|---|---|
| Default transport | `sse` (hardcoded) | `MCP_TRANSPORT=streamable-http` (env-driven) |
| Default endpoint | `http://0.0.0.0:9001/sse` | `http://127.0.0.1:9001/mcp` |
| Default host binding | `0.0.0.0` | `127.0.0.1` (loopback only); `MCP_HOST` env override |
| `ALLOWED_ORIGINS` | hardcoded `["*"]` | env-driven (default `*`); `_parse_allowed_origins()` mirrored from nrds-mcps |
| `ALLOW_CREDENTIALS` | not set | auto-derived (`False` on wildcard, `True` otherwise; coupling prevents the spec-forbidden `credentials=True + origins=["*"]` combo) |
| SSE monkey-patch | invoked at module import | invoked from `__main__`, gated on `transport == "sse"` |

### Security fix (R12)

The legacy `_patch_sse_transport_for_cors` previously emitted **`access-control-allow-origin: <reflected origin>` AND `access-control-allow-credentials: true` for ANY OPTIONS preflight**, regardless of `ALLOWED_ORIGINS`. Any cross-site script could issue authenticated tool calls on the SSE endpoint.

Aligned with the corrected `nrds-mcps` version: reflect origin only when in `ALLOWED_ORIGINS`, gate credentials header on a successful match. Lands in this PR even though the SSE compat path is becoming legacy — it remains reachable for the migration window.

### Documentation (Unit 3)

- `CLAUDE.md` — flipped MCP server description to Streamable HTTP at `/mcp`, loopback default, env-driven CORS
- Module docstring updated
- `CHANGELOG.md` (new) — Breaking-change entry with action-required guidance for users with `/sse`-suffixed localStorage configs and the `MCP_TRANSPORT=sse` fallback

## Migration safety

| Concern | Mitigation |
|---|---|
| Existing user localStorage `/sse` URLs | Set `MCP_TRANSPORT=sse` server-side to keep working while updating |
| chatbox-core suffix selector | Unchanged — `/sse`-suffixed URLs still route to SSE |
| SSE patch security bug | Fixed in R12 (this PR) for the duration of the migration window |
| Compat-path deletion trigger | Documented in plan: 4 weeks after merge OR confirmation no localStorage entries reference `/sse`, whichever first |

## Tests

`pytest tethysapp/tethysdash/tests/mcp/ --no-cov -q` → **546 passed** (529 prior + 17 new in `test_transport_and_cors.py`)

New test coverage:
- `_parse_allowed_origins` parsing across wildcard / empty / malformed / single / multi inputs
- `ALLOW_CREDENTIALS` auto-derivation
- Malformed input falls back to `["*"]`, NOT silent lockdown
- Streamable-HTTP CORS preflight via Starlette TestClient: wildcard, matching-origin allowlist, non-matching-origin rejection
- `/mcp` path resolution (regression guard against trailing-slash drift or path-arg drift)
- **R12 regression tests (3)**: SSE patch with allowlist refuses to reflect attacker origin / refuses credentials; matching origin gets both; wildcard mode never emits credentials per CORS spec

## Plan reference

`docs/plans/2026-05-08-001-fix-mcp-validation-and-streamable-http-migration-plan.md` — Phased Delivery → PR 2; Units 2 + 3; K1-K6 / R5-R13.

## Test plan

- [x] Unit + integration tests pass — 546 / 546
- [x] R12 reflected-origin CORS bug regression test added and passes
- [x] CLAUDE.md, module docstring, CHANGELOG updated
- [ ] Manual smoke: chatbox-core connecting to `http://localhost:9001/mcp` works end-to-end
- [ ] Manual smoke (compat): `MCP_TRANSPORT=sse` set on server still serves the legacy path
- [ ] CI passes
- [ ] Companion PR Aquaveo/chatbox-core#16 reviewed/merged