### PR TITLE
feat(controllers): proxy route for Ollama /v1/chat/completions OpenAI-compat

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ COPY package.json package-lock.json ./
 # Swap `@chatbox/core` file: link → published npm alias; the sibling source
 # isn't in this build context. Bump version when chatbox-core releases.
 RUN sed -i \
-        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.15.2"|' \
+        's|"@chatbox/core": "file:\.\./lib/chatbox-core"|"@chatbox/core": "npm:@aquaveo/chatbox-core@0.15.3"|' \
         package.json \
     && rm package-lock.json \
     && npm install --no-audit --no-fund

--- a/tethysapp/tethysdash/controllers.py
+++ b/tethysapp/tethysdash/controllers.py
@@ -1182,6 +1182,18 @@ def ollama_chat(request):
 
 
 @api_view(["POST"])
+@controller(url="tethysdash/ollama-proxy/v1/chat/completions/", login_required=True)
+def ollama_v1_chat_completions(request):
+    # Ollama's OpenAI-compat endpoint. Use this instead of /api/chat for
+    # multi-round tool-call sessions: newer Ollama (>0.16.2) rejects
+    # object-typed tool_calls.function.arguments on /api/chat with
+    # "cannot unmarshal object into Go struct field ... of type string",
+    # while /v1/chat/completions follows the stable OpenAI spec (arguments
+    # always stringified). See chatbox-core PR #23 follow-up note.
+    return _proxy_to_ollama(request, "v1/chat/completions", timeout=(10, 300))
+
+
+@api_view(["POST"])
 @controller(url="tethysdash/llm-proxy/chat/completions/", login_required=True)
 def llm_proxy_chat_completions(request):
     """Generic LLM proxy for providers that block browser CORS (e.g., Google AI Studio).

--- a/tethysapp/tethysdash/tests/integrated_tests/test_controllers.py
+++ b/tethysapp/tethysdash/tests/integrated_tests/test_controllers.py
@@ -2666,6 +2666,48 @@ def test_ollama_proxy_does_not_log_for_known_handled_exceptions(
     )
 
 
+@pytest.mark.django_db
+def test_ollama_v1_chat_completions_proxy_forwards_to_openai_compat_path(
+    client, admin_user, mock_app, mocker
+):
+    """The /ollama-proxy/v1/chat/completions/ route must forward upstream to
+    the OpenAI-compat endpoint, not /api/chat. This is the route that fixes
+    the tool_calls argument-shape dispute between Ollama versions: /api/chat
+    flipped from object-args (<=0.16.2) to string-args (>0.16.2) for tool
+    history, while /v1/chat/completions follows OpenAI spec stably.
+    """
+    mock_app("tethysapp.tethysdash.controllers.App")
+    client.force_login(admin_user)
+
+    mock_post = mocker.patch(
+        "tethysapp.tethysdash.controllers.http_requests.post"
+    )
+    mock_resp = mocker.MagicMock()
+    mock_resp.iter_content = lambda chunk_size: iter([b'{"id":"x"}\n'])
+    mock_resp.headers = {"Content-Type": "application/json"}
+    mock_resp.status_code = 200
+    mock_post.return_value = mock_resp
+
+    url = "/apps/tethysdash/ollama-proxy/v1/chat/completions/"
+    response = client.post(
+        url,
+        data=json.dumps({"messages": [{"role": "user", "content": "hi"}]}),
+        content_type="application/json",
+        HTTP_X_OLLAMA_HOST="http://localhost:11434",
+    )
+
+    assert response.status_code == 200
+    assert mock_post.called
+    call_url = mock_post.call_args[0][0]
+    assert call_url.endswith("/v1/chat/completions"), (
+        f"Expected forward path to end with /v1/chat/completions; got {call_url!r}"
+    )
+    # Confirm x-ollama-host routed correctly
+    assert call_url.startswith("http://localhost:11434"), (
+        f"Expected upstream host to be from X-Ollama-Host header; got {call_url!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Runtime plugin registry — anonymous read endpoint.
 #


### PR DESCRIPTION
## Summary

Adds the Django proxy route the new chatbox-core **Ollama (local)** preset depends on:

```
/apps/tethysdash/ollama-proxy/v1/chat/completions/
  → ${X-Ollama-Host}/v1/chat/completions
```

Companion to chatbox-core PR Aquaveo/chatbox-core#44. Without this controller, the new preset returns 404.

## Why

Local Ollama participants hit:

```
Error: 400 json: cannot unmarshal object into Go struct field
.messages.tool_calls.function.arguments of type string
```

on multi-round tool-call sessions against `/api/chat`. Ollama's native chat endpoint flipped the inbound `tool_calls[].function.arguments` shape between versions (object on <=0.16.2, string on >0.16.2); chatbox-core PR #22 stringified universally and PR #23 reverted because that broke 0.16.2's chat-template parser. The two versions can't be satisfied by a single static wire format on the native endpoint.

PR #23's follow-up note named the right architectural fix: route Ollama chat through `/v1/chat/completions` (OpenAI spec, stable wire contract across versions). This controller is the Django-side half — chatbox-core PR #44 is the adapter half.

## Changes

- `tethysapp/tethysdash/controllers.py` — new `@controller(url="tethysdash/ollama-proxy/v1/chat/completions/")` mirroring the existing `/api/chat` route. Same `_proxy_to_ollama` helper, same `X-Ollama-Host`/`X-Ollama-Key` header contract.
- `tethysapp/tethysdash/tests/integrated_tests/test_controllers.py` — new test `test_ollama_v1_chat_completions_proxy_forwards_to_openai_compat_path` asserting the upstream URL ends with `/v1/chat/completions` and respects `X-Ollama-Host`.

The Ollama Cloud preset (existing `/ollama-proxy/api/chat/` route) is untouched — Cloud's wire format is stable.

## Test plan

- [ ] CI runs `test_ollama_v1_chat_completions_proxy_forwards_to_openai_compat_path`
- [ ] After chatbox-core #44 lands + bundle is bumped, manual smoke: configure chatbox with "Ollama (local)", select `qwen3:30b-a3b-instruct-2507-q4_K_M`, send `List available dates for cfe_nom model` — assistant should successfully dispatch the `list_available_dates` tool without the unmarshal error.