### PR TITLE
feat(devcontainer): bake React bundle at image build (multi-stage)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,62 @@
-# Backend-only devcontainer for TethysDash.
-# Pip-only environment, SQLite persistent store, no Node/Webpack.
-# See .devcontainer/README.md for usage; docs/plans/2026-05-06-001-feat-backend-only-devcontainer-plan.md for design.
+# TethysDash devcontainer.
+#
+# Multi-stage build:
+#   Stage 1 (frontend-builder): node:20-slim runs `npm ci` + `npm run build`
+#     to produce the React production bundle at
+#     tethysapp/tethysdash/public/frontend/. Node and node_modules live
+#     ONLY in this stage and are discarded.
+#   Stage 2 (runtime): python:3.11-slim with the editable pip install,
+#     pulling the built bundle in via `COPY --from=frontend-builder`.
+#
+# Why baked at build time: the image always ships a bundle that matches the
+# source at the COPYed commit. Eliminates the "remember to npm run build &&
+# git add public/frontend/main.js" trap that produced silent UI drift on
+# stale-commit workshop deploys. See docs/solutions/integration-issues/...
+# and the workshop's setup.sh which asserts public/frontend/main.js exists.
+#
+# History: this Dockerfile was previously backend-only (pip-only, no Node)
+# per docs/plans/2026-05-06-001-feat-backend-only-devcontainer-plan.md. The
+# multi-stage refactor preserves the backend-only RUNTIME image (no Node in
+# the final layers) while restoring fresh-bundle guarantee at build time.
+# See .devcontainer/README.md for usage.
 
+# ---------------------------------------------------------------------------
+# Stage 1: frontend bundle
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS frontend-builder
+
+WORKDIR /build
+
+COPY package.json package-lock.json ./
+
+# Swap the `@chatbox/core` file: link → published npm alias before install.
+# package.json declares `"@chatbox/core": "file:../lib/chatbox-core"` for
+# co-evolution in the firoh workspace, but that path is NOT inside this
+# Docker build context — npm would fail to resolve it. `npm:` alias keeps
+# the consumer import paths (`@chatbox/core/components`, `.../messages`)
+# unchanged. Bump the version when chatbox-core ships a new release.
+RUN sed -i \
+        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.0"|' \
+        package.json \
+    && rm package-lock.json \
+    && npm install --no-audit --no-fund
+
+# Source + configs webpack needs. Listed explicitly (not `COPY . .`) so a
+# Python-only change doesn't invalidate the npm cache layer above.
+COPY babel.config.json jsconfig.json ./
+COPY reactapp/ ./reactapp/
+COPY tethysapp/tethysdash/public/ ./tethysapp/tethysdash/public/
+
+# Produces /build/tethysapp/tethysdash/public/frontend/main.js + sibling chunks.
+# webpack's `--mode production` reads ./reactapp/config/production.env if
+# present (gitignored; falls back to default tethys_prefix_url when absent —
+# verified safe via the webpack config's `process.env.TETHYS_PREFIX_URL`
+# fallback branch).
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime (python:3.11-slim, pip-only)
+# ---------------------------------------------------------------------------
 FROM python:3.11-slim
 
 # Tethys path conventions, used by Salt states under .devcontainer/salt/.
@@ -47,6 +102,14 @@ COPY . .
 
 # Editable install with the [test] extra.
 RUN pip install --no-cache-dir -e ".[test]"
+
+# Overwrite the (possibly stale) committed bundle with the fresh one produced
+# in stage 1. Must come AFTER `COPY . .` to clobber any stale main.js that
+# rode in via the broad copy. Placed after pip install so reactapp-source
+# changes don't bust the pip layer cache.
+COPY --from=frontend-builder \
+     /build/tethysapp/tethysdash/public/frontend/ \
+     /workspaces/tethysapp-tethys_dash/tethysapp/tethysdash/public/frontend/
 
 # (MCP contract test build gate removed: the embedded MCP server was extracted
 # into the standalone repo Aquaveo/tethysdash_mcps and is now published as

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,85 +1,39 @@
-# TethysDash devcontainer.
-#
-# Multi-stage build:
-#   Stage 1 (frontend-builder): node:20-slim runs `npm ci` + `npm run build`
-#     to produce the React production bundle at
-#     tethysapp/tethysdash/public/frontend/. Node and node_modules live
-#     ONLY in this stage and are discarded.
-#   Stage 2 (runtime): python:3.11-slim with the editable pip install,
-#     pulling the built bundle in via `COPY --from=frontend-builder`.
-#
-# Why baked at build time: the image always ships a bundle that matches the
-# source at the COPYed commit. Eliminates the "remember to npm run build &&
-# git add public/frontend/main.js" trap that produced silent UI drift on
-# stale-commit workshop deploys. See docs/solutions/integration-issues/...
-# and the workshop's setup.sh which asserts public/frontend/main.js exists.
-#
-# History: this Dockerfile was previously backend-only (pip-only, no Node)
-# per docs/plans/2026-05-06-001-feat-backend-only-devcontainer-plan.md. The
-# multi-stage refactor preserves the backend-only RUNTIME image (no Node in
-# the final layers) while restoring fresh-bundle guarantee at build time.
-# See .devcontainer/README.md for usage.
+# TethysDash devcontainer. Multi-stage: node:20-slim builds the React bundle;
+# python:3.11-slim runtime pulls it in. Node lives only in stage 1.
 
