### PR TITLE
fix(mcp): two critical correctness fixes — fastmcp prod dep + stale add_map_service_layer prose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "python-dateutil",
     "pytz",
     "jsonpatch==1.33",
+    "fastmcp",
 ]
 classifiers = [
      "Environment :: Web Environment",
@@ -46,11 +47,6 @@ classifiers = [
      "Programming Language :: Python :: 3.10",
      "Topic :: Internet :: WWW/HTTP",
      "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
-]
-
-[project.optional-dependencies]
-test = [
-    "fastmcp",
 ]
 
 [tool.setuptools]

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -748,7 +748,11 @@ def _build_markers_layer(markers):
         "When the user wants to focus on a specific feature, call a "
         "data-source feature-lookup tool first to obtain the bounding box "
         "and pass it via 'map_extent'. To add WMS, ESRI, GeoJSON, or other "
-        "service layers to a NEWLY-CREATED map, call add_map_service_layer "
+        "service layers to a NEWLY-CREATED map, call the matching `add_*_layer` "
+        "tool (add_wms_layer, add_esri_image_layer, add_esri_feature_layer, "
+        "add_geojson_layer, add_kml_layer, add_image_tile_layer, "
+        "add_vector_tile_layer, add_pmtiles_vector_layer, add_pmtiles_raster_layer, "
+        "add_geotiff_layer, add_static_image_layer, or add_dynamic_map_layer) "
         "with the returned map UUID. "
         "DO NOT call this when the user named an existing visualization "
         "UUID (from `dashboard_state`) OR asked to add to / modify / "
@@ -819,8 +823,9 @@ def create_map_visualization(
     """Create a geographic map on the dashboard.
 
     Simple usage: provide 'center' or 'markers' for a quick map.
-    For service layers (WMS, ESRI, GeoJSON, KML, GeoTIFF, etc.): call
-    add_map_service_layer with the returned map UUID after creating the map.
+    For service layers (WMS, ESRI, GeoJSON, KML, GeoTIFF, etc.): call the
+    matching `add_*_layer` tool (add_wms_layer, add_geojson_layer, etc.) with
+    the returned map UUID after creating the map.
     """
     map_uuid = str(uuid.uuid4())
     LOGGER.info("create_map_visualization: uuid=%s, center=%s, markers=%s",
@@ -883,9 +888,13 @@ def create_map_visualization(
         },
         "map_uuid": map_uuid,
         "message": (
-            f"Map created (uuid: {map_uuid}). Use add_map_service_layer with "
-            "this UUID to add WMS, ESRI, GeoJSON, GeoTIFF, or other service "
-            "layers."
+            f"Map created (uuid: {map_uuid}). Use the matching `add_*_layer` "
+            f"tool (add_wms_layer, add_esri_image_layer, add_esri_feature_layer, "
+            f"add_geojson_layer, add_kml_layer, add_image_tile_layer, "
+            f"add_vector_tile_layer, add_pmtiles_vector_layer, "
+            f"add_pmtiles_raster_layer, add_geotiff_layer, add_static_image_layer, "
+            f"or add_dynamic_map_layer) with this UUID to add WMS, ESRI, GeoJSON, "
+            f"GeoTIFF, or other service layers."
         ),
     }
 
@@ -2668,7 +2677,8 @@ def _check_r5c_array_collision(ops):
 
 
 def _check_layer_construction_boundary(source, ops):
-    """R9/R10: Map layer construction is reserved for add_map_service_layer.
+    """R9/R10: Map layer construction is reserved for the `add_*_layer` tools
+    (add_wms_layer, add_geojson_layer, add_esri_image_layer, etc.).
 
     Reject `add`/`replace` at /args/layers (whole array — the LLM's wrong-
     shape escape that produced the duplicate-layer bug).
@@ -2690,8 +2700,9 @@ def _check_layer_construction_boundary(source, ops):
             return (
                 f"op {i} `{op_name}` at '/args/layers' would replace the "
                 f"whole layers array, which is not permitted via "
-                f"patch_visualization. To add a new layer use "
-                f"`add_map_service_layer`. To modify an existing layer's "
+                f"patch_visualization. To add a new layer use the matching "
+                f"`add_*_layer` tool (add_wms_layer, add_geojson_layer, "
+                f"add_esri_image_layer, etc.). To modify an existing layer's "
                 f"fields, patch under '/args/layers/N/...'. To remove a "
                 f"layer, use a `remove` op at '/args/layers/N'."
             )
@@ -2700,9 +2711,12 @@ def _check_layer_construction_boundary(source, ops):
                 return (
                     f"op {i} `add` at {path!r} would construct a new map layer, "
                     f"which is not permitted via patch_visualization. Use the "
-                    f"`add_map_service_layer` tool to add a new service layer "
-                    f"(WMS, ESRI, GeoJSON, KML, tile, etc.) with its required "
-                    f"flat parameters."
+                    f"matching `add_*_layer` tool (add_wms_layer, add_geojson_layer, "
+                    f"add_esri_image_layer, add_esri_feature_layer, add_kml_layer, "
+                    f"add_image_tile_layer, add_vector_tile_layer, "
+                    f"add_pmtiles_vector_layer, add_pmtiles_raster_layer, "
+                    f"add_geotiff_layer, add_static_image_layer, or "
+                    f"add_dynamic_map_layer) with its required flat parameters."
                 )
         if op_name == "replace":
             if _BARE_LAYER_INDEX.match(path):
@@ -2711,8 +2725,8 @@ def _check_layer_construction_boundary(source, ops):
                     f"object, which is not permitted. Either patch individual "
                     f"fields within the existing layer (e.g., "
                     f"{path}/configuration/props/opacity or "
-                    f"{path}/visible) or use `add_map_service_layer` to add a "
-                    f"new layer."
+                    f"{path}/visible) or use the matching `add_*_layer` tool "
+                    f"(add_wms_layer, add_geojson_layer, etc.) to add a new layer."
                 )
     return None
 
@@ -2770,7 +2784,8 @@ def _emit_rejection_telemetry(
         "Paths use JSON Pointer syntax (RFC 6901): literal `.` in a segment is preserved "
         "as-is (do not escape). Supported ops: add, replace, remove, move, test. "
         "Copy is intentionally excluded. "
-        "To CREATE a new map layer, use add_map_service_layer — this tool is for edits only."
+        "To CREATE a new map layer, use the matching `add_*_layer` tool "
+        "(add_wms_layer, add_geojson_layer, add_esri_image_layer, etc.) — this tool is for edits only."
     ),
     tags=["visualization", "patch", "update"],
 )
