### PR TITLE
fix(chatbox): assert dashboard_state authority over prior tool-call history

### DIFF
--- a/reactapp/__tests__/components/sidebar/ChatSidebar.test.js
+++ b/reactapp/__tests__/components/sidebar/ChatSidebar.test.js
@@ -343,4 +343,52 @@ describe("ChatSidebar beforeFirstMessage system-message framing", () => {
     expect(priorityIdx).toBeGreaterThan(editFramingIdx);
     expect(priorityIdx).toBeLessThan(jsonIdx);
   });
+
+  // Debug session 2026-05-17 — LLM was treating dashboard_state as
+  // additive to its own prior-turn tool-call history. When the user
+  // deleted a viz in the UI between turns, the LLM trusted "I created
+  // uuid X earlier" over the fresh dashboard_state that no longer
+  // listed X — refusing to recreate ("it already exists") or trying to
+  // patch_visualization a UUID that was gone. The fix adds an
+  // AUTHORITATIVE clause establishing dashboard_state as the complete
+  // current truth, with prior tool-call history explicitly subordinate.
+  // These tests pin the wording and its position so the rule can't
+  // silently regress.
+
+  test("AUTHORITATIVE clause establishes dashboard_state as the complete current truth, overriding prior tool-call history", () => {
+    renderWithContexts({ editable: true, tabs: tabsWithViz });
+    const msg = globalThis.__chatboxLastProps.engineExtensions.beforeFirstMessage();
+    expect(msg.content).toMatch(/AUTHORITATIVE/);
+    expect(msg.content).toMatch(/COMPLETE list/i);
+    // Names the deletion semantics so the LLM knows what missing UUIDs mean.
+    expect(msg.content).toMatch(/DELETED by the user/i);
+    // Names the wrong behaviors the rule prevents — refusing to recreate
+    // and trying to patch a UUID that no longer exists.
+    expect(msg.content).toMatch(/recreate from scratch/i);
+    // Explicitly subordinates prior-turn history to dashboard_state.
+    expect(msg.content).toMatch(
+      /tool-call history is NOT authoritative/i,
+    );
+    expect(msg.content).toMatch(/`?dashboard_state`?\s+always\s+wins/i);
+  });
+
+  test("AUTHORITATIVE clause appears AFTER the escape clause and BEFORE the dashboard-edit framing", () => {
+    renderWithContexts({ editable: true, tabs: tabsWithViz });
+    const msg = globalThis.__chatboxLastProps.engineExtensions.beforeFirstMessage();
+    const escapeIdx = msg.content.indexOf("REFERENCE for editing");
+    const authorityIdx = msg.content.indexOf("AUTHORITATIVE");
+    const editFramingIdx = msg.content.indexOf(
+      "Current dashboard state and patch_visualization reference",
+    );
+    expect(escapeIdx).toBeGreaterThanOrEqual(0);
+    expect(authorityIdx).toBeGreaterThanOrEqual(0);
+    expect(editFramingIdx).toBeGreaterThanOrEqual(0);
+    // Position is load-bearing: the escape clause defends against
+    // off-topic refusals (must lead); the AUTHORITATIVE clause defends
+    // against stale-history reasoning (must lead the dashboard-edit
+    // section so the LLM knows dashboard_state is current truth before
+    // it reads any patch_visualization instructions).
+    expect(authorityIdx).toBeGreaterThan(escapeIdx);
+    expect(authorityIdx).toBeLessThan(editFramingIdx);
+  });
 });