-# ---------------------------------------------------------------------------
 # Stage 1: frontend bundle
-# ---------------------------------------------------------------------------
 FROM node:20-slim AS frontend-builder
 
 WORKDIR /build
 
 COPY package.json package-lock.json ./
 
-# Swap the `@chatbox/core` file: link → published npm alias before install.
-# package.json declares `"@chatbox/core": "file:../lib/chatbox-core"` for
-# co-evolution in the firoh workspace, but that path is NOT inside this
-# Docker build context — npm would fail to resolve it. `npm:` alias keeps
-# the consumer import paths (`@chatbox/core/components`, `.../messages`)
-# unchanged. Bump the version when chatbox-core ships a new release.
+# Swap `@chatbox/core` file: link → published npm alias; the sibling source
+# isn't in this build context. Bump version when chatbox-core releases.
 RUN sed -i \
         's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.0"|' \
         package.json \
     && rm package-lock.json \
     && npm install --no-audit --no-fund
 
-# Source + configs webpack needs. Listed explicitly (not `COPY . .`) so a
-# Python-only change doesn't invalidate the npm cache layer above.
+# Explicit COPYs (not `COPY . .`) so Python-only changes don't bust the npm layer.
 COPY babel.config.json jsconfig.json ./
 COPY reactapp/ ./reactapp/
 COPY tethysapp/tethysdash/public/ ./tethysapp/tethysdash/public/
 
-# Produces /build/tethysapp/tethysdash/public/frontend/main.js + sibling chunks.
-# webpack's `--mode production` reads ./reactapp/config/production.env if
-# present (gitignored; falls back to default tethys_prefix_url when absent —
-# verified safe via the webpack config's `process.env.TETHYS_PREFIX_URL`
-# fallback branch).
 RUN npm run build
 
-# ---------------------------------------------------------------------------
 # Stage 2: runtime (python:3.11-slim, pip-only)
-# ---------------------------------------------------------------------------
 FROM python:3.11-slim
 
-# Tethys path conventions, used by Salt states under .devcontainer/salt/.
-# Same value in v1; structured so a future iteration can repoint TETHYS_PERSIST
-# to a volume-mounted path without touching Salt code.
 ENV TETHYS_HOME=/root/.tethys
 ENV TETHYS_PERSIST=/root/.tethys
-
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# OS deps:
-#   build-essential + libpq-dev — psycopg2-binary fallback if no manylinux wheel matches
-#   git, curl, ca-certificates — devcontainer hygiene
-# No GDAL/proj/geos: tethys-platform 4.5.1 PyPI deps include none, and tethysdash
-# imports nothing from osgeo/gdal/fiona/shapely/geopandas (verified 2026-05-06).
-# No Salt: pip-distributed Salt has incomplete install_requires on slim Python
-# images (missing looseversion, distro, more), and the SaltProject apt repo
-# isn't reliably reachable from all build environments. Provisioning is bash
-# scripts under .devcontainer/scripts/ instead — same idempotence semantics
-# as the agwa .sls pattern, no install footprint.
+# build-essential + libpq-dev for psycopg2-binary source fallback; rest is dev hygiene.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -90,33 +44,20 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Isolated venv. Tethysdash + its deps land here; system pip stays clean.
 RUN python -m venv "${VIRTUAL_ENV}"
 
 WORKDIR /workspaces/tethysapp-tethys_dash
 
-# Build context is the subrepo root (.devcontainer/.. via devcontainer.json `build.context`).
-# At runtime, the host workspace bind-mounts over this path; the editable install
-# from build time still resolves because absolute paths match.
 COPY . .
 
-# Editable install with the [test] extra.
 RUN pip install --no-cache-dir -e ".[test]"
 
