### PR TITLE
refactor(deps): drop broken legacy chatbox file: link

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@tiptap/starter-kit": "^2.12.0",
     "axios": "^0.27.2",
     "bootstrap": "^5.1.3",
-    "chatbox": "file:../plugins/nextgen_plugins/nextgen_plugins/chatbox/frontend/chatbox",
     "css-loader": "^6.5.1",
     "date-fns": "^4.1.0",
     "dompurify": "^3.1.6",


### PR DESCRIPTION
## Summary

Dead-dep cleanup. The \`\"chatbox\": \"file:../plugins/nextgen_plugins/nextgen_plugins/chatbox/frontend/chatbox\"\` entry in \`package.json\` points at a directory that no longer exists on disk — the path was deleted during the 2026-05-02 workspace restructure that made \`plugins/nextgen_plugins/\` MFE-only (per the \`project_workspace_layout\` workspace memory).

No source file in \`reactapp/\` imports the \`\"chatbox\"\` package. The live chatbox engine is consumed via \`\"@chatbox/core\": \"file:../lib/chatbox-core\"\`. The legacy entry was a leftover that the restructure missed.

## Test plan

- [x] \`node -e \"JSON.parse(require('fs').readFileSync('package.json','utf8'))\"\` confirms \`package.json\` remains valid JSON.
- [x] Full-repo grep for \`from ['\"]chatbox['\"]\` / \`require(['\"]chatbox['\"])\` returns zero hits in \`reactapp/\` outside \`node_modules\`.
- [ ] Post-merge: \`npm install\` on a fresh checkout succeeds without the broken \`file:\` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)