@@ -3164,8 +3179,10 @@ def _resolve_dynamic_map_layer_plugin(source: str) -> Dict[str, Any]:
                     return {
                         "error": (
                             f"Plugin {source!r} is a static map_layer plugin "
-                            f"(dynamic_map_layer=False). Use add_map_service_layer "
-                            f"with the plugin's pre-baked layer config instead."
+                            f"(dynamic_map_layer=False). Use the matching "
+                            f"`add_*_layer` tool (add_wms_layer, add_geojson_layer, "
+                            f"add_esri_image_layer, etc.) with the plugin's pre-baked "
+                            f"layer config instead."
                         )
                     }
                 return {"plugin": opt}

--- a/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
+++ b/tethysapp/tethysdash/tests/mcp/test_layer_contracts.py
@@ -429,7 +429,7 @@ class TestResolveDynamicMapLayerPluginBranches:
             result = _resolve_dynamic_map_layer_plugin("static_overlay")
         assert "error" in result
         assert "static map_layer plugin" in result["error"]
-        assert "add_map_service_layer" in result["error"]
+        assert "add_*_layer" in result["error"]
 
     def test_happy_path_returns_plugin_metadata(self):
         """Sanity: when the plugin resolves AND has the right type +

--- a/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
+++ b/tethysapp/tethysdash/tests/mcp/test_patch_visualization.py
@@ -872,7 +872,7 @@ class TestWhitelist:
 
 
 class TestLayerConstructionBoundary:
-    """Layer construction is reserved for add_map_service_layer."""
+    """Layer construction is reserved for the per-source-type `add_*_layer` tools."""
 
     def test_add_at_layers_dash_rejected(self):
         """`add` at /args/layers/- creates a new layer — banned."""
@@ -883,7 +883,7 @@ class TestLayerConstructionBoundary:
         )
         assert "error" in result
         assert "whitelist_rejected" in result["error"]
-        assert "add_map_service_layer" in result["error"]
+        assert "add_*_layer" in result["error"]
 
     def test_add_at_layers_index_rejected(self):
         """`add` at /args/layers/N inserts a new layer — banned."""
@@ -894,7 +894,7 @@ class TestLayerConstructionBoundary:
         )
         assert "error" in result
         assert "whitelist_rejected" in result["error"]
-        assert "add_map_service_layer" in result["error"]
+        assert "add_*_layer" in result["error"]
 
     def test_replace_whole_layer_at_index_rejected(self):
         """`replace` at /args/layers/N replaces a whole layer object — banned."""
@@ -940,7 +940,7 @@ class TestLayerConstructionBoundary:
         """Non-Map sources don't get the layer-construction check."""
         # Inline Plotly has no /args/layers, so this hits whitelist_rejected,
         # not the layer-boundary check. Verify the error is whitelist_rejected
