### PR TITLE
feat(chatbox): persist chat conversation per dashboard in localStorage

### DIFF
--- a/reactapp/__tests__/components/sidebar/ChatSidebar.persistence.test.js
+++ b/reactapp/__tests__/components/sidebar/ChatSidebar.persistence.test.js
@@ -1,0 +1,168 @@
+/**
+ * ChatSidebar.persistence.test.js — wiring coverage for per-dashboard
+ * chat history persistence (plan 2026-05-08-004 Unit 3).
+ *
+ * Verifies:
+ *   - <Chatbox> receives initialMessages hydrated from getChatHistory(uuid)
+ *   - <Chatbox> receives an onMessagesChange callback that delegates to
+ *     saveChatHistory(uuid, ...)
+ *   - <Chatbox> is keyed on the dashboard uuid so React tears down +
+ *     remounts on dashboard switch
+ *   - When uuid is missing (mounted outside LayoutContext or before the
+ *     dashboard loads), initialMessages is [] and the save callback is
+ *     a no-op (does not write to localStorage)
+ *
+ * The Chatbox is stubbed (matches the existing ChatSidebar.test.js
+ * pattern) so we don't need to mount the full chatbox-core stack.
+ * Captures props via the mock's `.mock.calls` rather than a closure
+ * array — `jest.clearAllMocks()` resets implementations, which makes
+ * the closure approach fragile.
+ */
+import { render } from "@testing-library/react";
+import ChatSidebar from "components/sidebar/ChatSidebar";
+import {
+  AppContext,
+  LayoutContext,
+  TabContext,
+  VariableInputsContext,
+} from "components/contexts/Contexts";
+import { ChatSidebarContext } from "components/contexts/ChatSidebarContext";
+
+jest.mock("@chatbox/core/components", () => ({
+  Chatbox: jest.fn(() => <div data-testid="chatbox-stub" />),
+}));
+jest.mock("services/chatHistoryStorage", () => ({
+  getChatHistory: jest.fn(() => []),
+  saveChatHistory: jest.fn(),
+}));
+
+import { Chatbox } from "@chatbox/core/components";
+import {
+  getChatHistory,
+  saveChatHistory,
+} from "services/chatHistoryStorage";
+
+beforeEach(() => {
+  // clearAllMocks() resets call history but NOT mock implementations,
+  // because the implementation was set via the factory function in
+  // jest.mock() above. Each test sees a fresh call log; the stub render
+  // continues to fire.
+  jest.clearAllMocks();
+});
+
+function lastChatboxProps() {
+  const calls = Chatbox.mock.calls;
+  if (calls.length === 0) return null;
+  // jest.fn for a function component receives (props, ref?) — props is index 0.
+  return calls[calls.length - 1][0];
+}
+
+function renderWithContexts(opts = {}) {
+  const editable = "editable" in opts ? opts.editable : true;
+  // Allow tests to explicitly pass undefined (or omit `uuid`) to
+  // simulate "mounted before LayoutContext.uuid is populated."
+  const dashboardUuid =
+    "dashboardUuid" in opts ? opts.dashboardUuid : "dash-1";
+  const layout = { editable, uuid: dashboardUuid };
+  const tab = { tabs: [] };
+  const variables = { variableInputValues: {}, setVariableInputValues: () => {} };
+  const chatSidebar = { isOpen: true, setIsOpen: () => {} };
+  const app = { csrf: "csrf-token", pluginEditablePaths: {} };
+  return render(
+    <AppContext.Provider value={app}>
+      <LayoutContext.Provider value={layout}>
+        <TabContext.Provider value={tab}>
+          <VariableInputsContext.Provider value={variables}>
+            <ChatSidebarContext.Provider value={chatSidebar}>
+              <ChatSidebar />
+            </ChatSidebarContext.Provider>
+          </VariableInputsContext.Provider>
+        </TabContext.Provider>
+      </LayoutContext.Provider>
+    </AppContext.Provider>,
+  );
+}
+
+describe("ChatSidebar persistence wiring", () => {
+  test("hydrates initialMessages from getChatHistory(uuid)", () => {
+    getChatHistory.mockReturnValueOnce([
+      { role: "user", content: "remembered from last session" },
+    ]);
+    renderWithContexts({ dashboardUuid: "dashboard-A" });
+
+    expect(getChatHistory).toHaveBeenCalledWith("dashboard-A");
+    expect(lastChatboxProps()?.initialMessages).toEqual([
+      { role: "user", content: "remembered from last session" },
+    ]);
+  });
+
+  test("onMessagesChange delegates to saveChatHistory(uuid, messages)", () => {
+    renderWithContexts({ dashboardUuid: "dashboard-A" });
+
+    const newMessages = [{ role: "user", content: "hi" }];
+    lastChatboxProps().onMessagesChange(newMessages);
+
+    expect(saveChatHistory).toHaveBeenCalledWith("dashboard-A", newMessages);
+  });
+
+  test("keying on dashboard uuid forces remount-with-fresh-history on switch", () => {
+    // First render with dashboard-A.
+    getChatHistory.mockReturnValueOnce([
+      { role: "user", content: "A's history" },
+    ]);
+    const { rerender } = renderWithContexts({ dashboardUuid: "dashboard-A" });
+    expect(getChatHistory).toHaveBeenCalledWith("dashboard-A");
+    expect(lastChatboxProps().initialMessages).toEqual([
+      { role: "user", content: "A's history" },
+    ]);
+
+    // Re-render in the same React tree with dashboard-B. The uuid change
+    // forces useMemo to recompute initialMessages and getChatHistory to
+    // be called for B. (The literal React key on <Chatbox> ensures the
+    // child remounts; here we observe the upstream effect on prop wiring.)
+    getChatHistory.mockReturnValueOnce([
+      { role: "user", content: "B's history" },
+    ]);
+    const layout = { editable: true, uuid: "dashboard-B" };
+    const tab = { tabs: [] };
+    const variables = { variableInputValues: {}, setVariableInputValues: () => {} };
+    const chatSidebar = { isOpen: true, setIsOpen: () => {} };
+    const app = { csrf: "csrf-token", pluginEditablePaths: {} };
+    rerender(
+      <AppContext.Provider value={app}>
+        <LayoutContext.Provider value={layout}>
+          <TabContext.Provider value={tab}>
+            <VariableInputsContext.Provider value={variables}>
+              <ChatSidebarContext.Provider value={chatSidebar}>
+                <ChatSidebar />
+              </ChatSidebarContext.Provider>
+            </VariableInputsContext.Provider>
+          </TabContext.Provider>
+        </LayoutContext.Provider>
+      </AppContext.Provider>,
+    );
+
+    expect(getChatHistory).toHaveBeenCalledWith("dashboard-B");
+    expect(lastChatboxProps().initialMessages).toEqual([
+      { role: "user", content: "B's history" },
+    ]);
+  });
+
+  test("initialMessages defaults to [] when dashboardUuid is missing", () => {
+    renderWithContexts({ dashboardUuid: undefined });
+
+    // No call to getChatHistory because uuid is missing.
+    expect(getChatHistory).not.toHaveBeenCalled();
+    expect(lastChatboxProps().initialMessages).toEqual([]);
+  });
+
+  test("onMessagesChange is a no-op when dashboardUuid is missing", () => {
+    renderWithContexts({ dashboardUuid: undefined });
+
+    lastChatboxProps().onMessagesChange([
+      { role: "user", content: "should not save" },
+    ]);
+
+    expect(saveChatHistory).not.toHaveBeenCalled();
+  });
+});