-# Overwrite the (possibly stale) committed bundle with the fresh one produced
-# in stage 1. Must come AFTER `COPY . .` to clobber any stale main.js that
-# rode in via the broad copy. Placed after pip install so reactapp-source
-# changes don't bust the pip layer cache.
+# Overlay the fresh bundle from stage 1, clobbering any stale main.js from `COPY . .`.
 COPY --from=frontend-builder \
      /build/tethysapp/tethysdash/public/frontend/ \
      /workspaces/tethysapp-tethys_dash/tethysapp/tethysdash/public/frontend/
 
-# (MCP contract test build gate removed: the embedded MCP server was extracted
-# into the standalone repo Aquaveo/tethysdash_mcps and is now published as
-# ghcr.io/aquaveo/tethysdash-mcps. The contract suite lives there; this image
-# no longer ships the MCP server, so no contract test runs at build time.)
-
 EXPOSE 8000
 
-# No CMD: the devcontainer host (VS Code / Codex) keeps the container alive via
-# overrideCommand. Contributor runs `bash .devcontainer/run.sh` to start the server.
+# No CMD: devcontainer host keeps the container alive via overrideCommand;
+# contributor runs `bash .devcontainer/run.sh` to start the server.


### PR DESCRIPTION
## Summary

- Add a `node:20-slim` frontend-builder stage to `.devcontainer/Dockerfile` that runs `npm install` + `npm run build`, then `COPY --from=` the bundle into the existing `python:3.11-slim` runtime stage. **Runtime image stays Node-free.**
- Eliminates the *"remember to `npm run build && git add public/frontend/main.js`"* trap: any image built from this Dockerfile (workshop fallback, CI, contributor `docker build`) carries a bundle that matches the source at the COPYed commit — not whatever stale `main.js` happens to be in the worktree.
- Resolves the `@chatbox/core` file: link (`file:../lib/chatbox-core`, a sibling repo outside this build context) by swapping it for the published npm alias `npm:@aquaveo/chatbox-core@0.6.0` *before* `npm install`. Consumer imports (`@chatbox/core/components`, `.../messages`) keep working unchanged. Bump the pinned version when chatbox-core ships a new release.

## Why now

The workshop's `docker-compose.yml` (`workshops/devcon/`) builds tethysdash from `.devcontainer/Dockerfile` as a fallback when `ghcr.io/aquaveo/ciroh-devcon-2026:${IMAGE_TAG}` isn't pullable. Under the prior single-stage image, that fallback shipped whatever bundle was committed to the repo at the pinned SHA — silently stale relative to the source if the contributor forgot to rebuild. With multi-stage in place, the bundle is *always* regenerated at image build time.

## Charter delta

The prior Dockerfile claimed *"pip-only environment, SQLite persistent store, no Node/Webpack"* per `docs/plans/2026-05-06-001-feat-backend-only-devcontainer-plan.md`. This PR breaks that backend-only-image charter intentionally:
- **Runtime image is still backend-only** (no Node, no `node_modules` in the final layers — verified via `which node` returning nothing).
- **Build pipeline now runs Node** in a separate, discarded stage.

The Dockerfile's top-of-file comment is updated to reflect the new posture.

## Test plan

- [x] `docker build -f .devcontainer/Dockerfile -t tethysdash-devcontainer-test:multi .` succeeds (~104s on cold cache).
- [x] Final image carries fresh `main.js` at `/workspaces/tethysapp-tethys_dash/tethysapp/tethysdash/public/frontend/` with sha256 differing from the committed copy (proves the bundle swap took effect end-to-end).
- [x] `docker run --rm tethysdash-devcontainer-test:multi which node` returns nothing — Node absent from runtime image.
- [x] Image size 3.68GB, on parity with the prior single-stage backend image (frontend-builder layers don't ship).
- [ ] Verify the workshop's `docker-compose.yml` fallback build still works after merge (manual smoke on `workshops/devcon/`).
- [ ] Verify `tethys manage start` inside the built container serves the React app at `http://localhost:8000/apps/tethysdash/` (manual smoke; deferred to first contributor who rebuilds the devcontainer).

## Follow-ups

- The pinned `@aquaveo/chatbox-core@0.6.0` should be bumped whenever a new chatbox-core release ships. Consider wiring an automated bump (Dependabot or a workshop CI step) in a future iteration.
- The committed `public/frontend/main.js` is now redundant for image builds — but it's still required for the conda-based dev workflow (`tethys manage start -p 8000` directly, no docker). Don't delete it until that workflow also produces a fresh bundle on demand.