### PR TITLE
refactor: add save_runtime_plugin_registry() helper, consolidate 3-site path duplication

### DIFF
--- a/tethysapp/tethysdash/controllers.py
+++ b/tethysapp/tethysdash/controllers.py
@@ -40,6 +40,10 @@ from tethysapp.tethysdash.visualizations import (
 )
 from tethysapp.tethysdash.exceptions import VisualizationError
 from tethysapp.tethysdash.plugin_helpers import send_websocket_message
+from tethysapp.tethysdash.plugin_registry_loader import (
+    load_runtime_plugin_registry,
+    save_runtime_plugin_registry,
+)
 from channels.generic.websocket import AsyncWebsocketConsumer
 from tethys_sdk.routing import consumer
 from asgiref.sync import sync_to_async
@@ -1156,25 +1160,13 @@ def runtime_plugins_sync(request):
     POST: Overwrites the registry with the request body.
     The file is read by the MCP server for LLM tool discovery.
     """
-    registry_path = os.path.normpath(os.path.join(
-        os.path.dirname(__file__), "..", "..",
-        "reactapp", "generated", "runtimePluginRegistry.json"
-    ))
-
     if request.method == "GET":
-        try:
-            with open(registry_path, "r") as f:
-                data = json.load(f)
-            return JsonResponse(data, safe=False)
-        except (FileNotFoundError, json.JSONDecodeError):
-            return JsonResponse([], safe=False)
+        return JsonResponse(load_runtime_plugin_registry(), safe=False)
 
     # POST
     try:
         plugins = json.loads(request.body)
-        os.makedirs(os.path.dirname(registry_path), exist_ok=True)
-        with open(registry_path, "w") as f:
-            json.dump(plugins, f, indent=2)
+        save_runtime_plugin_registry(plugins)
         return JsonResponse({"status": "ok", "count": len(plugins)})
     except (json.JSONDecodeError, TypeError) as e:
         return JsonResponse({"error": str(e)}, status=400)

--- a/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
+++ b/tethysapp/tethysdash/mcp/tethysdash_mcp_server.py
@@ -50,6 +50,7 @@ from tethysapp.tethysdash.editable_schemas_plugin import (
 )
 from tethysapp.tethysdash.plugin_registry_loader import (
     load_runtime_plugin_registry,
+    save_runtime_plugin_registry,
 )
 from tethysapp.tethysdash.mcp._input_validation_middleware import (
     InputValidationEnvelopeMiddleware,
@@ -3610,15 +3611,9 @@ def register_runtime_plugin(
         "type": "client_custom_remote",
     }
 
-    registry_path = os.path.normpath(os.path.join(
-        os.path.dirname(__file__), "..", "..", "..",
-        "reactapp", "generated", "runtimePluginRegistry.json"
-    ))
     runtime = load_runtime_plugin_registry()
     runtime.append(entry)
-    os.makedirs(os.path.dirname(registry_path), exist_ok=True)
-    with open(registry_path, "w") as f:
-        json.dump(runtime, f, indent=2)
+    save_runtime_plugin_registry(runtime)
 
     LOGGER.info("Registered plugin %s → %s (total runtime: %d)", key, label, len(runtime))
     return {"status": "registered", "plugin": entry}

--- a/tethysapp/tethysdash/plugin_registry_loader.py
+++ b/tethysapp/tethysdash/plugin_registry_loader.py
@@ -53,3 +53,23 @@ def load_runtime_plugin_registry() -> List[Dict[str, Any]]:
     except json.JSONDecodeError as e:
         LOGGER.warning("Invalid JSON in runtime plugin registry: %s", e)
         return []
+
+
+def save_runtime_plugin_registry(plugins: List[Dict[str, Any]]) -> None:
+    """Persist the runtime plugin registry list to the canonical JSON path.
+
+    Creates the parent directory if needed. Overwrites any existing file.
+    Centralized here so the path construction (`reactapp/generated/
+    runtimePluginRegistry.json`) lives in exactly one place — previously
+    re-derived inline by ``controllers.runtime_plugins_sync`` and the
+    ``register_runtime_plugin`` MCP tool, each with a per-file-depth
+    ``__file__`` walk.
+    """
+    os.makedirs(os.path.dirname(_RUNTIME_REGISTRY_PATH), exist_ok=True)
+    with open(_RUNTIME_REGISTRY_PATH, "w") as f:
+        json.dump(plugins, f, indent=2)
+    LOGGER.info(
+        "Wrote %d runtime plugin(s) to %s",
+        len(plugins),
+        _RUNTIME_REGISTRY_PATH,
+    )


### PR DESCRIPTION
## Summary

The \`runtimePluginRegistry.json\` path was reconstructed inline in three places:

| Site | Depth | What it did |
|---|---|---|
| \`plugin_registry_loader.py:28\` | 2 (\`tethysapp/tethysdash/\`) | \`_RUNTIME_REGISTRY_PATH\` constant; used by \`load_runtime_plugin_registry\` |
| \`controllers.py:1159\` | 2 (\`tethysapp/tethysdash/\`) | \`runtime_plugins_sync\` rebuilt the path for GET (load) and POST (save) |
| \`mcp/tethysdash_mcp_server.py:3613\` | 3 (\`tethysapp/tethysdash/mcp/\`) | \`register_runtime_plugin\` rebuilt the path for save after appending |

Same logical path, three slightly-different mechanical computations (different \`__file__\` depths → different \`..\` counts).

Added \`save_runtime_plugin_registry(plugins: List[Dict]) -> None\` to \`plugin_registry_loader.py\` alongside the existing \`load_runtime_plugin_registry()\`. Both call sites now use the helpers — no inline path construction, no inline \`makedirs\`+\`json.dump\`, no inline \`open\`+\`json.load\`. The loader module is the single source of truth for the registry file path.

**Bonus:** \`controllers.py\` GET branch now goes through \`load_runtime_plugin_registry\` which already had \`FileNotFoundError\` + \`JSONDecodeError\` handling, instead of re-implementing the same error handling inline. The duplicated error paths collapse to the loader's existing behavior.

## Test plan

- [x] \`from tethysapp.tethysdash.plugin_registry_loader import load_runtime_plugin_registry, save_runtime_plugin_registry\` imports cleanly.
- [x] \`pytest tethysapp/tethysdash/tests/mcp/ --no-cov -q\` — 775/775 MCP contract tests pass.
- [ ] Post-merge: smoke the runtime-plugin sync round-trip end-to-end (register via chatbox → POST → file written → MCP server's load reads it).

## Net impact

+28 lines (helper definition + imports + docstring) / -21 lines (inlined path construction). Same byte count net; the duplication-elimination win is in maintainability (one path-edit instead of three) and consistency (one error-handling block instead of two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)