--- a/reactapp/__tests__/services/chatHistoryStorage.test.js
+++ b/reactapp/__tests__/services/chatHistoryStorage.test.js
@@ -1,0 +1,158 @@
+/**
+ * services/chatHistoryStorage.test.js — coverage for the per-dashboard
+ * chat-history localStorage helper (plan 2026-05-08-004 Unit 2).
+ */
+
+import {
+  getChatHistory,
+  saveChatHistory,
+  clearChatHistory,
+} from "services/chatHistoryStorage";
+
+const STORAGE_PREFIX = "tethysdash:chat:v1:";
+
+describe("chatHistoryStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("happy path", () => {
+    it("save then get round-trips the messages array", () => {
+      const messages = [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi there" },
+      ];
+      saveChatHistory("dashboard-A", messages);
+      expect(getChatHistory("dashboard-A")).toEqual(messages);
+    });
+
+    it("uses the versioned key shape tethysdash:chat:v1:<uuid>", () => {
+      saveChatHistory("dashboard-A", [{ role: "user", content: "x" }]);
+      expect(localStorage.getItem(`${STORAGE_PREFIX}dashboard-A`)).not.toBeNull();
+    });
+
+    it("empty array is a valid round-trip", () => {
+      saveChatHistory("dashboard-A", []);
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+    });
+  });
+
+  describe("per-dashboard isolation", () => {
+    it("dashboards have independent history", () => {
+      saveChatHistory("dashboard-A", [{ role: "user", content: "from A" }]);
+      saveChatHistory("dashboard-B", [{ role: "user", content: "from B" }]);
+      expect(getChatHistory("dashboard-A")).toEqual([
+        { role: "user", content: "from A" },
+      ]);
+      expect(getChatHistory("dashboard-B")).toEqual([
+        { role: "user", content: "from B" },
+      ]);
+    });
+
+    it("returns [] for a dashboard that has no saved history", () => {
+      saveChatHistory("dashboard-A", [{ role: "user", content: "hi" }]);
+      expect(getChatHistory("dashboard-never-saved")).toEqual([]);
+    });
+  });
+
+  describe("malformed data — silent fallback to []", () => {
+    it("returns [] for missing key", () => {
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+    });
+
+    it("returns [] for malformed JSON in storage", () => {
+      localStorage.setItem(`${STORAGE_PREFIX}dashboard-A`, "{not json");
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+    });
+
+    it("returns [] for non-array JSON value", () => {
+      localStorage.setItem(
+        `${STORAGE_PREFIX}dashboard-A`,
+        JSON.stringify({ not: "an array" }),
+      );
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+    });
+
+    it("returns [] for JSON null", () => {
+      localStorage.setItem(`${STORAGE_PREFIX}dashboard-A`, "null");
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+    });
+  });
+
+  describe("invalid UUID input", () => {
+    it("getChatHistory returns [] for empty string", () => {
+      expect(getChatHistory("")).toEqual([]);
+    });
+
+    it("getChatHistory returns [] for null / undefined", () => {
+      expect(getChatHistory(null)).toEqual([]);
+      expect(getChatHistory(undefined)).toEqual([]);
+    });
+
+    it("saveChatHistory is a no-op for empty / null uuid", () => {
+      saveChatHistory("", [{ role: "user", content: "ignored" }]);
+      saveChatHistory(null, [{ role: "user", content: "ignored" }]);
+      // No keys with the prefix should exist.
+      const matchingKeys = Object.keys(localStorage).filter((k) =>
+        k.startsWith(STORAGE_PREFIX),
+      );
+      expect(matchingKeys).toEqual([]);
+    });
+
+    it("saveChatHistory is a no-op when messages is not an array", () => {
+      saveChatHistory("dashboard-A", null);
+      saveChatHistory("dashboard-A", "not an array");
+      saveChatHistory("dashboard-A", { not: "an array" });
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+    });
+  });
+
+  describe("storage failure — silent-fail", () => {
+    it("saveChatHistory swallows setItem throw (e.g., QuotaExceeded)", () => {
+      const originalSetItem = Storage.prototype.setItem;
+      Storage.prototype.setItem = jest.fn(() => {
+        throw new DOMException("QuotaExceededError");
+      });
+      // Must not throw.
+      expect(() => {
+        saveChatHistory("dashboard-A", [{ role: "user", content: "x" }]);
+      }).not.toThrow();
+      Storage.prototype.setItem = originalSetItem;
+    });
+
+    it("getChatHistory swallows getItem throw", () => {
+      const originalGetItem = Storage.prototype.getItem;
+      Storage.prototype.getItem = jest.fn(() => {
+        throw new Error("storage unavailable");
+      });
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+      Storage.prototype.getItem = originalGetItem;
+    });
+  });
+
+  describe("clearChatHistory", () => {
+    it("removes the persisted entry for the given uuid", () => {
+      saveChatHistory("dashboard-A", [{ role: "user", content: "x" }]);
+      expect(getChatHistory("dashboard-A")).toHaveLength(1);
+      clearChatHistory("dashboard-A");
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+    });
+
+    it("does not affect other dashboards' entries", () => {
+      saveChatHistory("dashboard-A", [{ role: "user", content: "A" }]);
+      saveChatHistory("dashboard-B", [{ role: "user", content: "B" }]);
+      clearChatHistory("dashboard-A");
+      expect(getChatHistory("dashboard-A")).toEqual([]);
+      expect(getChatHistory("dashboard-B")).toEqual([
+        { role: "user", content: "B" },
+      ]);
+    });
+
+    it("is a no-op for empty / null uuid", () => {
+      saveChatHistory("dashboard-A", [{ role: "user", content: "x" }]);
+      clearChatHistory("");
+      clearChatHistory(null);
+      expect(getChatHistory("dashboard-A")).toHaveLength(1);
+    });
+  });
+});

