### PR TITLE
added some default roots for prebuilt pypi frontend

### DIFF
--- a/reactapp/__tests__/services/api/app.test.js
+++ b/reactapp/__tests__/services/api/app.test.js
@@ -2,6 +2,41 @@ import { server } from "__tests__/utilities/server";
 import { rest } from "msw";
 import appAPI from "services/api/app";
 
+describe("appAPI APP_ROOT_URL fallback", () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  test("should default APP_ROOT_URL to /apps/tethysdash/ when TETHYS_APP_ROOT_URL is undefined", async () => {
+    process.env = { ...originalEnv };
+    delete process.env.TETHYS_APP_ROOT_URL;
+    jest.resetModules();
+
+    const { default: freshAppAPI } = require("services/api/app");
+
+    let capturedUrl;
+    server.use(
+      rest.get(
+        "http://api.test/apps/tethysdash/dashboards/list/",
+        (req, res, ctx) => {
+          capturedUrl = req.url.pathname;
+          return res(
+            ctx.status(200),
+            ctx.json({ success: true, dashboards: [] }),
+          );
+        },
+      ),
+    );
+
+    const response = await freshAppAPI.listDashboards();
+    expect(capturedUrl).toBe("/apps/tethysdash/dashboards/list/");
+    expect(response.success).toBe(true);
+  });
+});
+
 describe("appAPI", () => {
   test("downloadJSON replaces HTML entities in response data", async () => {
     server.use(

--- a/reactapp/__tests__/services/utilities.test.js
+++ b/reactapp/__tests__/services/utilities.test.js
@@ -221,6 +221,24 @@ describe("utilities", () => {
     });
   });
 
+  describe("undefined env var fallbacks", () => {
+    test("getTethysAppRoot should default TETHYS_APP_ROOT_URL to /apps/tethysdash/ when undefined", () => {
+      delete process.env.TETHYS_APP_ROOT_URL;
+      process.env.TETHYS_PREFIX_URL = "";
+
+      const result = getTethysAppRoot();
+      expect(result).toBe("/apps/tethysdash/");
+    });
+
+    test("getTethysAppRoot should default TETHYS_APP_ROOT_URL to /apps/tethysdash/ with a prefix when undefined", () => {
+      delete process.env.TETHYS_APP_ROOT_URL;
+      process.env.TETHYS_PREFIX_URL = "/tethys/";
+
+      const result = getTethysAppRoot();
+      expect(result).toBe("/tethys/apps/tethysdash/");
+    });
+  });
+
   describe("Integration tests", () => {
     test("should work together - full workflow with derived host", () => {
       // Setup environment without explicit host

--- a/reactapp/services/api/app.js
+++ b/reactapp/services/api/app.js
@@ -1,6 +1,6 @@
 import apiClient from "services/api/client";
 
-const APP_ROOT_URL = process.env.TETHYS_APP_ROOT_URL;
+const APP_ROOT_URL = process.env.TETHYS_APP_ROOT_URL ?? "/apps/tethysdash/";
 
 function replaceHtmlEntitiesInExpressions(obj) {
   const replacements = {

--- a/reactapp/services/utilities.js
+++ b/reactapp/services/utilities.js
@@ -19,7 +19,10 @@ export const getPublicUrl = (uuid) => {
 
 export function getTethysPortalBase() {
   let tethys_portal_host = getTethysPortalHost();
-  let tethys_prefix_url = (process.env.TETHYS_PREFIX_URL || "").replace(/^\/|\/$/g, "");
+  let tethys_prefix_url = (process.env.TETHYS_PREFIX_URL || "").replace(
+    /^\/|\/$/g,
+    "",
+  );
   let baseUrl = tethys_portal_host;
   if (tethys_prefix_url) {
     baseUrl += `/${tethys_prefix_url}`;
@@ -30,8 +33,12 @@ export function getTethysPortalBase() {
 }
 
 export function getTethysAppRoot() {
-  let tethys_app_root_url = process.env.TETHYS_APP_ROOT_URL ?? "/apps/tethysdash/";
-  let tethys_prefix_url = (process.env.TETHYS_PREFIX_URL || "").replace(/^\/|\/$/g, "");
+  let tethys_app_root_url =
+    process.env.TETHYS_APP_ROOT_URL ?? "/apps/tethysdash/";
+  let tethys_prefix_url = (process.env.TETHYS_PREFIX_URL || "").replace(
+    /^\/|\/$/g,
+    "",
+  );
   let fp = `/${tethys_prefix_url}/${tethys_app_root_url}`;
   return fp.replace(/\/{2,}/g, "/");
 }

--- a/reactapp/services/utilities.js
+++ b/reactapp/services/utilities.js
@@ -19,7 +19,7 @@ export const getPublicUrl = (uuid) => {
 
 export function getTethysPortalBase() {
   let tethys_portal_host = getTethysPortalHost();
-  let tethys_prefix_url = process.env.TETHYS_PREFIX_URL.replace(/^\/|\/$/g, "");
+  let tethys_prefix_url = (process.env.TETHYS_PREFIX_URL || "").replace(/^\/|\/$/g, "");
   let baseUrl = tethys_portal_host;
   if (tethys_prefix_url) {
     baseUrl += `/${tethys_prefix_url}`;
@@ -30,8 +30,8 @@ export function getTethysPortalBase() {
 }
 
 export function getTethysAppRoot() {
-  let tethys_app_root_url = process.env.TETHYS_APP_ROOT_URL;
-  let tethys_prefix_url = process.env.TETHYS_PREFIX_URL.replace(/^\/|\/$/g, "");
+  let tethys_app_root_url = process.env.TETHYS_APP_ROOT_URL ?? "/apps/tethysdash/";
+  let tethys_prefix_url = (process.env.TETHYS_PREFIX_URL || "").replace(/^\/|\/$/g, "");
   let fp = `/${tethys_prefix_url}/${tethys_app_root_url}`;
   return fp.replace(/\/{2,}/g, "/");
 }


### PR DESCRIPTION
## Summary

- Fix blank page crash when TethysDash is installed via `pip install tethysdash` by adding defensive fallbacks for `process.env` variables that `dotenv-webpack` may not have replaced at build time
- `process.env.TETHYS_PREFIX_URL` and `process.env.TETHYS_APP_ROOT_URL` are baked into the JS bundle during `npm run build` — when the prebuilt bundle from PyPI skips that step, these remain `undefined` in the browser, and calling `.replace()` on `undefined` crashes the app before React mounts
- Adds `?? "/apps/tethysdash/"` for `TETHYS_APP_ROOT_URL` and `|| ""` for `TETHYS_PREFIX_URL` in `utilities.js` and `app.js`, matching the pattern already used in `AppTour.js`, `Header.js`, and `VisualizationCard.js`

## Changes

| File | Change |
|------|--------|
| `reactapp/services/utilities.js` | Add `?? "/apps/tethysdash/"` fallback for `TETHYS_APP_ROOT_URL` and `\|\| ""` fallback for `TETHYS_PREFIX_URL` in `getTethysPortalBase()` and `getTethysAppRoot()` |
| `reactapp/services/api/app.js` | Add `?? "/apps/tethysdash/"` fallback for module-level `APP_ROOT_URL` |
| `reactapp/__tests__/services/utilities.test.js` | Add tests for `getTethysAppRoot()` when `TETHYS_APP_ROOT_URL` is undefined (with and without prefix) |
| `reactapp/__tests__/services/api/app.test.js` | Add test verifying `APP_ROOT_URL` defaults to `/apps/tethysdash/` when env var is undefined (uses `jest.resetModules()` to re-evaluate the module-level constant) |

## Test plan

- [x] Existing tests pass (`npm run test` — 47/47 in affected files)
- [ ] Install via `pip install tethysdash` in a clean environment and confirm the app loads at `/apps/tethysdash/`
- [ ] Verify no regression when env vars ARE set (standard `npm run build` with `production.env`)
