### PR TITLE
add a subplot toggle to plotly plots

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -141,6 +141,87 @@ Displays a `Plotly <https://plotly.com/python/>`_ chart with the provided data, 
 
 |
 
+Subplot Show/Hide Toggle
+::::::::::::::::::::::::::
+
+For figures built from multiple subplots, a plugin can let viewers show and hide
+individual subplots from a control in the top-right corner of the plot. When a
+subplot is hidden, the remaining subplots **reflow** to fill the freed space.
+
+To opt in, return ``toggle_subplots: True`` as a top-level key alongside
+``data``/``layout``/``config``::
+
+    return {
+        "data": data,
+        "layout": layout,
+        "config": config,
+        "toggle_subplots": True,
+    }
+
+That single key is all that is required. The frontend discovers the subplots
+("panes") from the figure's axes:
+
+- Traces are grouped into a pane by their ``xaxis``/``yaxis`` assignment.
+  Secondary-y overlays (an axis with ``overlaying``) are folded into the pane of
+  the axis they overlay.
+- Each pane's checkbox label comes from its y-axis ``title`` → else the first
+  trace ``name`` → else ``"Subplot N"``.
+- Toggling a pane off hides its traces and its dedicated axes (axes shared with
+  another pane are never hidden), then recomputes the domains of the remaining
+  visible panes. Axes are only hidden and re-domained, never removed, so
+  ``matches``/zoom-linking is preserved.
+
+The toggle state is ephemeral (it resets on reload) and at least one pane always
+remains visible.
+
+**Reflow.** Reflow is only applied when the subplots form a single row-stack
+(shared x-domain, stacked y-domains) or column-strip (the mirror). Grids,
+insets, and non-cartesian subplots (polar/geo/3D) fall back to *visibility-only*
+— panes hide but the layout does not reflow. To override the auto-detection,
+return an optional hint::
+
+    "subplot_toggle": {"reflow": "vertical"}  # or "horizontal" or "none"
+
+**Checkbox labels.** By default each checkbox is labeled from the subplot's
+primary y-axis ``title`` → else the first trace ``name`` → else ``"Subplot N"``.
+If your y-axis titles are units (e.g. ``"°F"``, ``"m/s"``) the labels will be
+units and may repeat, so you can supply explicit labels keyed by axis reference
+(``"y"``, ``"y3"``, ...) or layout key (``"yaxis"``, ``"yaxis3"``, ...)::
+
+    "subplot_toggle": {
+        "labels": {"y": "Temperature", "y3": "Pressure", "y5": "Wind Speed"},
+    }
+
+You can build this from each subplot's primary axis (see ``get_subplot_axes``).
+Any pane without an explicit label uses the default fallback above.
+
+**Tying annotations, shapes, and images to a subplot.** So that titles,
+drawings, and images for a hidden subplot are hidden (and reflow) along with it,
+**anchor them to that subplot's axes** rather than to the paper. The frontend
+ties a layout item to a pane by resolving its ``xref``/``yref``:
+
+- **Drawings/shapes** that live in data coordinates already work — e.g. a shape
+  with ``"xref": "x3", "yref": "y5"`` is tied to that subplot, hides with it, and
+  follows reflow automatically.
+- **Subplot titles / annotations** should use the axis *domain* reference
+  instead of ``"paper"`` so they both hide and reflow with their subplot::
+
+      # Instead of an absolute paper position:
+      {"text": "Wind Speed", "xref": "paper", "yref": "paper", "x": 0, "y": 0.65}
+
+      # Anchor to the subplot's axes (here the Wind row uses x3 / y5):
+      {"text": "Wind Speed", "xref": "x3 domain", "yref": "y5 domain",
+       "x": 0, "y": 1, "xanchor": "left", "yanchor": "bottom"}
+
+- **Images** likewise: a paper-anchored logo stays put (often desired), while an
+  image anchored to a subplot's axis is tied to it.
+
+Items that cannot be tied to a single subplot (paper-anchored, spanning multiple
+panes, or anchored only to a shared axis) are left untouched — for example a
+full-height vertical line drawn across all subplots is never hidden.
+
+|
+
 Table
 `````
 

--- a/reactapp/__tests__/components/visualizations/BasePlot.subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/BasePlot.subplotToggle.test.js
@@ -1,0 +1,183 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createRef } from "react";
+
+// --- Mocks: capture the props handed to the Plotly component, and drive the
+// resize-detector size so we can simulate a resize. ---------------------------
+// (mock factories may only reference globals, not module-scoped vars)
+jest.mock("react-resize-detector", () => ({
+  useResizeDetector: () => ({
+    width: global.__resizeSize.width,
+    height: global.__resizeSize.height,
+    ref: { current: null },
+  }),
+}));
+
+jest.mock("react-plotly.js/factory", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: () =>
+      function MockPlot(props) {
+        global.__plotProps = props;
+        return React.createElement("div", {
+          className: props.className,
+          "data-testid": "plot",
+        });
+      },
+  };
+});
+
+jest.mock("plotly.js-strict-dist-min", () => ({
+  relayout: jest.fn(),
+  purge: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import BasePlot from "components/visualizations/BasePlot";
+// eslint-disable-next-line import/first
+import {
+  VariableInputsContext,
+  GridItemContext,
+  DataViewerModeContext,
+} from "components/contexts/Contexts";
+
+// Vertical stack of three rows, each with a right-side overlay and a dedicated
+// x-axis sharing one x-domain (mirrors tethysapp .../data.json).
+const figure = () => ({
+  data: [
+    { name: "Temp", xaxis: "x", yaxis: "y" }, // 0
+    { name: "RH", xaxis: "x", yaxis: "y2" }, // 1 (overlay)
+    { name: "MSLP", xaxis: "x2", yaxis: "y3" }, // 2
+    { name: "Solar", xaxis: "x2", yaxis: "y4" }, // 3 (overlay)
+    { name: "Wind", xaxis: "x3", yaxis: "y5" }, // 4
+  ],
+  layout: {
+    xaxis: { domain: [0, 0.94], anchor: "y", matches: "x3" },
+    xaxis2: { domain: [0, 0.94], anchor: "y3", matches: "x3" },
+    xaxis3: { domain: [0, 0.94], anchor: "y5" },
+    yaxis: { domain: [0.7, 1.0], anchor: "x", title: { text: "Temperature" } },
+    yaxis2: { anchor: "x", overlaying: "y", side: "right" },
+    yaxis3: { domain: [0.35, 0.65], anchor: "x2", title: { text: "Pressure" } },
+    yaxis4: { anchor: "x2", overlaying: "y3", side: "right" },
+    yaxis5: { domain: [0, 0.3], anchor: "x3", title: { text: "Wind" } },
+    annotations: [
+      { text: "Temperature", xref: "x domain", yref: "y domain", x: 0, y: 1 },
+      { text: "Pressure", xref: "x2 domain", yref: "y3 domain", x: 0, y: 1 },
+      { text: "Wind", xref: "x3 domain", yref: "y5 domain", x: 0, y: 1 },
+    ],
+    shapes: [
+      { type: "line", xref: "x2", yref: "y3", x0: 0, x1: 1, y0: 1, y1: 2 },
+    ],
+  },
+});
+
+const renderPlot = (metadata) => {
+  const { data, layout } = figure();
+  return render(
+    <VariableInputsContext.Provider
+      value={{ variableInputDateFormats: {}, variableInputValues: {} }}
+    >
+      <GridItemContext.Provider value={{ gridItemArgsString: "{}" }}>
+        <DataViewerModeContext.Provider value={{ mode: "default" }}>
+          <BasePlot
+            data={data}
+            layout={layout}
+            config={{ responsive: true }}
+            visualizationRef={createRef()}
+            metadata={metadata}
+          />
+        </DataViewerModeContext.Provider>
+      </GridItemContext.Provider>
+    </VariableInputsContext.Provider>,
+  );
+};
+
+beforeEach(() => {
+  global.__resizeSize = { width: 500, height: 300 };
+  global.__plotProps = undefined;
+});
+
+describe("BasePlot subplot toggle", () => {
+  it("does not render the control when toggle_subplots is off", () => {
+    renderPlot({});
+    expect(
+      screen.queryByTestId("subplot-toggle-control"),
+    ).not.toBeInTheDocument();
+    // Original data passed through untouched.
+    expect(global.__plotProps.data[2].visible).toBeUndefined();
+  });
+
+  it("renders all panes visible initially with the original figure untouched", () => {
+    renderPlot({ toggle_subplots: true });
+    expect(screen.getByTestId("subplot-toggle-control")).toBeInTheDocument();
+    // No trace hidden, no domain rewrite while everything is visible.
+    global.__plotProps.data.forEach((t) => expect(t.visible).toBeUndefined());
+    expect(global.__plotProps.layout.yaxis.domain).toEqual([0.7, 1.0]);
+  });
+
+  it("hides a pane's traces + exclusive axes and reflows the rest", () => {
+    renderPlot({ toggle_subplots: true });
+    fireEvent.click(screen.getByLabelText("Toggle subplots"));
+    fireEvent.click(screen.getByLabelText("Pressure")); // hide middle row
+
+    const { data, layout } = global.__plotProps;
+    // Pressure row traces hidden (primary + overlay).
+    expect(data[2].visible).toBe(false);
+    expect(data[3].visible).toBe(false);
+    // Other rows still visible.
+    expect(data[0].visible).toBe(true);
+    expect(data[4].visible).toBe(true);
+    // Pressure's exclusive axes hidden.
+    expect(layout.yaxis3.visible).toBe(false);
+    expect(layout.yaxis4.visible).toBe(false);
+    expect(layout.xaxis2.visible).toBe(false);
+    // Remaining two rows reflow to fill the vertical space.
+    expect(layout.yaxis.domain[1]).toBeCloseTo(1, 6);
+    expect(layout.yaxis5.domain[0]).toBeCloseTo(0, 6);
+    // Overlay axis never receives a domain.
+    expect(layout.yaxis2.domain).toBeUndefined();
+    // The hidden row's annotation and drawing are hidden too; others stay.
+    expect(layout.annotations[1].visible).toBe(false); // Pressure title
+    expect(layout.shapes[0].visible).toBe(false); // Pressure drawing
+    expect(layout.annotations[0].visible).toBeUndefined(); // Temperature title
+    expect(layout.annotations[2].visible).toBeUndefined(); // Wind title
+  });
+
+  it("does not revert the toggle when the plot resizes", () => {
+    renderPlot({ toggle_subplots: true });
+    fireEvent.click(screen.getByLabelText("Toggle subplots"));
+    fireEvent.click(screen.getByLabelText("Pressure"));
+    expect(global.__plotProps.data[2].visible).toBe(false);
+
+    // Simulate a resize: width changes, component re-renders.
+    global.__resizeSize = { width: 900, height: 300 };
+    fireEvent.click(screen.getByLabelText("Wind")); // any state change triggers re-render
+    fireEvent.click(screen.getByLabelText("Wind")); // toggle back on
+
+    expect(global.__plotProps.layout.width).toBe(900);
+    // The Pressure toggle survived the resize/re-render.
+    expect(global.__plotProps.data[2].visible).toBe(false);
+    expect(global.__plotProps.layout.yaxis3.visible).toBe(false);
+  });
+
+  it("keeps at least one pane visible", () => {
+    renderPlot({ toggle_subplots: true });
+    fireEvent.click(screen.getByLabelText("Toggle subplots"));
+    fireEvent.click(screen.getByLabelText("Temperature"));
+    fireEvent.click(screen.getByLabelText("Pressure"));
+    fireEvent.click(screen.getByLabelText("Wind")); // attempt to hide the last
+
+    // Wind cannot be hidden — its traces remain visible.
+    expect(global.__plotProps.data[4].visible).toBe(true);
+  });
+
+  it("coexists with a vertical line without crashing", () => {
+    expect(() =>
+      renderPlot({
+        toggle_subplots: true,
+        plotlyVerticalLine: { mode: "on", value: "2026-06-10T00:00:00" },
+      }),
+    ).not.toThrow();
+    expect(screen.getByTestId("subplot-toggle-control")).toBeInTheDocument();
+  });
+});

--- a/reactapp/__tests__/components/visualizations/SubplotToggleControl.test.js
+++ b/reactapp/__tests__/components/visualizations/SubplotToggleControl.test.js
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SubplotToggleControl from "components/visualizations/SubplotToggleControl";
+
+const panes = [
+  { id: "x|y", label: "Temperature" },
+  { id: "x2|y3", label: "Pressure" },
+  { id: "x3|y5", label: "Wind" },
+];
+
+describe("SubplotToggleControl", () => {
+  it("renders nothing when there are fewer than two panes", () => {
+    const { container } = render(
+      <SubplotToggleControl
+        panes={[panes[0]]}
+        visiblePaneIds={["x|y"]}
+        onToggle={jest.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("keeps the checkbox list collapsed until the toggle button is clicked", () => {
+    render(
+      <SubplotToggleControl
+        panes={panes}
+        visiblePaneIds={panes.map((p) => p.id)}
+        onToggle={jest.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText("Temperature")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Toggle subplots"));
+    expect(screen.getByLabelText("Temperature")).toBeInTheDocument();
+    expect(screen.getByLabelText("Wind")).toBeInTheDocument();
+  });
+
+  it("reflects visibility state and emits toggle events", () => {
+    const onToggle = jest.fn();
+    render(
+      <SubplotToggleControl
+        panes={panes}
+        visiblePaneIds={["x|y", "x3|y5"]} // Pressure hidden
+        onToggle={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Toggle subplots"));
+
+    expect(screen.getByLabelText("Temperature")).toBeChecked();
+    expect(screen.getByLabelText("Pressure")).not.toBeChecked();
+
+    fireEvent.click(screen.getByLabelText("Temperature")); // uncheck
+    expect(onToggle).toHaveBeenCalledWith("x|y", false);
+
+    fireEvent.click(screen.getByLabelText("Pressure")); // check
+    expect(onToggle).toHaveBeenCalledWith("x2|y3", true);
+  });
+});

--- a/reactapp/__tests__/components/visualizations/subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/subplotToggle.test.js
@@ -1,0 +1,460 @@
+import {
+  axisRefToLayoutKey,
+  layoutKeyToAxisRef,
+  resolveBaseAxis,
+  derivePanes,
+  classifyArrangement,
+  reflowDomains,
+  applySubplotToggle,
+  associateItemToPane,
+} from "components/visualizations/subplotToggle";
+
+// --- Fixtures ------------------------------------------------------------
+
+// Vertical stack of 3 rows, each with a right-side secondary-y overlay and its
+// own x-axis (all sharing the same x-domain), mirroring tethysapp .../data.json.
+const verticalStackWithOverlays = () => ({
+  data: [
+    { name: "Temp", xaxis: "x", yaxis: "y" }, // 0 row1 primary
+    { name: "RH", xaxis: "x", yaxis: "y2" }, // 1 row1 overlay
+    { name: "MSLP", xaxis: "x2", yaxis: "y3" }, // 2 row2 primary
+    { name: "Solar", xaxis: "x2", yaxis: "y4" }, // 3 row2 overlay
+    { name: "Wind", xaxis: "x3", yaxis: "y5" }, // 4 row3 primary
+    { name: "Soil", xaxis: "x3", yaxis: "y5" }, // 5 row3 primary (2nd trace)
+  ],
+  layout: {
+    xaxis: { domain: [0, 0.94], anchor: "y", matches: "x3" },
+    xaxis2: { domain: [0, 0.94], anchor: "y3", matches: "x3" },
+    xaxis3: { domain: [0, 0.94], anchor: "y5" },
+    yaxis: { domain: [0.7, 1.0], anchor: "x", title: { text: "Temperature" } },
+    yaxis2: { anchor: "x", overlaying: "y", side: "right" },
+    yaxis3: { domain: [0.35, 0.65], anchor: "x2", title: { text: "Pressure" } },
+    yaxis4: { anchor: "x2", overlaying: "y3", side: "right" },
+    yaxis5: { domain: [0, 0.3], anchor: "x3", title: { text: "Wind" } },
+  },
+});
+
+// Two columns side by side, shared y-domain.
+const horizontalStrip = () => ({
+  data: [
+    { name: "A", xaxis: "x", yaxis: "y" },
+    { name: "B", xaxis: "x2", yaxis: "y2" },
+  ],
+  layout: {
+    xaxis: { domain: [0, 0.45] },
+    xaxis2: { domain: [0.55, 1.0] },
+    yaxis: { domain: [0, 1], anchor: "x" },
+    yaxis2: { domain: [0, 1], anchor: "x2" },
+  },
+});
+
+// 2x2 grid -> no canonical reflow.
+const grid2x2 = () => ({
+  data: [
+    { name: "TL", xaxis: "x", yaxis: "y" },
+    { name: "TR", xaxis: "x2", yaxis: "y2" },
+    { name: "BL", xaxis: "x3", yaxis: "y3" },
+    { name: "BR", xaxis: "x4", yaxis: "y4" },
+  ],
+  layout: {
+    xaxis: { domain: [0, 0.45] },
+    xaxis2: { domain: [0.55, 1] },
+    xaxis3: { domain: [0, 0.45] },
+    xaxis4: { domain: [0.55, 1] },
+    yaxis: { domain: [0.55, 1] },
+    yaxis2: { domain: [0.55, 1] },
+    yaxis3: { domain: [0, 0.45] },
+    yaxis4: { domain: [0, 0.45] },
+  },
+});
+
+// --- Tests ---------------------------------------------------------------
+
+describe("axis ref helpers", () => {
+  it("converts refs to layout keys and back", () => {
+    expect(axisRefToLayoutKey("y")).toBe("yaxis");
+    expect(axisRefToLayoutKey("y3")).toBe("yaxis3");
+    expect(axisRefToLayoutKey("x")).toBe("xaxis");
+    expect(axisRefToLayoutKey("x2")).toBe("xaxis2");
+    expect(layoutKeyToAxisRef("yaxis")).toBe("y");
+    expect(layoutKeyToAxisRef("yaxis3")).toBe("y3");
+    expect(layoutKeyToAxisRef("title")).toBeNull();
+  });
+
+  it("resolves overlay chains to the base axis", () => {
+    const { layout } = verticalStackWithOverlays();
+    expect(resolveBaseAxis("y2", layout)).toBe("y"); // overlay -> base
+    expect(resolveBaseAxis("y", layout)).toBe("y"); // base -> itself
+    expect(resolveBaseAxis("y4", layout)).toBe("y3");
+  });
+
+  it("treats overlaying:'free' as its own base and guards cycles", () => {
+    const layout = {
+      yaxis: { overlaying: "y2" },
+      yaxis2: { overlaying: "y" }, // cycle
+      yaxis3: { overlaying: "free" },
+    };
+    expect(resolveBaseAxis("y3", layout)).toBe("y3");
+    expect(() => resolveBaseAxis("y", layout)).not.toThrow();
+  });
+});
+
+describe("derivePanes", () => {
+  it("groups overlays into one pane per row and assigns member traces", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    expect(panes).toHaveLength(3);
+
+    expect(panes[0].label).toBe("Temperature");
+    expect(panes[0].traceIndices).toEqual([0, 1]); // primary + overlay traces
+    expect(panes[2].traceIndices).toEqual([4, 5]);
+
+    // Row 1 owns yaxis (primary) + yaxis2 (overlay) + its dedicated xaxis.
+    expect(panes[0].exclusiveAxisKeys.sort()).toEqual(
+      ["xaxis", "yaxis", "yaxis2"].sort(),
+    );
+    expect(panes[0].primaryYKey).toBe("yaxis");
+    expect(panes[0].rect.y).toEqual([0.7, 1.0]);
+  });
+
+  it("falls back to trace name then Subplot N for labels", () => {
+    const { data, layout } = horizontalStrip();
+    delete layout.yaxis.title;
+    const panes = derivePanes(data, layout);
+    expect(panes[0].label).toBe("A"); // first trace name
+  });
+
+  it("uses explicit labels (by axis ref or layout key) over derived labels", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout, {
+      labels: { y: "Air Temp", yaxis3: "Pressure (units)" },
+    });
+    expect(panes[0].label).toBe("Air Temp"); // matched by ref "y"
+    expect(panes[1].label).toBe("Pressure (units)"); // matched by layout key
+    expect(panes[2].label).toBe("Wind"); // no explicit -> axis title fallback
+  });
+
+  it("ignores empty explicit labels and falls back", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout, { labels: { y: "" } });
+    expect(panes[0].label).toBe("Temperature"); // axis title, not the empty override
+  });
+
+  it("does not mark a shared x-axis as exclusive to any single row", () => {
+    // Vertical stack where all rows share a single x-axis.
+    const data = [{ yaxis: "y" }, { yaxis: "y2" }];
+    const layout = {
+      xaxis: { domain: [0, 1] },
+      yaxis: { domain: [0.55, 1], anchor: "x" },
+      yaxis2: { domain: [0, 0.45], anchor: "x" },
+    };
+    const panes = derivePanes(data, layout);
+    // Neither pane should claim the shared xaxis.
+    panes.forEach((p) => expect(p.exclusiveAxisKeys).not.toContain("xaxis"));
+    expect(panes[0].exclusiveAxisKeys).toEqual(["yaxis"]);
+  });
+
+  it("treats non-cartesian traces as one pane each, no exclusive axes", () => {
+    const data = [
+      { type: "scatterpolar", subplot: "polar" },
+      { type: "scatterpolar", subplot: "polar2" },
+    ];
+    const layout = {
+      polar: { domain: { x: [0, 0.45], y: [0, 1] } },
+      polar2: { domain: { x: [0.55, 1], y: [0, 1] } },
+    };
+    const panes = derivePanes(data, layout);
+    expect(panes).toHaveLength(2);
+    expect(panes[0].kind).toBe("nonCartesian");
+    expect(panes[0].exclusiveAxisKeys).toEqual([]);
+    expect(panes[0].rect.x).toEqual([0, 0.45]);
+  });
+});
+
+describe("classifyArrangement", () => {
+  it("detects a vertical stack", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    expect(classifyArrangement(derivePanes(data, layout))).toBe("vertical");
+  });
+
+  it("detects a horizontal strip", () => {
+    const { data, layout } = horizontalStrip();
+    expect(classifyArrangement(derivePanes(data, layout))).toBe("horizontal");
+  });
+
+  it("returns none for a grid", () => {
+    const { data, layout } = grid2x2();
+    expect(classifyArrangement(derivePanes(data, layout))).toBe("none");
+  });
+
+  it("returns none for non-cartesian and for single-pane figures", () => {
+    const polar = derivePanes([{ subplot: "polar" }, { subplot: "polar2" }], {
+      polar: { domain: { x: [0, 0.45], y: [0, 1] } },
+      polar2: { domain: { x: [0.55, 1], y: [0, 1] } },
+    });
+    expect(classifyArrangement(polar)).toBe("none");
+    expect(classifyArrangement([{ rect: { x: [0, 1], y: [0, 1] } }])).toBe(
+      "none",
+    );
+  });
+});
+
+describe("reflowDomains", () => {
+  it("redistributes equal bands to fill the space with preserved gap", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    // Hide the middle row; keep rows 1 and 3.
+    const visible = [panes[0].id, panes[2].id];
+    const domains = reflowDomains(panes, visible, "vertical");
+
+    const keys = Object.keys(domains);
+    expect(keys.sort()).toEqual(["yaxis", "yaxis5"].sort());
+    // Two equal bands + one ~0.05 gap fill [0,1].
+    const bottom = domains.yaxis5;
+    const top = domains.yaxis;
+    expect(bottom[0]).toBeCloseTo(0, 6);
+    expect(top[1]).toBeCloseTo(1, 6);
+    expect(bottom[1]).toBeLessThan(top[0]); // bottom below top, gap between
+    // Bands equal size.
+    expect(top[1] - top[0]).toBeCloseTo(bottom[1] - bottom[0], 6);
+  });
+
+  it("preserves relative proportions for unequal bands", () => {
+    // Tall top (0.75 high) + short bottom (0.25 high), adjacent (no gap).
+    const panes = [
+      {
+        id: "p1",
+        kind: "cartesian",
+        primaryYKey: "yaxis",
+        primaryXKey: "xaxis",
+        rect: { x: [0, 1], y: [0.25, 1.0] },
+      },
+      {
+        id: "p2",
+        kind: "cartesian",
+        primaryYKey: "yaxis2",
+        primaryXKey: "xaxis2",
+        rect: { x: [0, 1], y: [0, 0.25] },
+      },
+    ];
+    const domains = reflowDomains(panes, ["p1", "p2"], "vertical");
+    const topSize = domains.yaxis[1] - domains.yaxis[0];
+    const botSize = domains.yaxis2[1] - domains.yaxis2[0];
+    // Original ratio 0.6 : 0.2 == 3 : 1 preserved.
+    expect(topSize / botSize).toBeCloseTo(3, 5);
+    // No gap -> they fill [0,1] exactly.
+    expect(topSize + botSize).toBeCloseTo(1, 6);
+  });
+
+  it("expands a single visible pane to the full range", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    const domains = reflowDomains(panes, [panes[1].id], "vertical");
+    expect(domains.yaxis3).toEqual([0, 1]);
+  });
+});
+
+describe("applySubplotToggle", () => {
+  it("is a no-op when all panes are visible", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const out = applySubplotToggle(data, layout, null);
+    expect(out.data).toBe(data); // same reference
+    expect(out.layout).toBe(layout);
+    expect(out.arrangement).toBe("vertical");
+  });
+
+  it("hides member traces and exclusive axes, and reflows the rest", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id, panes[2].id]);
+
+    // Middle row hidden.
+    expect(out.data[2].visible).toBe(false); // MSLP
+    expect(out.data[3].visible).toBe(false); // Solar overlay
+    expect(out.layout.yaxis3.visible).toBe(false);
+    expect(out.layout.yaxis4.visible).toBe(false);
+    expect(out.layout.xaxis2.visible).toBe(false);
+
+    // Kept rows visible and reflowed.
+    expect(out.data[0].visible).toBe(true);
+    expect(out.layout.yaxis.visible).toBe(true);
+    expect(out.layout.yaxis.domain[1]).toBeCloseTo(1, 6);
+    expect(out.layout.yaxis5.domain[0]).toBeCloseTo(0, 6);
+  });
+
+  it("makes the plot background transparent while reflowing so leftover hidden backgrounds can't cover traces", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    layout.plot_bgcolor = "white";
+    const panes = derivePanes(data, layout);
+    // Keep only the top row; hide rows 2 and 3.
+    const out = applySubplotToggle(data, layout, [panes[0].id]);
+    expect(out.layout.plot_bgcolor).toBe("rgba(0,0,0,0)");
+    // Visible row still fills the space and stays visible.
+    expect(out.layout.yaxis.domain).toEqual([0, 1]);
+    expect(out.layout.yaxis.visible).not.toBe(false);
+  });
+
+  it("neutralizes the background for a horizontal strip too", () => {
+    const { data, layout } = horizontalStrip();
+    layout.plot_bgcolor = "white";
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id]);
+    expect(out.layout.plot_bgcolor).toBe("rgba(0,0,0,0)");
+  });
+
+  it("leaves the background untouched for a grid (no reflow, no overlap)", () => {
+    const { data, layout } = grid2x2();
+    layout.plot_bgcolor = "white";
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [
+      panes[0].id,
+      panes[1].id,
+      panes[2].id,
+    ]);
+    expect(out.layout.plot_bgcolor).toBe("white");
+    expect(out.layout.yaxis4.visible).toBe(false); // BR still hidden
+  });
+
+  it("preserves the original background when all panes are visible", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    layout.plot_bgcolor = "white";
+    const out = applySubplotToggle(data, layout, null);
+    expect(out.layout.plot_bgcolor).toBe("white"); // pristine
+  });
+
+  it("never assigns a domain to overlay axes", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id]);
+    expect(out.layout.yaxis2.domain).toBeUndefined(); // overlay stays domain-less
+  });
+
+  it("does not mutate the input figure", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const out = applySubplotToggle(data, layout, [
+      derivePanes(data, layout)[0].id,
+    ]);
+    expect(data[2].visible).toBeUndefined();
+    expect(layout.yaxis3.visible).toBeUndefined();
+    expect(out.layout).not.toBe(layout);
+  });
+
+  it("degrades to visibility-only for a grid (no domain rewrite)", () => {
+    const { data, layout } = grid2x2();
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [
+      panes[0].id,
+      panes[1].id,
+      panes[2].id,
+    ]);
+    expect(out.arrangement).toBe("none");
+    expect(out.data[3].visible).toBe(false); // BR hidden
+    expect(out.layout.yaxis4.visible).toBe(false);
+    // Visible panes keep their original domains (no reflow).
+    expect(out.layout.yaxis.domain).toEqual([0.55, 1]);
+  });
+
+  it("honors an explicit arrangement override (reflow: none)", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id, panes[2].id], {
+      arrangement: "none",
+    });
+    expect(out.arrangement).toBe("none");
+    // Visible panes keep original domains despite being a stack.
+    expect(out.layout.yaxis.domain).toEqual([0.7, 1.0]);
+    expect(out.layout.yaxis5.domain).toEqual([0, 0.3]);
+  });
+});
+
+describe("annotation / shape / image association", () => {
+  // verticalStackWithOverlays + layout items anchored various ways.
+  const withItems = () => {
+    const { data, layout } = verticalStackWithOverlays();
+    layout.annotations = [
+      { text: "Temp title", xref: "x domain", yref: "y domain", x: 0, y: 1 }, // row1
+      { text: "Wind title", xref: "x3 domain", yref: "y5 domain", x: 0, y: 1 }, // row3
+      { text: "RH (overlay)", xref: "x", yref: "y2" }, // overlay -> row1
+      { text: "global", xref: "paper", yref: "paper", x: 0.5, y: 1.05 }, // unassoc
+    ];
+    layout.shapes = [
+      { type: "line", xref: "x3", yref: "y5", x0: 0, x1: 1, y0: 2, y1: 3 }, // row3 drawing
+      {
+        type: "line",
+        xref: "paper",
+        yref: "paper",
+        y0: 0,
+        y1: 1,
+        meta: { createdBy: "addVerticalLine" }, // runtime vline -> never touched
+      },
+    ];
+    layout.images = [
+      { xref: "paper", yref: "paper", x: 0, y: 1.04 }, // logo -> unassoc
+    ];
+    return { data, layout };
+  };
+
+  it("associates items to panes by axis ref (incl. overlays and domain refs)", () => {
+    const { data, layout } = withItems();
+    const panes = derivePanes(data, layout);
+    const [row1, , row3] = panes;
+    const assoc = (item) =>
+      associateItemToPane(item, panes, layout, "vertical")?.id;
+
+    expect(assoc(layout.annotations[0])).toBe(row1.id); // x/y domain
+    expect(assoc(layout.annotations[1])).toBe(row3.id); // x3/y5 domain
+    expect(assoc(layout.annotations[2])).toBe(row1.id); // overlay y2 -> y
+    expect(assoc(layout.annotations[3])).toBeUndefined(); // paper
+    expect(assoc(layout.shapes[0])).toBe(row3.id); // x3/y5 data ref
+  });
+
+  it("hides annotations/shapes of a hidden pane and leaves the rest", () => {
+    const { data, layout } = withItems();
+    const panes = derivePanes(data, layout);
+    // Hide row 3 (Wind).
+    const out = applySubplotToggle(data, layout, [panes[0].id, panes[1].id]);
+
+    expect(out.layout.annotations[1].visible).toBe(false); // Wind title
+    expect(out.layout.shapes[0].visible).toBe(false); // Wind drawing
+    // Row 1 items stay visible.
+    expect(out.layout.annotations[0].visible).toBeUndefined();
+    expect(out.layout.annotations[2].visible).toBeUndefined();
+    // Unassociated paper items untouched.
+    expect(out.layout.annotations[3].visible).toBeUndefined();
+    expect(out.layout.images[0].visible).toBeUndefined();
+  });
+
+  it("never hides the runtime vertical line", () => {
+    const { data, layout } = withItems();
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id]); // hide rows 2 & 3
+    const vline = out.layout.shapes.find(
+      (s) => s.meta?.createdBy === "addVerticalLine",
+    );
+    expect(vline.visible).toBeUndefined();
+  });
+
+  it("does not associate items anchored only to a shared axis", () => {
+    // All rows share one x-axis; an item anchored to that x (paper y) is
+    // ambiguous and must not be hidden.
+    const data = [{ yaxis: "y" }, { yaxis: "y2" }];
+    const layout = {
+      xaxis: { domain: [0, 1] },
+      yaxis: { domain: [0.55, 1], anchor: "x" },
+      yaxis2: { domain: [0, 0.45], anchor: "x" },
+      annotations: [{ text: "shared", xref: "x", yref: "paper", x: 0.5 }],
+    };
+    const panes = derivePanes(data, layout);
+    expect(
+      associateItemToPane(layout.annotations[0], panes, layout, "vertical"),
+    ).toBeNull();
+  });
+
+  it("does not mutate the input layout items", () => {
+    const { data, layout } = withItems();
+    const panes = derivePanes(data, layout);
+    applySubplotToggle(data, layout, [panes[0].id]);
+    expect(layout.annotations[1].visible).toBeUndefined();
+    expect(layout.shapes[0].visible).toBeUndefined();
+  });
+});

--- a/reactapp/__tests__/components/visualizations/subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/subplotToggle.test.js
@@ -458,3 +458,199 @@ describe("annotation / shape / image association", () => {
     expect(layout.shapes[0].visible).toBeUndefined();
   });
 });
+
+describe("branch coverage", () => {
+  it("resolveBaseAxis tolerates a missing layout (line 61)", () => {
+    expect(resolveBaseAxis("y")).toBe("y");
+    expect(resolveBaseAxis("x3", undefined)).toBe("x3");
+  });
+
+  it("derivePanes returns [] with no arguments (lines 107-110)", () => {
+    expect(derivePanes()).toEqual([]);
+  });
+
+  it("places scene and geo traces as non-cartesian panes (lines 74-75)", () => {
+    const panes = derivePanes([
+      { type: "scatter3d", scene: "scene" },
+      { type: "scattergeo", geo: "geo2" },
+      { type: "scatterpolar", subplot: "polar" },
+    ]);
+    expect(panes.map((p) => p.id)).toEqual(["np:scene", "np:geo2", "np:polar"]);
+    expect(panes.every((p) => p.kind === "nonCartesian")).toBe(true);
+  });
+
+  it("defaults cartesian refs and axis domains when absent (lines 80-85)", () => {
+    // Trace with no xaxis/yaxis -> defaults to x/y; empty layout -> [0,1] rects.
+    const panes = derivePanes([{}], {});
+    expect(panes[0].id).toBe("x|y");
+    expect(panes[0].rect.x).toEqual([0, 1]);
+    expect(panes[0].rect.y).toEqual([0, 1]);
+    expect(panes[0].primaryYKey).toBe("yaxis");
+  });
+
+  it("non-cartesian pane without a domain defaults its rect (lines 166-180)", () => {
+    const panes = derivePanes([{ scene: "scene" }], {}); // no layout.scene
+    expect(panes[0].kind).toBe("nonCartesian");
+    expect(panes[0].rect).toEqual({ x: [0, 1], y: [0, 1] });
+    expect(panes[0].exclusiveAxisKeys).toEqual([]);
+  });
+
+  it("listAxisKeys skips non-axis layout keys (line 50 filter)", () => {
+    // A non-axis top-level key ("title") must be filtered out of overlay scan.
+    const layout = {
+      title: "ignored",
+      xaxis: { domain: [0, 1] },
+      yaxis: { domain: [0.6, 1], anchor: "x" },
+      yaxis2: { domain: [0, 0.4], anchor: "x" },
+    };
+    const panes = derivePanes([{ yaxis: "y" }, { yaxis: "y2" }], layout);
+    expect(panes).toHaveLength(2);
+  });
+
+  it("classifyArrangement returns none for overlapping bands (line 220)", () => {
+    const layout = {
+      xaxis: { domain: [0, 1] },
+      yaxis: { domain: [0, 0.6], anchor: "x" },
+      yaxis2: { domain: [0.4, 1], anchor: "x" }, // overlaps yaxis
+    };
+    const panes = derivePanes([{ yaxis: "y" }, { yaxis: "y2" }], layout);
+    expect(classifyArrangement(panes)).toBe("none");
+  });
+
+  it("reflowDomains returns {} when nothing is visible (line 275)", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    expect(reflowDomains(panes, [], "vertical")).toEqual({});
+  });
+
+  it("reflowDomains splits evenly when bands sum to ~0 (lines 287-290)", () => {
+    const panes = [
+      { id: "a", kind: "cartesian", primaryYKey: "yaxis", rect: { y: [0, 0] } },
+      {
+        id: "b",
+        kind: "cartesian",
+        primaryYKey: "yaxis3",
+        rect: { y: [0, 0] },
+      },
+    ];
+    const out = reflowDomains(panes, ["a", "b"], "vertical");
+    expect(out.yaxis).toEqual([0, 0.5]);
+    expect(out.yaxis3).toEqual([0.5, 1]);
+  });
+
+  it("associateItemToPane prefers the x-axis for a horizontal strip (line 333)", () => {
+    const { data, layout } = horizontalStrip();
+    const panes = derivePanes(data, layout);
+    const item = { xref: "x2", yref: "paper" };
+    expect(associateItemToPane(item, panes, layout, "horizontal").id).toBe(
+      panes[1].id,
+    );
+  });
+
+  it("associateItemToPane returns null for items with no axis refs (lines 309-310)", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    expect(associateItemToPane({}, panes, layout, "vertical")).toBeNull();
+  });
+
+  it("applySubplotToggle no-ops with no arguments (lines 355-372)", () => {
+    const out = applySubplotToggle();
+    expect(out).toEqual({
+      data: [],
+      layout: {},
+      panes: [],
+      arrangement: "none",
+    });
+  });
+
+  it("applySubplotToggle forwards labels when deriving internally (lines 358-363)", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id], {
+      labels: { y: "Air Temp" },
+    });
+    expect(out.panes[0].label).toBe("Air Temp");
+  });
+
+  it("leaves a trace already at the target visibility untouched (line 385)", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    data[2].visible = false; // MSLP already hidden
+    const out = applySubplotToggle(data, layout, [panes0Ids(data, layout)]);
+    // Unchanged trace keeps its identity (no needless clone).
+    expect(out.data[2]).toBe(data[2]);
+    expect(out.data[2].visible).toBe(false);
+    // A sibling that did need flipping is a new object.
+    expect(out.data[3]).not.toBe(data[3]);
+    expect(out.data[3].visible).toBe(false);
+  });
+
+  it("leaves a non-array annotations/images container untouched (line 431)", () => {
+    const { data, layout } = verticalStackWithOverlays();
+    const notArray = { text: "oops, not wrapped in a list" };
+    layout.images = notArray;
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id]);
+    expect(out.layout.images).toBe(notArray); // returned as-is
+  });
+
+  it("does not mark a shared y-axis exclusive in a horizontal strip (line 188)", () => {
+    // Two columns sharing one y-axis -> usageY[y] === 2, so y is not exclusive.
+    const layout = {
+      xaxis: { domain: [0, 0.45] },
+      xaxis2: { domain: [0.55, 1] },
+      yaxis: { domain: [0, 1], anchor: "x" },
+    };
+    const panes = derivePanes(
+      [
+        { xaxis: "x", yaxis: "y" },
+        { xaxis: "x2", yaxis: "y" },
+      ],
+      layout,
+    );
+    expect(panes[0].exclusiveAxisKeys).toEqual(["xaxis"]); // y omitted (shared)
+    expect(panes[1].exclusiveAxisKeys).toEqual(["xaxis2"]);
+  });
+
+  it("clones an override target absent from the layout (line 298)", () => {
+    // Axes referenced by traces but not declared in layout.
+    const data = [
+      { xaxis: "x", yaxis: "y" },
+      { xaxis: "x2", yaxis: "y2" },
+    ];
+    const panes = derivePanes(data, {});
+    const out = applySubplotToggle(data, {}, [panes[0].id]);
+    expect(out.layout.yaxis2.visible).toBe(false); // built from {}
+    expect(out.layout.xaxis2.visible).toBe(false);
+  });
+
+  it("associateItemToPane falls through to the other axis (line 333)", () => {
+    const horiz = horizontalStrip();
+    const hPanes = derivePanes(horiz.data, horiz.layout);
+    // Horizontal but only the y-ref resolves -> byX null, falls back to byY.
+    expect(
+      associateItemToPane(
+        { xref: "paper", yref: "y2" },
+        hPanes,
+        horiz.layout,
+        "horizontal",
+      )?.id,
+    ).toBe(hPanes[1].id);
+
+    const vert = verticalStackWithOverlays();
+    const vPanes = derivePanes(vert.data, vert.layout);
+    // Vertical but only the x-ref resolves -> byY null, falls back to byX.
+    expect(
+      associateItemToPane(
+        { xref: "x2", yref: "paper" },
+        vPanes,
+        vert.layout,
+        "vertical",
+      )?.id,
+    ).toBe(vPanes[1].id);
+  });
+});
+
+// Helper: id of the first pane for a figure (keeps the line-385 test terse).
+function panes0Ids(data, layout) {
+  return derivePanes(data, layout)[0].id;
+}

--- a/reactapp/__tests__/components/visualizations/utilities.test.js
+++ b/reactapp/__tests__/components/visualizations/utilities.test.js
@@ -181,6 +181,52 @@ test("getVisualization plotly", async () => {
     data: {},
     layout: {},
     config: undefined,
+    toggle_subplots: undefined,
+    subplot_toggle: undefined,
+  });
+});
+
+test("getVisualization plotly passes through subplot toggle opt-in keys", async () => {
+  // Regression: the plotly branch must forward plugin-returned top-level
+  // `toggle_subplots`/`subplot_toggle` keys, not strip them to data/layout/config.
+  const plotData = {
+    data: [],
+    layout: {},
+    toggle_subplots: true,
+    subplot_toggle: { reflow: "vertical" },
+  };
+  server.use(
+    rest.get(
+      "http://api.test/apps/tethysdash/visualizations/get/",
+      (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({ success: true, viz_type: "plotly", data: plotData }),
+          ctx.set("Content-Type", "application/json"),
+        );
+      },
+    ),
+  );
+
+  const mockSetVizType = jest.fn();
+  const mockSetVizData = jest.fn();
+  await getVisualization({
+    setVizType: mockSetVizType,
+    setVizData: mockSetVizData,
+    sourceType: "plotly",
+    itemData: {},
+    visualizationRef: jest.fn(),
+    metadataString: "{}",
+    argsString: "{}",
+    variableInputValues: [],
+  });
+
+  expect(mockSetVizData.mock.calls[0][0]).toStrictEqual({
+    data: [],
+    layout: {},
+    config: undefined,
+    toggle_subplots: true,
+    subplot_toggle: { reflow: "vertical" },
   });
 });
 

--- a/reactapp/components/visualizations/Base.js
+++ b/reactapp/components/visualizations/Base.js
@@ -201,7 +201,17 @@ export const Visualization = memo(
             layout={vizData.layout}
             config={vizData.config}
             visualizationRef={vizRef}
-            metadata={vizMetadata}
+            metadata={{
+              ...vizMetadata,
+              // Plugin-driven subplot toggle opt-in: a plugin can enable the
+              // feature by returning these keys at the top level of its
+              // figure. Grid-item metadata (authored in the dashboard) takes
+              // precedence so it can override the plugin default later.
+              toggle_subplots:
+                vizMetadata.toggle_subplots ?? vizData.toggle_subplots,
+              subplot_toggle:
+                vizMetadata.subplot_toggle ?? vizData.subplot_toggle,
+            }}
           />
         );
       case "card":

--- a/reactapp/components/visualizations/BasePlot.js
+++ b/reactapp/components/visualizations/BasePlot.js
@@ -7,6 +7,7 @@ import {
   useCallback,
   memo,
   useContext,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -21,6 +22,11 @@ import {
   DataViewerModeContext,
 } from "components/contexts/Contexts";
 import { format } from "date-fns";
+import {
+  derivePanes,
+  applySubplotToggle,
+} from "components/visualizations/subplotToggle";
+import SubplotToggleControl from "components/visualizations/SubplotToggleControl";
 
 const Plotly = require("plotly.js-strict-dist-min");
 const Plot = createPlotlyComponent(Plotly);
@@ -367,16 +373,71 @@ const BasePlot = ({
     mode: verticalLineMode,
     value: verticalLineValue,
   } = plotlyVerticalLine;
-  const [plotLayout, setPlotLayout] = useState({
-    ...layout,
-    ...{
-      width: width,
-      height: height,
-    },
-  });
+
+  // --- Subplot show/hide (opt-in via metadata.toggle_subplots) ---
+  const subplotToggleEnabled = !!metadata.toggle_subplots;
+  const reflowOverride = metadata.subplot_toggle?.reflow;
+  const subplotLabels = metadata.subplot_toggle?.labels;
+
+  // Panes are derived from the PRISTINE figure; reflow always recomputes from
+  // these originals so toggling stays stateless/idempotent.
+  const panes = useMemo(
+    () =>
+      subplotToggleEnabled
+        ? derivePanes(data, layout, { labels: subplotLabels })
+        : [],
+    [subplotToggleEnabled, data, layout, subplotLabels],
+  );
+  const paneIdsKey = panes.map((p) => p.id).join("|");
+  const [visiblePaneIds, setVisiblePaneIds] = useState(() =>
+    panes.map((p) => p.id),
+  );
+  // Reset to all-visible whenever the underlying pane set changes (new data).
+  useEffect(() => {
+    setVisiblePaneIds(panes.map((p) => p.id));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paneIdsKey]);
+
+  const { data: plotData, layout: toggledLayout } = useMemo(
+    () =>
+      applySubplotToggle(
+        data,
+        layout,
+        subplotToggleEnabled ? visiblePaneIds : null,
+        { panes, arrangement: reflowOverride },
+      ),
+    [data, layout, subplotToggleEnabled, visiblePaneIds, panes, reflowOverride],
+  );
+
+  // Vertical-line shapes are computed in the el-gated effect below. Subplot
+  // toggle geometry does NOT depend on the plot element, so it is applied here
+  // via the memo and therefore survives resize/re-render: the effect re-runs
+  // off `toggledLayout`, which already encodes the active toggles.
+  const [verticalLineShapes, setVerticalLineShapes] = useState(null);
+  const plotLayout = useMemo(() => {
+    const merged = { ...toggledLayout, width, height };
+    if (verticalLineShapes !== null) merged.shapes = verticalLineShapes;
+    return merged;
+  }, [toggledLayout, width, height, verticalLineShapes]);
 
   // Ref to track the original vertical line shape
   const verticalLineOriginalRef = useRef(null);
+
+  const handleSubplotToggle = useCallback(
+    (paneId, checked) => {
+      setVisiblePaneIds((prev) => {
+        const next = new Set(prev);
+        if (checked) {
+          next.add(paneId);
+        } else {
+          if (prev.length <= 1) return prev; // keep at least one pane visible
+          next.delete(paneId);
+        }
+        return panes.map((p) => p.id).filter((id) => next.has(id));
+      });
+    },
+    [panes],
+  );
 
   // istanbul ignore next - functons tested separately, this is just cleanup
   useEffect(() => {
@@ -385,9 +446,11 @@ const BasePlot = ({
 
     if (!plotElement.layout) return;
 
-    // remove current vertical line shape if it exists to prevent duplicates
-    let currentShapes = plotElement.layout?.shapes || [];
-    currentShapes = currentShapes.filter(
+    // Seed from the toggle-aware shapes (so subplot show/hide visibility is
+    // preserved) and strip any prior vertical line to prevent duplicates.
+    // `.filter` returns a fresh array, so the subsequent push never mutates
+    // `toggledLayout`.
+    let currentShapes = (toggledLayout.shapes || []).filter(
       (s) => s.meta?.createdBy !== "addVerticalLine",
     );
 
@@ -405,8 +468,8 @@ const BasePlot = ({
       // short-circuit accepts unchanged.
       let xValueResolved = verticalLineValue;
       try {
-        const rawValue = JSON.parse(gridItemMetadataString)
-          ?.plotlyVerticalLine?.value;
+        const rawValue = JSON.parse(gridItemMetadataString)?.plotlyVerticalLine
+          ?.value;
         const sourceVar = checkForVariable(rawValue);
         const dateFormat = sourceVar
           ? variableInputDateFormats?.[sourceVar]
@@ -437,20 +500,12 @@ const BasePlot = ({
       };
     }
 
-    setPlotLayout((prevLayout) => ({
-      ...prevLayout,
-      ...layout,
-      ...{
-        width: width,
-        height: height,
-      },
-      shapes: currentShapes,
-    }));
+    setVerticalLineShapes(currentShapes);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     width,
     height,
-    layout,
+    toggledLayout,
     plotlyVerticalLine,
     gridItemMetadataString,
     variableInputDateFormats,
@@ -475,14 +530,24 @@ const BasePlot = ({
   );
 
   return (
-    <div ref={ref} style={{ display: "flex", height: "100%" }}>
+    <div
+      ref={ref}
+      style={{ display: "flex", height: "100%", position: "relative" }}
+    >
       <StyledPlot
         ref={visualizationRef}
-        data={data}
+        data={plotData}
         layout={plotLayout}
         config={config}
         onRelayout={handleRelayout}
       />
+      {subplotToggleEnabled && (
+        <SubplotToggleControl
+          panes={panes}
+          visiblePaneIds={visiblePaneIds}
+          onToggle={handleSubplotToggle}
+        />
+      )}
     </div>
   );
 };

--- a/reactapp/components/visualizations/SubplotToggleControl.js
+++ b/reactapp/components/visualizations/SubplotToggleControl.js
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import Form from "react-bootstrap/Form";
+import { FaLayerGroup } from "react-icons/fa";
+
+const Container = styled.div`
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const ToggleButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #333;
+  cursor: pointer;
+
+  &:hover {
+    background: #fff;
+  }
+`;
+
+const Panel = styled.div`
+  margin-top: 4px;
+  padding: 8px 10px;
+  max-height: 70%;
+  overflow-y: auto;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+`;
+
+/**
+ * Overlay control (top-right corner of the plot) that lists each toggleable
+ * subplot as a checkbox. Purely presentational: it owns only its open/closed
+ * state; pane visibility state lives in the parent (BasePlot).
+ */
+const SubplotToggleControl = ({ panes, visiblePaneIds, onToggle }) => {
+  const [open, setOpen] = useState(false);
+
+  if (!panes || panes.length < 2) return null;
+
+  const visibleSet = new Set(visiblePaneIds);
+
+  return (
+    <Container data-testid="subplot-toggle-control">
+      <ToggleButton
+        type="button"
+        aria-label="Toggle subplots"
+        aria-expanded={open}
+        title="Show/hide subplots"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <FaLayerGroup />
+      </ToggleButton>
+      {open && (
+        <Panel role="group" aria-label="Subplot visibility">
+          {panes.map((pane) => (
+            <Form.Check
+              key={pane.id}
+              type="checkbox"
+              id={`subplot-toggle-${pane.id}`}
+              label={pane.label}
+              aria-label={pane.label}
+              checked={visibleSet.has(pane.id)}
+              onChange={(e) => onToggle(pane.id, e.target.checked)}
+            />
+          ))}
+        </Panel>
+      )}
+    </Container>
+  );
+};
+
+SubplotToggleControl.propTypes = {
+  panes: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string,
+    }),
+  ),
+  visiblePaneIds: PropTypes.arrayOf(PropTypes.string),
+  onToggle: PropTypes.func.isRequired,
+};
+
+export default SubplotToggleControl;

--- a/reactapp/components/visualizations/subplotToggle.js
+++ b/reactapp/components/visualizations/subplotToggle.js
@@ -1,0 +1,451 @@
+/**
+ * Pure, framework-free helpers for deriving toggleable subplots from a Plotly
+ * figure and recomputing geometry when subplots are shown/hidden.
+ *
+ * Design contract (see docs/plans/2026-06-11-001-feat-subplot-toggle-reflow-plan.md):
+ *
+ *   - Visibility toggling is UNIVERSAL: any subplot arrangement can have its
+ *     panes identified and their member traces + axes toggled.
+ *   - Reflow (redistributing freed space) is only mathematically defined for a
+ *     1-D arrangement — a vertical stack (shared x-domain, partitioned
+ *     y-domains) or a horizontal strip (mirror). Grids, insets, overlapping
+ *     domains, and non-cartesian subplots classify as "none" and degrade to
+ *     visibility-only.
+ *
+ * Safety rails enforced here:
+ *   - Axes are NEVER deleted, only toggled `visible` and (for the reflow
+ *     dimension) given a new `domain`. This preserves `matches`/zoom-linking.
+ *   - Overlay axes (those carrying `overlaying`) never receive a `domain`;
+ *     they inherit position from their base axis.
+ *   - Reflow always recomputes from the PRISTINE layout, so it is stateless and
+ *     idempotent — callers must pass the original (unpatched) figure.
+ */
+
+const EPS = 1e-6;
+const AXIS_KEY_RE = /^([xy])axis(\d*)$/;
+
+// Transparent fill used to neutralize the plot background while subplots are
+// hidden. A `visible:false` axis still keeps its domain and its `plot_bgcolor`
+// rectangle; after reflow that rectangle overlaps the visible panes and —
+// because Plotly draws subplots in axis-index order — a higher-index hidden
+// subplot's opaque background paints over the traces of lower-index panes.
+// Collapsing the domain is unreliable (Plotly resets a too-small/equal domain
+// to the full default), so instead we make the background paint nothing.
+const TRANSPARENT = "rgba(0,0,0,0)";
+
+/** "y" -> "yaxis", "y3" -> "yaxis3", "x" -> "xaxis", "x2" -> "xaxis2". */
+export const axisRefToLayoutKey = (ref) => {
+  const letter = ref[0];
+  const num = ref.slice(1);
+  return (letter === "x" ? "xaxis" : "yaxis") + num;
+};
+
+/** "yaxis3" -> "y3", "xaxis" -> "x". Returns null for non-axis keys. */
+export const layoutKeyToAxisRef = (key) => {
+  const m = key.match(AXIS_KEY_RE);
+  return m ? m[1] + m[2] : null;
+};
+
+const listAxisKeys = (layout) =>
+  Object.keys(layout || {}).filter((k) => AXIS_KEY_RE.test(k));
+
+/**
+ * Follow an axis's `overlaying` chain to its base axis ref. An overlay
+ * (`overlaying: "y"`) resolves to the axis it overlays; `overlaying: "free"`
+ * is treated as its own base. Cycle-guarded.
+ */
+export const resolveBaseAxis = (ref, layout, seen) => {
+  seen = seen || new Set();
+  if (seen.has(ref)) return ref;
+  seen.add(ref);
+  const ax = (layout || {})[axisRefToLayoutKey(ref)];
+  if (ax && typeof ax.overlaying === "string" && ax.overlaying !== "free") {
+    return resolveBaseAxis(ax.overlaying, layout, seen);
+  }
+  return ref;
+};
+
+/**
+ * Determine which subplot a trace belongs to. Non-cartesian traces
+ * (3D/polar/geo/mapbox/ternary/smith) reference a named subplot; cartesian
+ * traces reference an x/y axis pair (defaulting to "x"/"y").
+ */
+const getTracePlacement = (trace) => {
+  if (trace.scene) return { kind: "nonCartesian", id: trace.scene };
+  if (trace.geo) return { kind: "nonCartesian", id: trace.geo };
+  if (trace.subplot) return { kind: "nonCartesian", id: trace.subplot };
+  return {
+    kind: "cartesian",
+    xref: trace.xaxis || "x",
+    yref: trace.yaxis || "y",
+  };
+};
+
+const getDomain = (layout, layoutKey, fallback) =>
+  (layout && layout[layoutKey] && layout[layoutKey].domain) || fallback;
+
+/**
+ * Identify the toggleable subplots ("panes") in a Plotly figure.
+ *
+ * Each pane groups the trace indices that share a plotting region, plus the
+ * axes exclusive to that region (which is what gets its `visible` toggled).
+ * An axis is "exclusive" only if no other pane uses it as a base — so a shared
+ * x-axis in a vertical stack is never hidden when one row is toggled off.
+ *
+ * @param {Object} [options]
+ * @param {Object<string,string>} [options.labels] - explicit pane labels keyed
+ *   by an axis reference or layout key (e.g. "y5", "yaxis5", "x3") or a
+ *   non-cartesian subplot id ("polar2"). Takes precedence over the derived
+ *   label (axis title -> first trace name -> "Subplot N").
+ * @returns {Array<{
+ *   id: string, label: string, kind: "cartesian"|"nonCartesian",
+ *   traceIndices: number[], exclusiveAxisKeys: string[],
+ *   primaryXKey: string|null, primaryYKey: string|null,
+ *   rect: { x: [number, number], y: [number, number] },
+ * }>}
+ */
+export const derivePanes = (data, layout, options) => {
+  data = data || [];
+  layout = layout || {};
+  const explicitLabels = (options && options.labels) || {};
+
+  // Group trace indices by pane key, preserving first-seen order.
+  const order = [];
+  const groups = new Map();
+  data.forEach((trace, i) => {
+    const place = getTracePlacement(trace);
+    let key;
+    let meta;
+    if (place.kind === "nonCartesian") {
+      key = `np:${place.id}`;
+      meta = { kind: "nonCartesian", subplotId: place.id };
+    } else {
+      const baseX = resolveBaseAxis(place.xref, layout);
+      const baseY = resolveBaseAxis(place.yref, layout);
+      key = `${baseX}|${baseY}`;
+      meta = { kind: "cartesian", baseX, baseY };
+    }
+    if (!groups.has(key)) {
+      groups.set(key, { ...meta, traceIndices: [] });
+      order.push(key);
+    }
+    groups.get(key).traceIndices.push(i);
+  });
+
+  // Count how many panes use each base axis ref (to detect shared axes).
+  const usageX = {};
+  const usageY = {};
+  for (const key of order) {
+    const g = groups.get(key);
+    if (g.kind !== "cartesian") continue;
+    usageX[g.baseX] = (usageX[g.baseX] || 0) + 1;
+    usageY[g.baseY] = (usageY[g.baseY] || 0) + 1;
+  }
+
+  // Map each base axis ref to its overlay axis refs (axes overlaying it).
+  const overlaysOf = (baseRef) =>
+    listAxisKeys(layout)
+      .map(layoutKeyToAxisRef)
+      .filter((r) => r !== baseRef && resolveBaseAxis(r, layout) === baseRef);
+
+  return order.map((key, idx) => {
+    const g = groups.get(key);
+    const label = (explicitKeys, fallbackKey) => {
+      for (const k of explicitKeys) {
+        if (k != null && explicitLabels[k]) return explicitLabels[k];
+      }
+      const titled =
+        layout[fallbackKey] &&
+        layout[fallbackKey].title &&
+        layout[fallbackKey].title.text;
+      const firstTraceName = data[g.traceIndices[0]]?.name;
+      return titled || firstTraceName || `Subplot ${idx + 1}`;
+    };
+
+    if (g.kind === "nonCartesian") {
+      const dom = (layout[g.subplotId] && layout[g.subplotId].domain) || {};
+      return {
+        id: key,
+        label: label([g.subplotId], g.subplotId),
+        kind: "nonCartesian",
+        traceIndices: g.traceIndices,
+        // Non-cartesian subplots have no simple layout-level `visible`; v1
+        // toggles trace visibility only and leaves the (empty) frame.
+        exclusiveAxisKeys: [],
+        primaryXKey: null,
+        primaryYKey: null,
+        rect: {
+          x: Array.isArray(dom.x) ? dom.x : [0, 1],
+          y: Array.isArray(dom.y) ? dom.y : [0, 1],
+        },
+      };
+    }
+
+    const primaryXKey = axisRefToLayoutKey(g.baseX);
+    const primaryYKey = axisRefToLayoutKey(g.baseY);
+
+    const exclusiveRefs = [];
+    if (usageY[g.baseY] === 1)
+      exclusiveRefs.push(g.baseY, ...overlaysOf(g.baseY));
+    if (usageX[g.baseX] === 1)
+      exclusiveRefs.push(g.baseX, ...overlaysOf(g.baseX));
+
+    return {
+      id: key,
+      label: label([g.baseY, primaryYKey, g.baseX, primaryXKey], primaryYKey),
+      kind: "cartesian",
+      traceIndices: g.traceIndices,
+      exclusiveAxisKeys: exclusiveRefs.map(axisRefToLayoutKey),
+      primaryXKey,
+      primaryYKey,
+      rect: {
+        x: getDomain(layout, primaryXKey, [0, 1]),
+        y: getDomain(layout, primaryYKey, [0, 1]),
+      },
+    };
+  });
+};
+
+const approxEqualDomain = (a, b) =>
+  Math.abs(a[0] - b[0]) < EPS && Math.abs(a[1] - b[1]) < EPS;
+
+const domainsOverlap = (a, b) => a[0] < b[1] - EPS && b[0] < a[1] - EPS;
+
+const allEqual = (domains) =>
+  domains.every((d) => approxEqualDomain(d, domains[0]));
+
+const pairwiseDisjoint = (domains) => {
+  for (let i = 0; i < domains.length; i++) {
+    for (let j = i + 1; j < domains.length; j++) {
+      if (domainsOverlap(domains[i], domains[j])) return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Decide whether the panes form a 1-D arrangement reflow can act on.
+ * @returns {"vertical"|"horizontal"|"none"}
+ */
+export const classifyArrangement = (panes) => {
+  if (!panes || panes.length < 2) return "none";
+  if (panes.some((p) => p.kind === "nonCartesian")) return "none";
+
+  const xs = panes.map((p) => p.rect.x);
+  const ys = panes.map((p) => p.rect.y);
+
+  if (allEqual(xs) && pairwiseDisjoint(ys)) return "vertical";
+  if (allEqual(ys) && pairwiseDisjoint(xs)) return "horizontal";
+  return "none";
+};
+
+const median = (nums) => {
+  if (!nums.length) return 0;
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+};
+
+/**
+ * Recompute base-axis domains for the visible panes along the reflow axis,
+ * proportional to each pane's ORIGINAL band size and preserving the median
+ * inter-pane gap. Overlay axes and the cross-axis are untouched.
+ *
+ * @returns {Object<string, [number, number]>} primary-axis-key -> new domain
+ */
+export const reflowDomains = (panes, visibleIds, axis) => {
+  const dim = axis === "horizontal" ? "x" : "y";
+  const keyOf = (p) => (dim === "x" ? p.primaryXKey : p.primaryYKey);
+
+  const cartesian = panes.filter((p) => p.kind === "cartesian");
+
+  // Median gap measured across ALL panes (sorted by band start).
+  const sortedAll = [...cartesian].sort(
+    (a, b) => a.rect[dim][0] - b.rect[dim][0],
+  );
+  const gaps = [];
+  for (let i = 1; i < sortedAll.length; i++) {
+    const gap = sortedAll[i].rect[dim][0] - sortedAll[i - 1].rect[dim][1];
+    if (gap > EPS) gaps.push(gap);
+  }
+  const gap = median(gaps);
+
+  const visibleSet = new Set(visibleIds);
+  const visible = sortedAll.filter((p) => visibleSet.has(p.id));
+  if (!visible.length) return {};
+
+  const sumBands = visible.reduce(
+    (acc, p) => acc + (p.rect[dim][1] - p.rect[dim][0]),
+    0,
+  );
+  const available = Math.max(0, 1 - gap * (visible.length - 1));
+
+  const result = {};
+  let cursor = 0;
+  visible.forEach((p) => {
+    const band = p.rect[dim][1] - p.rect[dim][0];
+    const size =
+      sumBands > EPS
+        ? available * (band / sumBands)
+        : available / visible.length;
+    result[keyOf(p)] = [cursor, cursor + size];
+    cursor += size + gap;
+  });
+  return result;
+};
+
+const cloneAxis = (layout, key, override) => ({
+  ...(layout[key] || {}),
+  ...override,
+});
+
+const CARTESIAN_REF_RE = /^[xy]\d*$/;
+
+/**
+ * Resolve an annotation/shape/image axis reference (e.g. "y5", "x3 domain",
+ * "paper") to the base-axis layout key of the pane it sits in, or null when it
+ * is paper-anchored or not a cartesian axis ref.
+ */
+const refToBaseLayoutKey = (ref, layout) => {
+  if (typeof ref !== "string") return null;
+  const clean = ref.replace(/ domain$/, "");
+  if (!CARTESIAN_REF_RE.test(clean)) return null; // "paper", "x unified", etc.
+  return axisRefToLayoutKey(resolveBaseAxis(clean, layout));
+};
+
+/**
+ * Associate a layout item (annotation/shape/image) to the pane it belongs to,
+ * by resolving its axis references. Ambiguous matches against a SHARED axis
+ * (more than one pane) are treated as unassociated so we never hide an item
+ * that spans panes. In a vertical stack the row (y) axis is authoritative; in a
+ * horizontal strip the column (x) axis is.
+ */
+export const associateItemToPane = (item, panes, layout, arrangement) => {
+  const xKey = refToBaseLayoutKey(item.xref, layout);
+  const yKey = refToBaseLayoutKey(item.yref, layout);
+  const unique = (key, prop) => {
+    if (!key) return null;
+    const matches = panes.filter((p) => p[prop] === key);
+    return matches.length === 1 ? matches[0] : null;
+  };
+  const byY = unique(yKey, "primaryYKey");
+  const byX = unique(xKey, "primaryXKey");
+  return arrangement === "horizontal" ? byX || byY : byY || byX;
+};
+
+/**
+ * Apply a subplot visibility selection to a figure.
+ *
+ * Recomputes everything from the PRISTINE figure passed in, so it is
+ * idempotent — callers must always pass the original `data`/`layout`, never a
+ * previously-patched result.
+ *
+ * @param {Array} data - original traces
+ * @param {Object} layout - original layout
+ * @param {Array<string>|Set<string>|null} visiblePaneIds - ids to keep visible;
+ *   null/undefined means "all visible" (no-op).
+ * @param {Object} [options]
+ * @param {Array} [options.panes] - precomputed panes (avoids re-deriving)
+ * @param {"vertical"|"horizontal"|"none"} [options.arrangement] - plugin
+ *   override that takes precedence over auto-detection (the `reflow` hint).
+ * @param {Object<string,string>} [options.labels] - explicit pane labels,
+ *   forwarded to `derivePanes` when panes are not precomputed.
+ * @returns {{ data: Array, layout: Object, panes: Array, arrangement: string }}
+ */
+export const applySubplotToggle = (data, layout, visiblePaneIds, options) => {
+  data = data || [];
+  layout = layout || {};
+  const {
+    panes: givenPanes,
+    arrangement: arrangementOverride,
+    labels,
+  } = options || {};
+  const panes = givenPanes || derivePanes(data, layout, { labels });
+  const arrangement = arrangementOverride || classifyArrangement(panes);
+
+  // Nothing to toggle, or everything visible -> return originals untouched so
+  // the initial render is pixel-identical to what the plugin produced.
+  const ids = visiblePaneIds ? Array.from(visiblePaneIds) : null;
+  const visibleSet = ids ? new Set(ids) : null;
+  const allVisible = !visibleSet || panes.every((p) => visibleSet.has(p.id));
+  if (panes.length < 2 || allVisible) {
+    return { data, layout, panes, arrangement };
+  }
+
+  const isVisible = (p) => visibleSet.has(p.id);
+
+  // Per-trace visibility.
+  const traceVisible = {};
+  panes.forEach((p) => {
+    p.traceIndices.forEach((i) => {
+      traceVisible[i] = isVisible(p);
+    });
+  });
+  const newData = data.map((t, i) =>
+    i in traceVisible && t.visible !== traceVisible[i]
+      ? { ...t, visible: traceVisible[i] }
+      : t,
+  );
+
+  // Axis overrides: visibility for exclusive axes...
+  const overrides = {};
+  panes.forEach((p) => {
+    const vis = isVisible(p);
+    p.exclusiveAxisKeys.forEach((key) => {
+      overrides[key] = { ...overrides[key], visible: vis };
+    });
+  });
+
+  // ...and reflowed domains for visible panes (1-D arrangements only).
+  const reflowed = arrangement === "vertical" || arrangement === "horizontal";
+  if (reflowed) {
+    const visibleIds = panes.filter(isVisible).map((p) => p.id);
+    const domains = reflowDomains(panes, visibleIds, arrangement);
+    Object.entries(domains).forEach(([key, domain]) => {
+      overrides[key] = { ...overrides[key], domain };
+    });
+  }
+
+  const newLayout = { ...layout };
+  Object.entries(overrides).forEach(([key, ov]) => {
+    newLayout[key] = cloneAxis(layout, key, ov);
+  });
+
+  // When reflowing, the visible panes overlap the (still-present) plot
+  // background rectangles of the hidden panes, which would paint over the
+  // traces beneath them. Make the plot background transparent so only the
+  // paper background shows through; restored automatically when all panes are
+  // visible again (this function returns the pristine layout in that case).
+  // Grids do not reflow and therefore never overlap, so their background is
+  // left untouched.
+  if (reflowed) {
+    newLayout.plot_bgcolor = TRANSPARENT;
+  }
+
+  // Hide annotations/shapes/images that belong to a hidden pane. Items
+  // anchored to a subplot's axis (data refs like "y5", or "y5 domain") follow
+  // reflow automatically, so we only ever toggle their `visible`. The runtime
+  // vertical line is never touched. Items we cannot associate (paper-anchored,
+  // spanning, or on a shared axis) are left untouched.
+  const hideItemsForHiddenPanes = (items) => {
+    if (!Array.isArray(items)) return items;
+    let changed = false;
+    const out = items.map((item) => {
+      if (item?.meta?.createdBy === "addVerticalLine") return item;
+      const pane = associateItemToPane(item, panes, layout, arrangement);
+      if (pane && !isVisible(pane) && item.visible !== false) {
+        changed = true;
+        return { ...item, visible: false };
+      }
+      return item;
+    });
+    return changed ? out : items;
+  };
+
+  if (layout.annotations)
+    newLayout.annotations = hideItemsForHiddenPanes(layout.annotations);
+  if (layout.shapes) newLayout.shapes = hideItemsForHiddenPanes(layout.shapes);
+  if (layout.images) newLayout.images = hideItemsForHiddenPanes(layout.images);
+
+  return { data: newData, layout: newLayout, panes, arrangement };
+};

--- a/reactapp/components/visualizations/subplotToggle.js
+++ b/reactapp/components/visualizations/subplotToggle.js
@@ -46,8 +46,10 @@ export const layoutKeyToAxisRef = (key) => {
   return m ? m[1] + m[2] : null;
 };
 
+// `layout` is always a real object here — the sole caller (`overlaysOf` in
+// derivePanes) runs after `layout` has been defaulted to `{}`.
 const listAxisKeys = (layout) =>
-  Object.keys(layout || {}).filter((k) => AXIS_KEY_RE.test(k));
+  Object.keys(layout).filter((k) => AXIS_KEY_RE.test(k));
 
 /**
  * Follow an axis's `overlaying` chain to its base axis ref. An overlay

--- a/reactapp/components/visualizations/utilities.js
+++ b/reactapp/components/visualizations/utilities.js
@@ -228,6 +228,9 @@ export async function getVisualization({
         data: responseData.data,
         layout: responseData.layout,
         config: responseData.config,
+        // Plugin-driven subplot toggle opt-in (top-level figure keys).
+        toggle_subplots: responseData.toggle_subplots,
+        subplot_toggle: responseData.subplot_toggle,
       });
     } else if (apiResponse.viz_type === "card") {
       setVizType("card");


### PR DESCRIPTION
# Subplot show/hide with reflow for Plotly visualizations

## Summary

Adds an opt-in control that lets dashboard viewers **show/hide individual subplots** of a Plotly figure from a checkbox menu in the corner of the plot. When subplots are hidden, the remaining ones **reflow** to fill the freed space, and each hidden subplot's traces, axes, annotations, shapes, and drawings disappear with it.

A plugin opts in with a single flag in its returned figure (`toggle_subplots: true`); the frontend derives everything else (which subplots exist, their member traces/axes, geometry, and labels) from the Plotly `layout` the plugin already produces. No backend changes.

## Motivation

CW3E surface-meteorology plots (and similar multi-panel timeseries) stack 6–7 subplots in one figure. Viewers often care about a subset at a time, but Plotly's only built-in toggle (`updatemenus`) is stateless — a static button can't recompute layout based on what *else* is currently visible, so independent N-subplot toggles with reflow aren't possible with it. This implements that interactivity client-side.

## Design

The feature splits into two capabilities with very different generality:

- **Visibility toggling is universal.** Any subplot arrangement — vertical stack, horizontal strip, grid, insets, secondary-y overlays, and non-cartesian (`polar`/`geo`/`scene`) subplots — can have its panes identified and their traces + axes toggled.
- **Reflow is only defined for a 1-D arrangement.** A vertical stack (shared x-domain, stacked y-domains) or a horizontal strip (mirror) reflows proportionally with gaps preserved. Grids, insets, overlapping, and non-cartesian layouts **degrade to visibility-only** (panes hide, no reflow) — collapsing a 2-D cell has no canonical answer.

Pane structure is **derived, not declared**: traces are grouped by their resolved axis pair (overlays fold into the axis they overlay), the row/column axis is authoritative for association, and a shared axis is never claimed by a single pane.

### Safety rails

- **Axes are never deleted** — only their `visible` flag and (for the reflow dimension) `domain` change. This preserves `matches`/zoom-linking across subplots.
- **Overlay axes never receive a domain** — they inherit position from their base axis, so right-side secondary-y axes follow reflow automatically.
- **Stateless/idempotent** — every toggle recomputes from the pristine figure, so reflow proportions never drift.
- **Resize-safe** — toggle state lives in React state and is re-applied through the layout memo, so a container resize doesn't revert it (regression-tested).
- The runtime vertical-line shape is never touched.

## Changes

**Frontend (this repo):**

| File | Change |
|------|--------|
| `reactapp/components/visualizations/subplotToggle.js` | New pure module: `derivePanes`, `classifyArrangement`, `reflowDomains`, `associateItemToPane`, `applySubplotToggle`. |
| `reactapp/components/visualizations/SubplotToggleControl.js` | New overlay UI: a corner button that expands a per-pane checkbox list. |
| `reactapp/components/visualizations/BasePlot.js` | Wires the opt-in: derives panes, holds visible-pane state, applies the toggle to data/layout, and composes it with the existing vertical-line shapes (decoupled so geometry survives resize). |
| `reactapp/components/visualizations/Base.js` | Merges plugin-returned `toggle_subplots`/`subplot_toggle` into the metadata passed to `BasePlot`. |
| `reactapp/components/visualizations/utilities.js` | `getVisualization` now forwards the plugin's top-level `toggle_subplots`/`subplot_toggle` keys (previously the plotly branch dropped any key other than data/layout/config). |
| `docs/source/plugins.rst` | Plugin-author docs under *Plotly Chart → Subplot Show/Hide Toggle*. |

**Backend:** none.

## Plugin author contract

Return the flag at the top level of the figure dict:

```python
figure = json.loads(fig.to_json())
figure["toggle_subplots"] = True
return figure
```

Optional overrides (under `subplot_toggle`):

- `reflow`: `"vertical" | "horizontal" | "none"` — force or disable reflow when auto-detection isn't right.
- `labels`: `{ "<axis ref or layout key>": "Label" }` — explicit checkbox labels (e.g. `{"y": "Temperature", "y3": "Pressure"}`); falls back to axis title → first trace name → `"Subplot N"`.

**Tying annotations/shapes/images to a subplot:** anchor them to that subplot's axes so they hide and reflow with it. Data-coordinate shapes (`xref: "x3", yref: "y5"`) already tie automatically; subplot titles should use axis-domain refs (`yref: "y5 domain"`) rather than `"paper"`. See `docs/source/plugins.rst` for the full recipe.

## Testing

- **`subplotToggle.test.js`** — pure-logic matrix: vertical stack w/ overlays, horizontal strip, grid, insets/overlap, non-cartesian, single-plot, unequal bands, explicit labels, annotation/shape/image association, plus dedicated branch-coverage cases. **100% statement/branch/function/line coverage** of the module.
- **`BasePlot.subplotToggle.test.js`** — integration: hide+reflow, overlay never gets a domain, hidden-pane annotations/shapes hidden, **resize-does-not-revert** regression guard, keep-at-least-one-visible, vertical-line coexistence.
- **`SubplotToggleControl.test.js`** — UI: collapsed-until-clicked, reflects state, emits toggle events, hidden below 2 panes.
- **`utilities.test.js`** — regression that the plotly branch forwards the opt-in keys.

All visualization suites pass; ESLint and Prettier clean.

## Notes for reviewers

- Two bugs surfaced during manual testing and shaped the final design, both documented in the plan:
  1. Hidden subplots left **white background bands** that covered traces. Collapsing the hidden axis domain was unreliable (Plotly resets a too-small/equal domain to full `[0,1]`, *worsening* the cover). Final fix: make `plot_bgcolor` transparent while reflowing so leftover hidden backgrounds paint nothing (identical look when `plot_bgcolor === paper_bgcolor`).
  2. The opt-in keys were being dropped before reaching the component — fixed in `utilities.js`.
- The full design rationale and iteration history live in `docs/plans/2026-06-11-001-feat-subplot-toggle-reflow-plan.md`.
- Toggle state is **ephemeral** (resets on reload); a persisted, editor-configurable default is a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
