### PR TITLE
fix(chatbox): always inject dashboard_state so AUTHORITATIVE clause fires on empty dashboard

### DIFF
--- a/reactapp/__tests__/components/sidebar/ChatSidebar.test.js
+++ b/reactapp/__tests__/components/sidebar/ChatSidebar.test.js
@@ -242,11 +242,26 @@ describe("ChatSidebar beforeFirstMessage system-message framing", () => {
   };
   const tabsWithViz = [{ id: "t1", gridItems: [plotItem] }];
 
-  test("returns null when the dashboard has no patchable visualizations", () => {
+  test("emits the AUTHORITATIVE clause with empty dashboard_state when the dashboard is empty", () => {
+    // Empty dashboard must still emit a system message so the AUTHORITATIVE
+    // clause fires. Without this, the LLM reasons over prior-turn
+    // create_* / patch_visualization tool calls and believes deleted UUIDs
+    // still exist (bug 2026-05-19: user deletes plot, asks for new plot of
+    // same data, LLM patches the no-longer-existing tile instead of
+    // creating fresh).
     renderWithContexts({ editable: true, tabs: [] });
     const props = globalThis.__chatboxLastProps;
     expect(props).toBeDefined();
-    expect(props.engineExtensions.beforeFirstMessage()).toBeNull();
+    const msg = props.engineExtensions.beforeFirstMessage();
+    expect(msg).not.toBeNull();
+    expect(msg.role).toBe("system");
+    expect(msg.content).toMatch(/AUTHORITATIVE/);
+    expect(msg.content).toMatch(
+      /has been DELETED by the user since that call/,
+    );
+    // dashboard_state is the empty array — LLM applies AUTHORITATIVE semantics
+    // ("everything previously created has been deleted") to all prior UUIDs.
+    expect(msg.content).toMatch(/"dashboard_state":\[\]/);
   });
 
   test("emits a system message containing both the escape clause AND the dashboard-edit framing", () => {

--- a/reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js
+++ b/reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js
@@ -514,10 +514,26 @@ describe("buildValueHintsBySource", () => {
 });
 
 describe("buildPatchContext", () => {
-  test("returns null when no patchable items are in the dashboard", () => {
-    // Empty dashboard, no variable inputs set — nothing useful to say.
-    expect(buildPatchContext([], {})).toBeNull();
-    expect(buildPatchContext(undefined, undefined)).toBeNull();
+  test("returns envelope with empty dashboard_state when the dashboard is empty", () => {
+    // Empty dashboard must still emit a context payload so the
+    // beforeFirstMessage AUTHORITATIVE clause fires. Without this, the LLM
+    // reasons over prior-turn create_* / patch_visualization tool calls and
+    // believes deleted UUIDs still exist (bug 2026-05-19: user deletes plot,
+    // asks for new plot of same data, LLM patches the no-longer-existing
+    // tile instead of creating fresh).
+    const ctx = buildPatchContext([], {});
+    expect(ctx).not.toBeNull();
+    expect(ctx.dashboard_state).toEqual([]);
+    expect(ctx.editable_paths_by_source).toEqual({});
+    expect(ctx.value_hints_by_source).toEqual({});
+    expect(ctx.variable_input_values).toEqual({});
+  });
+
+  test("undefined/null inputs still emit an envelope (variable_input_values defaults to {})", () => {
+    const ctx = buildPatchContext(undefined, undefined);
+    expect(ctx).not.toBeNull();
+    expect(ctx.dashboard_state).toEqual([]);
+    expect(ctx.variable_input_values).toEqual({});
   });
 
   test("returns context when items are present", () => {
@@ -546,16 +562,21 @@ describe("buildPatchContext", () => {
     );
   });
 
-  test("returns context even when no items are patchable but variable inputs exist", () => {
-    // A dashboard with only Text items and variable inputs — still useful
-    // to tell the LLM what variables exist, even if nothing is patchable.
-    // Decision: return null here (no patchable targets, injection has no
-    // effect on patch_visualization). Keep behavior narrow.
-    const result = buildPatchContext(
+  test("returns context with non-empty dashboard_state when items exist but none are patchable", () => {
+    // A dashboard with only Text items — Text is not in LLM_EDITABLE_PATHS
+    // so editable_paths_by_source ends up empty. We still emit the envelope:
+    // the LLM needs to see the tile exists (so it doesn't try to recreate
+    // it) and the AUTHORITATIVE clause needs dashboard_state to compare
+    // against prior-turn tool-call history. Variable inputs surface too.
+    const ctx = buildPatchContext(
       [{ id: "t", gridItems: [textItem] }],
       { year: 2026 },
     );
-    expect(result).toBeNull();
+    expect(ctx).not.toBeNull();
+    expect(ctx.dashboard_state).toHaveLength(1);
+    expect(ctx.dashboard_state[0].source).toBe("Text");
+    expect(ctx.editable_paths_by_source).toEqual({});
+    expect(ctx.variable_input_values).toEqual({ year: 2026 });
   });
 
   test("plugin tiles produce a context when server-provided whitelists are supplied", () => {

--- a/reactapp/components/sidebar/chatboxStateBuilder.js
+++ b/reactapp/components/sidebar/chatboxStateBuilder.js
@@ -258,24 +258,24 @@ export function buildValueHintsBySource(items) {
 
 /**
  * Build the full system-message payload for the chatbox beforeFirstMessage
- * injection. Returns null if there is nothing useful to inject — either
- * the dashboard has no grid items, or every item's source is outside the
- * whitelist (nothing patchable anyway).
+ * injection. Always returns an envelope so the AUTHORITATIVE clause in
+ * ChatSidebar's beforeFirstMessage can fire on every turn — including the
+ * empty-dashboard case, where the clause's "anything in history but not in
+ * `dashboard_state` has been deleted" semantics protect against staleness
+ * after a user deletes their only visualization. (Without this, the LLM
+ * reasons over prior `create_*` / `patch_visualization` tool calls and
+ * believes deleted UUIDs still exist.)
  *
  * @param {Array} tabs - TabContext tabs array
  * @param {Object} variableInputValues - current variable input values
- * @returns {Object|null} {dashboard_state, editable_paths_by_source, value_hints_by_source, variable_input_values}
+ * @returns {Object} {dashboard_state, editable_paths_by_source, value_hints_by_source, variable_input_values}
  */
 export function buildPatchContext(tabs, variableInputValues, pluginEditablePaths) {
   const dashboardState = buildDashboardState(tabs);
-  if (dashboardState.length === 0) return null;
   const editablePathsBySource = buildEditablePathsBySource(
     dashboardState,
     pluginEditablePaths,
   );
-  // If nothing in the dashboard is patchable, skip the injection — the
-  // LLM has no use for it (and the create tools provide their own context).
-  if (Object.keys(editablePathsBySource).length === 0) return null;
   return {
     dashboard_state: dashboardState,
     editable_paths_by_source: editablePathsBySource,


### PR DESCRIPTION
## Summary

- After a user deletes their last visualization and asks for a new one, the LLM was treating the deleted tile as still present — confirming \"your plot has been updated\" instead of creating fresh
- Root cause: `buildPatchContext` returned `null` when `dashboard_state` was empty, which short-circuited the entire `beforeFirstMessage` injection — including the AUTHORITATIVE clause added in the 2026-05-17 debug session that exists specifically to defend against post-deletion staleness
- Fix: always emit the envelope. The AUTHORITATIVE clause's semantics (\"UUIDs in history but not in `dashboard_state` have been DELETED\") already cover the empty-array case correctly — every prior UUID becomes \"deleted, recreate from scratch\"

User-reported bug 2026-05-19, model: nemotron-3-nano-30b. Visible in the LLM thinking trace where it reasons \"we already created a plotly chart… we patched mode to lines… we can inform the user the plot has been updated\" when the plot no longer exists.

## What changed

- \`reactapp/components/sidebar/chatboxStateBuilder.js\` — removed two early-return-null paths in \`buildPatchContext\`. Updated JSDoc to reflect the new always-envelope contract.
- \`reactapp/__tests__/components/sidebar/chatboxStateBuilder.test.js\` — 2 new tests pinning the empty + undefined cases; 1 flipped test pinning the Text-only-dashboard case (used to return null; now returns envelope with non-empty \`dashboard_state\`).
- \`reactapp/__tests__/components/sidebar/ChatSidebar.test.js\` — 1 flipped test pinning that \`beforeFirstMessage()\` returns the AUTHORITATIVE clause + \`\"dashboard_state\":[]\` when tabs is empty.

The \`if (!patchContext) return null\` guard in \`ChatSidebar.js:262\` stays in place as defense-in-depth — \`buildPatchContext\` now never returns null, but the guard catches contract violations from future refactors.

## Test plan

- [x] Sidebar suite: 71/71 pass
- [x] Full Jest suite: 1773 passing, 2 pre-existing failures unrelated to chatbox (verified by stashing the change — \`ModuleLoader.test.js\` ESRI URL test + \`AppTour.test.js\` timeout fail identically on baseline)
- [ ] Manual smoke: create plot → delete → ask for new plot of same data → confirm LLM calls \`create_*\` instead of confirming the stale plot