--- a/reactapp/components/sidebar/ChatSidebar.js
+++ b/reactapp/components/sidebar/ChatSidebar.js
@@ -278,6 +278,23 @@ function ChatSidebar() {
             "off-topic requests just because dashboard context is " +
             "present. Treat the context below as advisory, not " +
             "exclusive.\n\n" +
+            // Authority clause — dashboard_state wins over conversation
+            // history. Without this, when the user deletes a viz in the
+            // UI between turns, the LLM trusts its own prior tool-call
+            // history ("I created uuid X") more than the fresh
+            // dashboard_state injection and either (a) refuses to
+            // recreate the viz because "it already exists" or (b) tries
+            // to patch_visualization on a UUID that's no longer there.
+            // See debug session 2026-05-17.
+            "AUTHORITATIVE: `dashboard_state` below is the COMPLETE list " +
+            "of visualizations currently on the dashboard. If a " +
+            "visualization was created by a prior tool call but is NOT " +
+            "listed in `dashboard_state`, it has been DELETED by the " +
+            "user since that call. Treat such UUIDs as gone — do NOT " +
+            "attempt to `patch_visualization` on them, and recreate from " +
+            "scratch if the user asks for them again. Prior-turn " +
+            "tool-call history is NOT authoritative for what currently " +
+            "exists; `dashboard_state` always wins.\n\n" +
             "Current dashboard state and patch_visualization reference. " +
             "To edit an existing visualization, target its uuid via the " +
             "patch_visualization tool. Use `editable_paths_by_source` to " +


### PR DESCRIPTION
## Summary

When a user deletes a visualization in the dashboard UI **between chatbox turns**, the chatbox's freshly-injected `dashboard_state` correctly omits that UUID — but the LLM's own prior-turn tool-call history still shows it as 'successfully created'. The LLM was trusting history over `dashboard_state`, leading to:

- Refusing to recreate (\"we already created it earlier\")
- Returning empty / no-tool-call responses (user sees nothing happen)
- Attempting `patch_visualization` on UUIDs that no longer exist

This PR adds an **AUTHORITATIVE clause** to ChatSidebar's `beforeFirstMessage` system message asserting that `dashboard_state` is the COMPLETE list of currently-present visualizations and that prior-turn tool-call history is NOT authoritative. Two Jest tests pin both the wording and the position.

## Repro (captured 2026-05-17)

1. User: \"Create variable input + 3 plots\"
2. LLM: `create_variable_input` + `render_plugin × 3` → all succeed, panels render
3. User: deletes the 3 plots via the dashboard UI (no LLM involvement)
4. User: \"please retry the last prompt\"
5. Fresh `dashboard_state` shows 1 viz; conversation history shows 4 successful tool calls
6. **LLM's reasoning (captured)**: walks through \"we have four visualizations now... they are part of the dashboard\" — concludes \"already done; respond with text confirming\" — produces empty response

## What changes

| File | Change |
|---|---|
| `reactapp/components/sidebar/ChatSidebar.js` (around line 280) | Adds AUTHORITATIVE clause between the existing escape clause and the dashboard-edit framing |
| `reactapp/__tests__/components/sidebar/ChatSidebar.test.js` | Two new tests: (1) pins the clause's wording (`COMPLETE list`, `DELETED by the user`, `recreate from scratch`, `dashboard_state always wins`); (2) pins position (after escape clause, before dashboard-edit framing) |

## Position is load-bearing

The system message now has 4 ordered sections, each defending against a different failure mode:

1. **Escape clause** (2026-05-09): prevents off-topic refusals
2. **AUTHORITATIVE clause** (THIS PR, 2026-05-17): prevents stale-history reasoning
3. **Dashboard-edit framing** (`patch_visualization` mechanics, RFC 6902 ops, editable paths)
4. **PRIORITY rule** (2026-05-09): prevents simultaneous create + patch on the same UUID

The new test asserts AUTHORITATIVE sits between (1) and (3) so future edits can't accidentally reorder.

## Test plan

- [x] `npm test -- --testPathPattern='ChatSidebar.test'` → 18/18 pass (16 existing + 2 new)
- [ ] Manual smoke: reproduce the 2026-05-17 flow (create viz → delete in UI → ask chatbox to recreate); confirm the LLM now recreates instead of returning empty.

## Out of scope

- The empty-response handling itself (when the LLM does decide to send no tool calls, the chatbox shows nothing — separate UX concern, lives in the merged context-visibility brainstorm).
- Engine-level deduplication of stale UUIDs from history — this PR is prompt-engineering only; the engine doesn't need to filter history for the LLM to behave correctly.

## Memory note

This is the third dashboard-context framing fix (escape clause, PRIORITY rule, now authority clause). Each addresses a distinct LLM-reasoning failure mode. The pattern: when the chatbox-host integration injects context, the system message must be explicit about both **scope** (what the context is for) and **authority** (whether the context overrides other information sources).