-        # without the add_map_service_layer hint.
+        # without the add_*_layer hint.
         result = patch_visualization(
             uuid=_fresh_uuid(),
             source="Inline Plotly",
@@ -949,7 +949,7 @@ class TestLayerConstructionBoundary:
         assert "error" in result
         assert "whitelist_rejected" in result["error"]
         # Hint is only emitted by the Map-specific check
-        assert "add_map_service_layer" not in result["error"]
+        assert "add_*_layer" not in result["error"]
 
     # -- Whole-array `/args/layers` ops: regression coverage for the
     # bug where an LLM emitted a single `replace` at `/args/layers` with
@@ -1007,8 +1007,8 @@ class TestLayerConstructionBoundary:
             }],
         )
         err = result.get("error", "")
-        # Add a new layer -> add_map_service_layer
-        assert "add_map_service_layer" in err
+        # Add a new layer -> add_*_layer family (add_wms_layer, add_geojson_layer, ...)
+        assert "add_*_layer" in err
         # Edit a layer field -> /args/layers/N/...
         assert "/args/layers/N/" in err or "/args/layers/N" in err
         # Remove a layer -> remove op


### PR DESCRIPTION
## Summary

Two critical correctness fixes surfaced by today's deep dead-code scan. Neither is dead code — both are latent production bugs.

### C1: \`fastmcp\` dependency declaration

\`pyproject.toml\` previously listed \`fastmcp\` ONLY under \`[project.optional-dependencies] test\`, but three production modules import it:

- \`tethysapp/tethysdash/mcp/tethysdash_mcp_server.py:32\`
- \`tethysapp/tethysdash/mcp/_input_validation_middleware.py:44\`
- \`tethysapp/tethysdash/mcp/_observability_middleware.py:48\`

A clean install via \`pip install .\` (without the \`[test]\` extras) would succeed at install time but the MCP server would ImportError on startup. **Moved \`fastmcp\` into the main \`dependencies\` list** so production installs are self-sufficient.

### C2: Stale \`add_map_service_layer\` LLM-facing prose

The umbrella tool \`add_map_service_layer\` was deleted in PR #109 (T3 split into 12 per-source-type tools: \`add_wms_layer\`, \`add_geojson_layer\`, \`add_esri_image_layer\`, etc.). **8 LLM-facing strings** in \`tethysdash_mcp_server.py\` still instructed the model to call the deleted tool — a latent silent-misroute.

Sites fixed (LLM-facing):

1. \`create_map_visualization\` description
2. \`create_map_visualization\` docstring
3. \`create_map_visualization\` return envelope \`message\`
4. \`_check_layer_construction_boundary\` error for \`/args/layers\` replace
5. \`_check_layer_construction_boundary\` error for \`/args/layers/-\` or \`/N\` add
6. \`_check_layer_construction_boundary\` error for \`/args/layers/N\` replace
7. \`patch_visualization\` tool description
8. \`_resolve_dynamic_map_layer_plugin\` error for static plugin

Also fixed one developer-facing docstring (\`_check_layer_construction_boundary\`) that read \"Map layer construction is reserved for add_map_service_layer\" in present tense.

Replaced prose points at the per-source-type tool family — short enough for the LLM, complete enough that the model can pick the right tool: *\"the matching \`add_*_layer\` tool (add_wms_layer, add_geojson_layer, add_esri_image_layer, etc.)\"*. The longest sites (the \`create_map_visualization\` description and return envelope) enumerate all 12 tools explicitly.

8 historical-context comments noting the umbrella was deleted (e.g., \`# These 12 tools replace the umbrella add_map_service_layer\`) are intentionally preserved as documentation.

## Test plan

- [x] \`pytest tethysapp/tethysdash/tests/mcp/ --no-cov -q\`: 775 passing (4 previously-failing tests updated to assert on the new \`add_*_layer\` family string).
- [ ] Post-merge: clean install with \`pip install .\` (no \`[test]\` extras) succeeds and \`python -m tethysapp.tethysdash.mcp.tethysdash_mcp_server\` starts without ImportError.
- [ ] Post-merge: LLM smoke test — issue \`/create_map ...\` then ask the model to add a WMS layer. The model should now pick \`add_wms_layer\` directly, not \`add_map_service_layer\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)