### PR TITLE
chore(devcontainer): bump @aquaveo/chatbox-core 0.6.3 → 0.6.4

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ COPY package.json package-lock.json ./
 # Swap `@chatbox/core` file: link → published npm alias; the sibling source
 # isn't in this build context. Bump version when chatbox-core releases.
 RUN sed -i \
-        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.3"|' \
+        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.6.4"|' \
         package.json \
     && rm package-lock.json \
     && npm install --no-audit --no-fund


### PR DESCRIPTION
## Summary

Bump the devcontainer Dockerfile's \`@aquaveo/chatbox-core\` npm alias from **0.6.3 → 0.6.4** to pick up the truncation-summary fix.

## What v0.6.4 fixes

The data-only \`else\` branch in chatbox-core's truncation block (\`engine/index.js:923-929\`) was producing an essentially empty summary for oversized non-envelope results. A 240-row time-series response from the new nrds_mcps multi-file query tool blew the 4000-char cap; the LLM received only \`{_engine_dispatched: [], _truncated: true, _originalChars: 17430}\` — no \`ok\`, \`rows\`, \`columns\`, or \`data\`. Nothing to consume, nothing to retry against → infinite retry loop on the same query.

v0.6.4 changes:
- Truncation summary now preserves \`ok\`, \`rows\`, \`file_count\`, \`columns\`, \`error\` (both \`{code, message}\` object and string forms), and \`fix_hint\`. Drops only the bulk \`data\` / \`files\` fields.
- Emits a \`_truncation_hint\` string describing what was dropped and suggesting recovery (WHERE filters, smaller LIMIT, aggregate).
- Bumped \`MAX_TOOL_RESULT_CHARS\` 4000 → 20000 — modern LLMs handle 128K+ contexts so 5K tokens per result is cheap, and the cap was triggering on basically any data-extraction query.

PR: https://github.com/Aquaveo/chatbox-core/pull/35

## Test plan

- [ ] Workshop container rebuild picks up \`@aquaveo/chatbox-core@0.6.4\`
- [ ] Re-run the time-series query that looped before; confirm single tool call returns chart-buildable data