### PR TITLE
chore(devcontainer): bump @aquaveo/chatbox-core to 0.6.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ COPY package.json package-lock.json ./
 # Swap `@chatbox/core` file: link → published npm alias; the sibling source
 # isn't in this build context. Bump version when chatbox-core releases.
 RUN sed -i \
-        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.0"|' \
+        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.1"|' \
         package.json \
     && rm package-lock.json \
     && npm install --no-audit --no-fund


### PR DESCRIPTION
## Summary

Bumps the npm-alias version in `.devcontainer/Dockerfile` from `@aquaveo/chatbox-core@0.6.0` → `@aquaveo/chatbox-core@0.6.1`.

Picks up [Aquaveo/chatbox-core#32](https://github.com/Aquaveo/chatbox-core/pull/32): **dynamic per-model Ollama `num_ctx` from `/api/show`**. Eliminates the hardcoded `num_ctx: 16384` cap that artificially throttled models with larger context windows. For `gpt-oss:120b` (reports 131,072), the adapter now sends the actual value, resolving the original 2026-05-17 round-2 500 in multi-round tool-use chains.

## What changes for the devcontainer image

- Multi-stage build's frontend-builder stage now installs `@aquaveo/chatbox-core@0.6.1` instead of `0.6.0`.
- Bundle output identical in shape; only the inlined chatbox-core code differs.
- Runtime image unchanged (Node-free).

## Test plan

- [ ] Manual: rebuild the devcontainer image (`docker build -f .devcontainer/Dockerfile .` from repo root) and confirm the build succeeds with the new alias version.
- [ ] Manual: launch the devcontainer, open chatbox, select `gpt-oss:120b` on Ollama Cloud, attach MCP servers, trigger a multi-round tool-use prompt. Verify in DevTools that `body.options.num_ctx` reflects the model's reported `context_length` (131,072 for gpt-oss:120b) rather than 16384.

## Out of scope

- The residual 5+-round 500s on `gpt-oss:120b` (where the conversation grows past whatever effective context window Ollama Cloud actually serves) are not addressed here — that's the merged context-visibility brainstorm's territory (`docs/brainstorms/2026-05-17-chatbox-context-visibility-requirements.md`). This PR only takes the dynamic-num_ctx fix.