--- a/reactapp/components/sidebar/ChatSidebar.js
+++ b/reactapp/components/sidebar/ChatSidebar.js
@@ -11,6 +11,10 @@ import { Chatbox } from "@chatbox/core/components";
 import { buildGenericSystemMessage } from "@chatbox/core/messages";
 import { BsXLg } from "react-icons/bs";
 import { buildDeltaSummary, buildPatchContext } from "./chatboxStateBuilder";
+import {
+  getChatHistory,
+  saveChatHistory,
+} from "services/chatHistoryStorage";
 
 // Plan 003 D3 — system-prompt instruction telling the LLM to use the
 // engine's `_engine_dispatched` field as ground truth for any claim
@@ -160,7 +164,10 @@ function ChatSidebar() {
   // chrome already uses to hide edit controls (DashboardLoader.js:50).
   // When mounted outside LayoutContext (test harness), default to not-
   // editable — failing closed is safer than failing open.
-  const { editable } = useContext(LayoutContext) ?? {};
+  // Plan 2026-05-08-004: also read `uuid` for per-dashboard chat
+  // history persistence. Same context source DashboardItem.js uses.
+  const { editable, uuid: dashboardUuid } =
+    useContext(LayoutContext) ?? {};
 
   const updateVariableInputValues = useCallback(
     (updatedValues) =>
@@ -171,6 +178,24 @@ function ChatSidebar() {
   const memoizedVariableInputValues = useMemo(
     () => variableInputValues,
     [variableInputValues],
+  );
+
+  // Plan 2026-05-08-004 — per-dashboard chat history persistence.
+  // Read once per dashboard mount (key={dashboardUuid} below remounts
+  // <Chatbox> on dashboard switch, so this useMemo runs fresh for each
+  // dashboard's history). Falls back to [] when no uuid is available
+  // (test harness, mounted outside LayoutContext).
+  const initialChatMessages = useMemo(
+    () => (dashboardUuid ? getChatHistory(dashboardUuid) : []),
+    [dashboardUuid],
+  );
+
+  const handleMessagesChange = useCallback(
+    (messages) => {
+      if (!dashboardUuid) return;
+      saveChatHistory(dashboardUuid, messages);
+    },
+    [dashboardUuid],
   );
 
   // Plan 2026-05-07-001 Unit B: chat-sidebar-visible feedback when a patch
@@ -357,10 +382,17 @@ function ChatSidebar() {
       )}
       <Content>
         <Chatbox
+          // Plan 2026-05-08-004 — `key={dashboardUuid}` forces React
+          // to tear down + remount when the user switches dashboards
+          // so `initialMessages` is read fresh per dashboard. Without
+          // this, the chatbox would carry stale state across switches.
+          key={dashboardUuid ?? "no-dashboard"}
           csrfToken={csrf}
           variableInputValues={memoizedVariableInputValues}
           updateVariableInputValues={updateVariableInputValues}
           engineExtensions={engineExtensions}
+          initialMessages={initialChatMessages}
+          onMessagesChange={handleMessagesChange}
           welcomeHeading="Ask me about your dashboard"
           welcomeSubtitle="I can create visualizations, edit tiles, add map layers, and analyze data — just ask."
           suggestedPrompts={[

--- a/reactapp/services/chatHistoryStorage.js
+++ b/reactapp/services/chatHistoryStorage.js
@@ -1,0 +1,87 @@
+/**
+ * chatHistoryStorage.js
+ *
+ * Persists chat conversation messages per dashboard to localStorage.
+ *
+ * Plan: docs/plans/2026-05-08-004-feat-persist-chatbox-per-dashboard-plan.md
+ *
+ * Mirrors the shape of `lib/chatbox-core/storage/mcpStorage.js`:
+ *   - STORAGE_PREFIX constant
+ *   - get/save/clear helpers
+ *   - try/catch silent-fail on quota / unavailable / serialization errors
+ *   - Array.isArray fallback on read so malformed data degrades to []
+ *
+ * The key shape is versioned (`tethysdash:chat:v1:<dashboardUuid>`) so a
+ * future schema change can ship with a v2 reader that ignores v1 data.
+ *
+ * Storage is per-origin per-browser-profile. Cache-clear or private-
+ * browsing wipes everything — this is intentional (see plan Scope
+ * Boundaries).
+ */
+
+const STORAGE_PREFIX = "tethysdash:chat:v1:";
+
+function buildKey(dashboardUuid) {
+  return `${STORAGE_PREFIX}${dashboardUuid}`;
+}
+
+function isValidUuid(dashboardUuid) {
+  return typeof dashboardUuid === "string" && dashboardUuid.length > 0;
+}
+
+/**
+ * Read the persisted message list for a dashboard.
+ *
+ * Returns `[]` for any failure mode: missing key, malformed JSON,
+ * non-array result, localStorage unavailable / throw on access.
+ * Defensive against empty / null UUIDs so callers don't have to
+ * guard themselves.
+ */
+export function getChatHistory(dashboardUuid) {
+  if (!isValidUuid(dashboardUuid)) return [];
+  try {
+    const raw = localStorage.getItem(buildKey(dashboardUuid));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist a message list for a dashboard.
+ *
+ * Silent-fail on:
+ *   - localStorage unavailable (private browsing some browsers)
+ *   - quota exceeded
+ *   - JSON serialization throw (e.g., circular references — shouldn't
+ *     happen for plain message objects, but defensive)
+ *   - empty / null UUID (no-op)
+ *
+ * Matches the existing chatbox-core storage helpers' silent-fail
+ * convention so the chatbox keeps working even when persistence is
+ * unavailable.
+ */
+export function saveChatHistory(dashboardUuid, messages) {
+  if (!isValidUuid(dashboardUuid)) return;
+  if (!Array.isArray(messages)) return;
+  try {
+    localStorage.setItem(buildKey(dashboardUuid), JSON.stringify(messages));
+  } catch {
+    // localStorage full, unavailable, or threw on serialize — silently fail.
+  }
+}
+
+/**
+ * Remove the persisted history for a dashboard. Useful for a future
+ * "clear chat" affordance and for tests.
+ */
+export function clearChatHistory(dashboardUuid) {
+  if (!isValidUuid(dashboardUuid)) return;
+  try {
+    localStorage.removeItem(buildKey(dashboardUuid));
+  } catch {
+    // Silent-fail, same convention as save.
+  }
+}


### PR DESCRIPTION
## Summary

Each dashboard now retains its chat thread across navigations and page reloads. Cache-clear loses everything (intentional). No backend, no migration. Frontend-only persistence via browser localStorage.

The architectural split mirrors plan 2026-05-06-003 (prompt templates): chatbox-core stays generic; tethysdash owns the per-dashboard localStorage key and ChatSidebar wiring. Companion PR **Aquaveo/chatbox-core#19** ships the generic chatbox-core API (\`initialMessages\` + \`onMessagesChange\` props).

## Demo

```
1. Open dashboard A. Send 5 chat turns about your tile layout.
2. Navigate to dashboard B. Empty chat thread (B has no history).
3. Send 2 chat turns about B.
4. Navigate back to dashboard A. All 5 turns restored.
5. Refresh the page (F5). Both threads still there.
6. Clear browser cache. Both threads gone (intentional reset).
```

## What changed

| File | Change |
|---|---|
| \`reactapp/services/chatHistoryStorage.js\` | **New** — get/save/clear by dashboard uuid; silent-fail on quota/unavailable/malformed; versioned key \`tethysdash:chat:v1:<uuid>\` |
| \`reactapp/__tests__/services/chatHistoryStorage.test.js\` | **New** — 18 tests |
| \`reactapp/components/sidebar/ChatSidebar.js\` | Read uuid from LayoutContext; useMemo load + useCallback save; \`<Chatbox key={uuid}>\` for clean remount |
| \`reactapp/__tests__/components/sidebar/ChatSidebar.persistence.test.js\` | **New** — 5 wiring tests |

## Edge cases handled

| Condition | Behavior |
|---|---|
| Dashboard with no prior chat | Empty thread (default) |
| localStorage unavailable (private browsing some browsers) | Silent-fail; chatbox works ephemerally |
| Quota exceeded mid-write | Silent-fail; existing thread keeps working in-memory until reload |
| Malformed JSON in localStorage | Returns \`[]\` on read |
| Non-array JSON value (e.g., \`null\`, object) | Returns \`[]\` on read |
| Empty / null dashboard uuid (mounted outside LayoutContext or pre-load) | initialMessages = []; save is no-op |
| Dashboard switch (uuid changes) | \`<Chatbox key={uuid}>\` forces React tear-down + remount; B's thread loads fresh |
| Multi-tab same dashboard | Last-write-wins (accepted per plan Scope Boundaries) |

## Tests

\`npx jest reactapp/__tests__/components/sidebar reactapp/__tests__/services\` → **128 / 128 pass** (was 105; +23 new):

- 18 storage helper tests
- 5 ChatSidebar wiring tests
- 10 existing ChatSidebar tests still pass (R11 permission gate, patch-rejected banner)

## What did NOT change

- Existing tests pass with no modifications
- LLM engine, MCP server, dashboard layout untouched
- ChatSidebar's R11 permission gate, patch-rejected banner, variable-input publishing all unchanged
- Other host wiring (csrf, mcpServers, engineExtensions) untouched
- Backend / Django / database — no changes

## Plan reference

\`docs/plans/2026-05-08-004-feat-persist-chatbox-per-dashboard-plan.md\` — Units 2 + 3.

## Companion

**Aquaveo/chatbox-core#19** — Unit 1 (\`initialMessages\` + \`onMessagesChange\` props on \`<Chatbox>\`). This PR consumes those props via the workspace's \`file:\` link to \`lib/chatbox-core\`. After #19 merges, no further changes needed here.

## Test plan

- [x] All existing tests pass
- [x] 23 new tests cover the helper (18) + wiring (5)
- [ ] CI passes
- [ ] Manual smoke: open 2 dashboards, chat in each, verify isolation; refresh page, verify both threads restore; clear localStorage, verify reset