### PR TITLE
fix(dashboard): copy only the bare UUID, not tile metadata

### DIFF
--- a/reactapp/__tests__/components/dashboard/DashboardItem.test.js
+++ b/reactapp/__tests__/components/dashboard/DashboardItem.test.js
@@ -2458,7 +2458,7 @@ describe("Copy grid item UUID button", () => {
     ).toBeInTheDocument();
   });
 
-  test("click writes the chat-ready payload to the clipboard and shows success toast", async () => {
+  test("click writes only the bare UUID to the clipboard and shows success toast", async () => {
     const writeText = mockClipboard();
     renderWithGridItem();
 
@@ -2466,21 +2466,15 @@ describe("Copy grid item UUID button", () => {
     await userEvent.click(copyBtn);
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
-    const payload = writeText.mock.calls[0][0];
-    expect(payload).toContain("uuid: some-uuid-1");
-    expect(payload).toContain("source: ");
-    // Single-digit position values for the default fixture (x=0, y=0, w=20, h=20)
-    expect(payload).toContain("position: 0,0 20×20");
-    expect(payload).toBe(
-      `uuid: some-uuid-1\nsource: \nposition: 0,0 20×20`,
-    );
+    // Bare UUID only — no source, no position, no labels.
+    expect(writeText.mock.calls[0][0]).toBe("some-uuid-1");
 
     expect(
       await screen.findByText("UUID copied to clipboard"),
     ).toBeInTheDocument();
   });
 
-  test("payload position formats for multi-digit coordinates", async () => {
+  test("clipboard payload is unaffected by grid-item position / size", async () => {
     const writeText = mockClipboard();
     renderWithGridItem({
       gridItemOverrides: { x: 12, y: 8, w: 24, h: 45 },
@@ -2488,9 +2482,7 @@ describe("Copy grid item UUID button", () => {
 
     await userEvent.click(await screen.findByLabelText("Copy grid item UUID"));
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
-    expect(writeText.mock.calls[0][0]).toContain(
-      "position: 12,8 24×45",
-    );
+    expect(writeText.mock.calls[0][0]).toBe("some-uuid-1");
   });
 
   test("warns and skips clipboard write when grid item index is out of range", async () => {

--- a/reactapp/components/dashboard/DashboardItem.js
+++ b/reactapp/components/dashboard/DashboardItem.js
@@ -457,10 +457,8 @@ const DashboardItem = () => {
       setShowGridItemWarning(true);
       return;
     }
-    const { x, y, w, h } = gridItem;
-    const payload = `uuid: ${gridItemUUID}\nsource: ${gridItemSource}\nposition: ${x},${y} ${w}×${h}`;
     try {
-      await window.navigator.clipboard.writeText(payload);
+      await window.navigator.clipboard.writeText(gridItemUUID);
       setGridItemMessage("UUID copied to clipboard");
       setShowGridItemMessage(true);
     } catch {


### PR DESCRIPTION
## Summary

The grid-item copy button wrote a multi-line payload:

```
uuid: <uuid>
source: <source>
position: <x>,<y> <w>×<h>
```

…but the success toast already says \"UUID copied to clipboard.\" Trim the clipboard contents to just the bare UUID so:
- Pasting somewhere drops in just the UUID, ready to feed into `patch_visualization` or any other UUID-keyed tool.
- The toast message matches what the user actually receives.

`copyGridItemContext` in `reactapp/components/dashboard/DashboardItem.js` now calls `clipboard.writeText(gridItemUUID)`. The out-of-range fixture guard, success / failure toasts, and click-propagation behavior are unchanged.

## Test plan

- [x] `npx jest reactapp/__tests__/components/dashboard/DashboardItem.test.js`: 54/54 passing.
- [x] Existing test \"click writes the chat-ready payload\" replaced with \"click writes only the bare UUID\" — asserts `writeText.mock.calls[0][0]` equals `\"some-uuid-1\"`.
- [x] Multi-digit position test repurposed to confirm the payload is unaffected by tile position / size.
- [ ] Manual smoke: click the copy icon on a tile, paste into a notepad, confirm only the UUID appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)