### PR TITLE
better main.js handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,12 @@ npm run build
 
 ### Serving the built frontend in development
 
-The production build emits content-hashed filenames (e.g. `main.<hash>.js`) and a `manifest.json` mapping logical names to the hashed files. When `DEBUG=True`, the Tethys server normally references the unhashed `main.js` served from memory by the webpack dev server. If you want to serve the *built* bundle directly from the Tethys server (e.g. at `localhost:8000`) without running the webpack dev server or disabling `DEBUG`, set the `TETHYSDASH_SERVE_BUILT_FRONTEND` environment variable when starting the server:
+The production build emits content-hashed filenames (e.g. `main.<hash>.js`) and a `manifest.json` mapping logical names to the hashed files. Mode detection is automatic:
 
-```
-TETHYSDASH_SERVE_BUILT_FRONTEND=true tethys manage start
-```
+- **Hit Django directly** (e.g. `localhost:8000/apps/tethysdash/`) → the page loads the hashed bundle named in `manifest.json`, served straight from the app's `public/frontend/` directory.
+- **Hit the webpack dev server** (e.g. `localhost:8080`) → the dev server proxies the page request to Django with an `X-Webpack-Dev-Server` header. Django detects it and renders the unhashed `main.js` URL, which the dev server serves from memory.
 
-The variable must be set in the shell that launches the server so the `runserver` child process inherits it. With it set, the page loads the hashed bundle from `manifest.json`; without it, behavior is unchanged.
+No environment variable or `DEBUG` toggle is required to switch between the two.
 
 ## Frontend Test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tethysdash"
-version = "0.19.15"
+version = "0.19.16"
 description = "A Tethys App for no code/low code web application development app"
 authors = [{ name = "Corey Krewson", email = "ckrewson@aquaveo.com" }]
 license-files = ["LICENSE"]

--- a/reactapp/config/webpack.config.js
+++ b/reactapp/config/webpack.config.js
@@ -116,12 +116,17 @@ module.exports = (env, argv) => {
       minimize: true,
     },
     devServer: {
-      proxy: {
-        "!/static/tethysdash/frontend/**": {
+      proxy: [
+        {
+          context: ["!/static/tethysdash/frontend/**"],
           target: "http://localhost:8000", // points to django dev server
           changeOrigin: true,
+          // Lets Django detect that this request was proxied through
+          // webpack-dev-server so it renders the unhashed main.js URL
+          // (served from memory) instead of the on-disk hashed bundle.
+          headers: { "X-Webpack-Dev-Server": "1" },
         },
-      },
+      ],
       open: true,
     },
   };

--- a/tethysapp/tethysdash/controllers.py
+++ b/tethysapp/tethysdash/controllers.py
@@ -65,29 +65,17 @@ _FRONTEND_DIR = os.path.join(os.path.dirname(__file__), "public", "frontend")
 _MANIFEST_PATH = os.path.join(_FRONTEND_DIR, "manifest.json")
 
 
-def _get_main_bundle_path():
+def _get_main_bundle_path(request):
     """Resolve the entry bundle path under the app's public dir.
 
-    The production webpack build emits ``main.<contenthash>.js`` and a
-    ``manifest.json`` mapping logical names to hashed filenames. In dev
-    (``DEBUG=True``) webpack-dev-server serves an unhashed ``main.js`` from
-    memory, so we normally reference that name and ignore any stale manifest
-    left over from a prior production build.
-
-    Set the ``TETHYSDASH_SERVE_BUILT_FRONTEND`` env var (``1``/``true``/``yes``)
-    to serve the on-disk hashed bundle from ``manifest.json`` even when
-    ``DEBUG=True``. This lets the built frontend be served straight from Django
-    (e.g. at ``localhost:8000``) without running webpack-dev-server or disabling
-    DEBUG.
-
-    Returns:
-        str: Relative path like ``"frontend/main.abc123.js"`` for use with
-        Tethys' ``public`` template filter.
+    Production builds emit ``main.<contenthash>.js`` and a ``manifest.json``
+    mapping logical names to hashed filenames. When webpack-dev-server proxies
+    a request to Django it injects ``X-Webpack-Dev-Server: 1``; that signals
+    Django to render the unhashed ``main.js`` URL, which the dev-server then
+    serves from memory. Direct hits to Django (no header) get the hashed
+    bundle from the manifest, served straight from disk.
     """
-    serve_built = os.environ.get(
-        "TETHYSDASH_SERVE_BUILT_FRONTEND", ""
-    ).lower() in ("1", "true", "yes")
-    if settings.DEBUG and not serve_built:
+    if request.headers.get("X-Webpack-Dev-Server"):
         return "frontend/main.js"
     try:
         with open(_MANIFEST_PATH) as f:
@@ -115,7 +103,7 @@ def home(request):
     return App.render(
         request,
         "index.html",
-        context={"main_bundle_path": _get_main_bundle_path()},
+        context={"main_bundle_path": _get_main_bundle_path(request)},
     )
 
 

