### PR TITLE
chore(devcontainer): bump @aquaveo/chatbox-core 0.6.1 → 0.6.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ COPY package.json package-lock.json ./
 # Swap `@chatbox/core` file: link → published npm alias; the sibling source
 # isn't in this build context. Bump version when chatbox-core releases.
 RUN sed -i \
-        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.1"|' \
+        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.3"|' \
         package.json \
     && rm package-lock.json \
     && npm install --no-audit --no-fund


### PR DESCRIPTION
## Summary

Bump the devcontainer Dockerfile's `@aquaveo/chatbox-core` npm alias from **0.6.1 → 0.6.3** to pick up two new chatbox-core releases:

| Version | Change |
|---------|--------|
| 0.6.2 | CI infra: publish workflow now uses npm Trusted Publishers (OIDC). No functional change in the published bundle. |
| 0.6.3 | `fix(engine)`: retry transient MCP transport failures during cold-start. The Streamable HTTP / SSE transport pick now retries through `ECONNREFUSED` / 502 / 503 while the external MCP container restarts, so initial chatbox connection no longer fails permanently in that race. |

## Scope

- Single line in `.devcontainer/Dockerfile`. Only affects workshop / production image builds, which sed-swap the `@chatbox/core` `file:` link to the npm alias before `npm install`.
- Dev `file:../lib/chatbox-core` link in root `package.json` is **untouched** — local dev keeps consuming the sibling source.

## Test plan

- [ ] Workshop container rebuild picks up `@aquaveo/chatbox-core@0.6.3`
- [ ] Initial chatbox connection survives a cold-start of the external MCP container (cold-start retry confirmed working in 0.6.3)