### PR TITLE
fix(model): stop inserting phantom empty grid item on dashboard create

### DIFF
--- a/tethysapp/tethysdash/model.py
+++ b/tethysapp/tethysdash/model.py
@@ -508,22 +508,14 @@ def add_new_dashboard(
                         tab_id=default_tab.id,
                     )
                     grid_item_i += 1
-            else:
-                add_new_grid_item(
-                    session,
-                    new_dashboard_id,
-                    str(grid_item_i),
-                    0,
-                    0,
-                    20,
-                    20,
-                    "",
-                    "{}",
-                    "{}",
-                    0,
-                    str(uuid4()),
-                    tab_id=default_tab.id,
-                )
+            # Fresh dashboards with no grid_items are left truly empty.
+            # The previous else branch inserted a placeholder GridItem with
+            # source="", args_string="{}", x=0, y=0 to make the default tab
+            # non-empty for the legacy "+" button workflow — but it persists
+            # forever as a phantom top-left tile that the user can't easily
+            # distinguish from a real empty tile awaiting Edit. With the
+            # chatbox + manual "+" button both able to create the first
+            # tile on demand, no placeholder is needed. Debug 2026-05-18.
 
         # Commit the session and close the connection
         session.commit()

--- a/tethysapp/tethysdash/tests/integrated_tests/test_model.py
+++ b/tethysapp/tethysdash/tests/integrated_tests/test_model.py
@@ -98,7 +98,10 @@ def test_add_and_delete_dashboard(db_session, mock_app_get_ps_db, test_owner_use
     dashboard_id = dashboard.id
 
     assert len(dashboard.tabs) == 1
-    assert len(dashboard.grid_items) == 1
+    # Fresh dashboards created with no grid_items now persist with zero
+    # grid items — the legacy empty placeholder at (0,0) was removed
+    # because it manifested as a phantom top-left tile in the UI.
+    assert len(dashboard.grid_items) == 0
 
     # Add a grid item and verify
     grid_item_i = "2"


### PR DESCRIPTION
## Summary

- `add_new_dashboard` in `tethysapp/tethysdash/model.py` inserted a placeholder `GridItem` (`source=""`, `x=0, y=0, w=20, h=20`) into the default tab whenever no `grid_items` were provided. That stub persisted as a **phantom top-left tile** the user couldn't easily distinguish from a real empty tile awaiting Edit.
- Symptom report: "every time a grid item gets created an empty grid item on the top left is also created." Actual cause: the placeholder was always there since dashboard creation; chatbox/manual tiles got placed around it.
- Fresh dashboards now persist with **zero** grid items when none are supplied. The manual `+` button (`Header.js:onAddGridItem`) and the chatbox `tethysdash:add-visualization` path both already construct their own tiles — no seed needed.

## What changed

- `model.py`: deleted the `else: add_new_grid_item(...)` branch in `add_new_dashboard`. Replaced with a brief comment explaining why no fallback is inserted.
- `test_model.py::test_add_and_delete_dashboard`: flipped `assert len(dashboard.grid_items) == 1` → `== 0`. The other two tests at lines 202 / 273 still expect `1` because they pass an explicit Text tile in `grid_items`.

## Test plan

- [x] `pytest tethysapp/tethysdash/tests/integrated_tests/test_model.py --reuse-db` → 59/59 pass
- [x] Manual: create a new dashboard, confirm zero tiles render before any chatbox use
- [x] Manual: chatbox `create_*` produces a single tile (no phantom companion)
- [x] Manual: `+` button adds a fresh empty editable tile as before