--- a/tethysapp/tethysdash/tests/integrated_tests/test_controllers.py
+++ b/tethysapp/tethysdash/tests/integrated_tests/test_controllers.py
@@ -2492,26 +2492,31 @@ def test_update_visualization_permissions_error(client, admin_user, mock_app, mo
     )
 
 
-@override_settings(DEBUG=True)
-def test_get_main_bundle_path_debug():
-    assert _get_main_bundle_path() == "frontend/main.js"
+def _request_with_headers(headers=None):
+    request = MagicMock()
+    request.headers = headers or {}
+    return request
 
 
-@override_settings(DEBUG=False)
+def test_get_main_bundle_path_dev_server_header():
+    request = _request_with_headers({"X-Webpack-Dev-Server": "1"})
+    assert _get_main_bundle_path(request) == "frontend/main.js"
+
+
 def test_get_main_bundle_path_manifest_not_found():
+    request = _request_with_headers()
     with patch("builtins.open", side_effect=FileNotFoundError):
-        assert _get_main_bundle_path() == "frontend/main.js"
+        assert _get_main_bundle_path(request) == "frontend/main.js"
 
 
-@override_settings(DEBUG=False)
 def test_get_main_bundle_path_manifest_invalid_json():
+    request = _request_with_headers()
     with patch("builtins.open", mock_open(read_data="not json")):
-        assert _get_main_bundle_path() == "frontend/main.js"
+        assert _get_main_bundle_path(request) == "frontend/main.js"
 
 
-@override_settings(DEBUG=True)
-def test_get_main_bundle_path_debug_serve_built_override():
+def test_get_main_bundle_path_returns_hashed_from_manifest():
+    request = _request_with_headers()
     manifest = json.dumps({"main.js": "main.abc123.js"})
-    with patch.dict(os.environ, {"TETHYSDASH_SERVE_BUILT_FRONTEND": "true"}):
-        with patch("builtins.open", mock_open(read_data=manifest)):
-            assert _get_main_bundle_path() == "frontend/main.abc123.js"
+    with patch("builtins.open", mock_open(read_data=manifest)):
+        assert _get_main_bundle_path(request) == "frontend/main.abc123.js"


### PR DESCRIPTION
## Summary

Replaces the `TETHYSDASH_SERVE_BUILT_FRONTEND` env var with automatic dev-server detection via a proxy header. The Tethys server now picks the right `main.js` URL based on how the request arrived — no env vars, no `DEBUG` toggle, no remembering which mode you're in.

## Why

The current setup forces users to opt into "serve the built frontend" mode with an env var:

```bash
TETHYSDASH_SERVE_BUILT_FRONTEND=true tethys manage start
```

That's confusing — most users just want `localhost:8000/apps/tethysdash/` to load the built bundle and `localhost:8080` (webpack dev server) to load the in-memory dev bundle. They shouldn't have to know which mode they're in or set anything.

## How it works

When `npm start` proxies a request to Django, it now injects an `X-Webpack-Dev-Server: 1` header. The home controller checks for that header:

- **Header present** → request came through the webpack dev server → render the unhashed `main.js` URL (the dev server serves it from memory).
- **Header absent** → direct hit on Django → render the hashed bundle name from `manifest.json` (Django serves it from `public/frontend/` on disk).

| Request | Header? | Bundle served | Served by |
|---|---|---|---|
| `localhost:8080/apps/tethysdash/` (npm start) | yes | `main.js` | webpack-dev-server (memory) |
| `localhost:8000/apps/tethysdash/` (built) | no | `main.<hash>.js` | Django (disk) |
| Kubernetes prod | no | `main.<hash>.js` | nginx → Django |

The same Django process works in all three scenarios without any configuration.

## Changes

- **`reactapp/config/webpack.config.js`** — `devServer.proxy` rewritten in the array form (object form is deprecated in webpack-dev-server v5) and adds `headers: { "X-Webpack-Dev-Server": "1" }` on proxied requests.
- **`tethysapp/tethysdash/controllers.py`** — `_get_main_bundle_path(request)` now takes the request and checks for the header. Dropped the `DEBUG` check and the env-var lookup.
- **`tethysapp/tethysdash/tests/integrated_tests/test_controllers.py`** — rewrote the four bundle-path tests around the header signal (dev-server header, missing manifest, malformed manifest, valid manifest).
- **`README.md`** — replaced the env-var section with a short explainer of the auto-detected behavior.

## Test plan

- [ ] `npm start` + `tethys manage start`, hit `localhost:8080/apps/tethysdash/` — page loads, dev-server serves `main.js`, HMR works.
- [ ] `npm run build` + `tethys manage start`, hit `localhost:8000/apps/tethysdash/` directly — page loads, hashed bundle is served from disk. No env var set.
- [ ] Existing flow on Kubernetes — deploy as usual, confirm the hashed bundle is served.
- [ ] `pytest tethysapp/tethysdash/tests/integrated_tests/test_controllers.py -k bundle_path` — all four tests pass.

## Migration note

If anyone has `TETHYSDASH_SERVE_BUILT_FRONTEND=true` set in a shell profile, dev script, or docker-compose file, it can be removed — it's no longer read.
