### PR TITLE
feat(dashboard): add per-grid-item fill viewport setting

### DIFF
--- a/reactapp/__tests__/components/dashboard/DashboardItem.test.js
+++ b/reactapp/__tests__/components/dashboard/DashboardItem.test.js
@@ -1651,6 +1651,197 @@ test("Dashboard attribution and not show", async () => {
   ).not.toBeInTheDocument();
 });
 
+test("Dashboard Item fill viewport fills the content area in view mode", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  const gridItem = mockedDashboard.tabs[0].gridItems[0];
+  gridItem.metadata_string = JSON.stringify({ fillViewport: true });
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 0,
+              enableFillViewport: true,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+      },
+    }),
+  );
+
+  const dashboardGridItem = await screen.findByLabelText("gridItemDiv");
+  // position:fixed escapes the react-grid-layout-positioned parent so the item
+  // spans the content area independent of grid units / screen size.
+  await waitFor(() => {
+    expect(
+      window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
+    ).toBe("fixed");
+  });
+  const styles = window.getComputedStyle(dashboardGridItem);
+  // Spans the full content width; height is derived in pure CSS from the header
+  // variable (no screen-size math), so the size is screen-independent.
+  expect(styles.getPropertyValue("width")).toBe("100vw");
+  expect(styles.getPropertyValue("left")).toBe("0px");
+  expect(
+    screen.queryByLabelText("fill-viewport-indicator"),
+  ).not.toBeInTheDocument();
+});
+
+test("Dashboard Item fill viewport shows grid size with indicator while editing", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  const gridItem = mockedDashboard.tabs[0].gridItems[0];
+  gridItem.metadata_string = JSON.stringify({ fillViewport: true });
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 0,
+              enableFillViewport: true,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+        inEditing: true,
+      },
+    }),
+  );
+
+  const dashboardGridItem = await screen.findByLabelText("gridItemDiv");
+  expect(await screen.findByTestId("editing")).toHaveTextContent("editing");
+  // In edit mode the item keeps grid sizing (not fixed) so it stays editable.
+  expect(
+    window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
+  ).not.toBe("fixed");
+  // An indicator tells the creator the setting is active even though it is not
+  // rendered full-size while editing.
+  expect(
+    await screen.findByLabelText("fill-viewport-indicator"),
+  ).toBeInTheDocument();
+});
+
+test("Dashboard Item fill viewport suppressed when not enabled (popup reuse)", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  const gridItem = mockedDashboard.tabs[0].gridItems[0];
+  gridItem.metadata_string = JSON.stringify({ fillViewport: true });
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 0,
+              enableFillViewport: false,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+      },
+    }),
+  );
+
+  const dashboardGridItem = await screen.findByLabelText("gridItemDiv");
+  // enableFillViewport=false (e.g. the popup modal / editor) must not fill.
+  expect(
+    window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
+  ).not.toBe("fixed");
+});
+
+test("Dashboard Item only the first fill item fills the viewport", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  mockedDashboard.tabs[0].gridItems = [
+    {
+      id: 1,
+      uuid: "some-uuid-1",
+      i: "1",
+      x: 0,
+      y: 0,
+      w: 20,
+      h: 20,
+      source: "",
+      args_string: "{}",
+      metadata_string: JSON.stringify({ fillViewport: true }),
+    },
+    {
+      id: 2,
+      uuid: "some-uuid-2",
+      i: "2",
+      x: 0,
+      y: 0,
+      w: 20,
+      h: 20,
+      source: "",
+      args_string: "{}",
+      metadata_string: JSON.stringify({ fillViewport: true }),
+    },
+  ];
+  const gridItem = mockedDashboard.tabs[0].gridItems[1];
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 1,
+              enableFillViewport: true,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+      },
+    }),
+  );
+
+  const dashboardGridItem = await screen.findByLabelText("gridItemDiv");
+  // The second fill item falls back to grid sizing — only the first wins.
+  expect(
+    window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
+  ).not.toBe("fixed");
+});
+
 test("handleGridItemExport", async () => {
   const gridItem = {
     i: "1",

--- a/reactapp/__tests__/components/dashboard/DashboardItem.test.js
+++ b/reactapp/__tests__/components/dashboard/DashboardItem.test.js
@@ -1842,6 +1842,176 @@ test("Dashboard Item only the first fill item fills the viewport", async () => {
   ).not.toBe("fixed");
 });
 
+test("Dashboard Item fill viewport skips siblings with unparseable metadata", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  mockedDashboard.tabs[0].gridItems = [
+    {
+      id: 1,
+      uuid: "some-uuid-1",
+      i: "1",
+      x: 0,
+      y: 0,
+      w: 20,
+      h: 20,
+      source: "",
+      args_string: "{}",
+      // Malformed metadata — the first-fill lookup must swallow the parse
+      // error and keep scanning rather than throwing.
+      metadata_string: "not valid json",
+    },
+    {
+      id: 2,
+      uuid: "some-uuid-2",
+      i: "2",
+      x: 0,
+      y: 0,
+      w: 20,
+      h: 20,
+      source: "",
+      args_string: "{}",
+      metadata_string: JSON.stringify({ fillViewport: true }),
+    },
+  ];
+  const gridItem = mockedDashboard.tabs[0].gridItems[1];
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 1,
+              enableFillViewport: true,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+      },
+    }),
+  );
+
+  const dashboardGridItem = await screen.findByLabelText("gridItemDiv");
+  // The unparseable first item is skipped; the valid fill item still fills.
+  await waitFor(() => {
+    expect(
+      window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
+    ).toBe("fixed");
+  });
+});
+
+test("Dashboard Item fill viewport still fills on a multi-tab dashboard", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  mockedDashboard.tabs[0].gridItems[0].metadata_string = JSON.stringify({
+    fillViewport: true,
+  });
+  // A second tab makes the tab bar visible in view mode, exercising the
+  // tab-bar-height branch of the fill-height calculation.
+  mockedDashboard.tabs.push({ id: 2, name: "Tab 2", gridItems: [] });
+  const gridItem = mockedDashboard.tabs[0].gridItems[0];
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 0,
+              enableFillViewport: true,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+      },
+    }),
+  );
+
+  const dashboardGridItem = await screen.findByLabelText("gridItemDiv");
+  await waitFor(() => {
+    expect(
+      window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
+    ).toBe("fixed");
+  });
+});
+
+test("Dashboard Item fill viewport badge marks non-first items inactive while editing", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  mockedDashboard.tabs[0].gridItems = [
+    {
+      id: 1,
+      uuid: "some-uuid-1",
+      i: "1",
+      x: 0,
+      y: 0,
+      w: 20,
+      h: 20,
+      source: "",
+      args_string: "{}",
+      metadata_string: JSON.stringify({ fillViewport: true }),
+    },
+    {
+      id: 2,
+      uuid: "some-uuid-2",
+      i: "2",
+      x: 0,
+      y: 0,
+      w: 20,
+      h: 20,
+      source: "",
+      args_string: "{}",
+      metadata_string: JSON.stringify({ fillViewport: true }),
+    },
+  ];
+  const gridItem = mockedDashboard.tabs[0].gridItems[1];
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 1,
+              enableFillViewport: true,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+        inEditing: true,
+      },
+    }),
+  );
+
+  // The second fill item shows the indicator marked inactive — the first wins.
+  const indicator = await screen.findByLabelText("fill-viewport-indicator");
+  expect(indicator).toHaveTextContent("inactive");
+});
+
 test("handleGridItemExport", async () => {
   const gridItem = {
     i: "1",

--- a/reactapp/__tests__/components/modals/DataViewer/SettingsPane.test.js
+++ b/reactapp/__tests__/components/modals/DataViewer/SettingsPane.test.js
@@ -759,6 +759,88 @@ test("SettingsPane renders PlotlySettings when visualizationRef.current.el.class
   expect(await screen.findByText(/Vertical Line/i)).toBeInTheDocument();
 });
 
+test("Settings with fill viewport", async () => {
+  render(
+    createLoadedComponent({
+      children: <TestingComponent currentSettings={{}} />,
+      options: {
+        inDataViewerMode: true,
+      },
+    }),
+  );
+
+  // Renders for any viz type (no visualizationRef), unlike Enforce Aspect Ratio
+  // which is image-only.
+  const fillViewportCheckbox = await screen.findByLabelText(
+    "Fill Viewport Input",
+  );
+  expect(fillViewportCheckbox).toBeInTheDocument();
+  expect(fillViewportCheckbox.checked).toBe(false);
+
+  await userEvent.click(fillViewportCheckbox);
+
+  expect(await screen.findByTestId("settings")).toHaveTextContent(
+    JSON.stringify({ fillViewport: true }),
+  );
+  expect(fillViewportCheckbox.checked).toBe(true);
+
+  await userEvent.click(fillViewportCheckbox);
+
+  expect(await screen.findByTestId("settings")).toHaveTextContent(
+    JSON.stringify({}),
+  );
+  expect(fillViewportCheckbox.checked).toBe(false);
+});
+
+test("Fill viewport disables aspect ratio control without losing it", async () => {
+  render(
+    createLoadedComponent({
+      children: (
+        <TestingComponent
+          visualizationRefElement={{
+            tagName: "img",
+            naturalWidth: 1,
+            naturalHeight: 2,
+          }}
+          currentSettings={{ aspectRatio: 0.5, enforceAspectRatio: true }}
+        />
+      ),
+      options: {
+        inDataViewerMode: true,
+      },
+    }),
+  );
+
+  const enforceAspectRatioInput = await screen.findByLabelText(
+    "Enforce Aspect Ratio Input",
+  );
+  expect(enforceAspectRatioInput).toBeChecked();
+  expect(enforceAspectRatioInput).not.toBeDisabled();
+
+  const fillViewportCheckbox = await screen.findByLabelText(
+    "Fill Viewport Input",
+  );
+  await userEvent.click(fillViewportCheckbox);
+
+  // Aspect ratio control becomes disabled, and its stored keys are preserved.
+  expect(enforceAspectRatioInput).toBeDisabled();
+  expect(await screen.findByTestId("settings")).toHaveTextContent(
+    JSON.stringify({
+      aspectRatio: 0.5,
+      enforceAspectRatio: true,
+      fillViewport: true,
+    }),
+  );
+
+  // Turning fill off restores the prior aspect-ratio setting unchanged.
+  await userEvent.click(fillViewportCheckbox);
+  expect(enforceAspectRatioInput).not.toBeDisabled();
+  expect(enforceAspectRatioInput).toBeChecked();
+  expect(await screen.findByTestId("settings")).toHaveTextContent(
+    JSON.stringify({ aspectRatio: 0.5, enforceAspectRatio: true }),
+  );
+});
+
 TestingComponent.propTypes = {
   visualizationRefElement: PropTypes.object,
   currentSettings: PropTypes.object,

--- a/reactapp/components/dashboard/DashboardItem.js
+++ b/reactapp/components/dashboard/DashboardItem.js
@@ -363,7 +363,7 @@ const DashboardItem = () => {
   // order renders as fill; the rest fall back to normal grid sizing.
   const isFirstFillItem = (() => {
     if (!fillViewportRequested) return false;
-    const activeGridItems = getActiveTab?.()?.gridItems ?? [];
+    const activeGridItems = getActiveTab().gridItems;
     const firstFill = activeGridItems.find((gi) => {
       try {
         return JSON.parse(gi.metadata_string)?.fillViewport;
@@ -378,7 +378,7 @@ const DashboardItem = () => {
     fillViewportRequested && isFirstFillItem && !isEditing;
   // The tab bar (44px) is shown in view mode only when more than one tab exists.
   const fillSubtract =
-    (tabs?.length ?? 0) > 1
+    tabs.length > 1
       ? "var(--ts-header-height) + 44px"
       : "var(--ts-header-height)";
 

--- a/reactapp/components/dashboard/DashboardItem.js
+++ b/reactapp/components/dashboard/DashboardItem.js
@@ -59,6 +59,35 @@ const StyledDiv = styled.div`
         ? "0 4px 8px rgba(0, 0, 0, 0.1)"
         : "none"};
   position: relative;
+  /* Fill-viewport override: escape the react-grid-layout-positioned parent via
+     position:fixed so the item spans the content area below the fixed header
+     (and tab bar when shown), independent of screen size. Kept below Bootstrap
+     modal/backdrop z-index (1040) so modals from the visualization stay usable. */
+  ${(props) =>
+    props.$fillViewport &&
+    css`
+      position: fixed;
+      top: var(--ts-header-height);
+      left: 0;
+      width: 100vw;
+      height: calc(100vh - (${props.$fillSubtract}));
+      z-index: 1020;
+    `}
+`;
+
+const FillViewportBadge = styled.div`
+  position: absolute;
+  top: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  background: rgba(0, 123, 255, 0.9);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  pointer-events: none;
+  white-space: nowrap;
 `;
 
 const InfoIconWrapper = styled.div`
@@ -284,8 +313,13 @@ export const handleGridItemImport = async (gridItem, csrf, dashboard_uuid) => {
 };
 
 const DashboardItem = () => {
-  const { gridItemSource, gridItemI, gridItemMetadataString, gridItemIndex } =
-    useContext(GridItemContext);
+  const {
+    gridItemSource,
+    gridItemI,
+    gridItemMetadataString,
+    gridItemIndex,
+    enableFillViewport,
+  } = useContext(GridItemContext);
   const { isEditing, setIsEditing } = useContext(EditingContext);
   const [showDataViewerModal, setShowDataViewerModal] = useState(false);
   const [gridItemMessage, setGridItemMessage] = useState("");
@@ -295,7 +329,7 @@ const DashboardItem = () => {
   const [gridItemStyling, setGridItemStyling] = useState(
     JSON.parse(gridItemMetadataString),
   );
-  const { getActiveTab, updateTab } = useContext(TabContext);
+  const { getActiveTab, updateTab, tabs } = useContext(TabContext);
   const { variableInputValues, setVariableInputValues } = useContext(
     VariableInputsContext,
   );
@@ -319,6 +353,34 @@ const DashboardItem = () => {
     setGridItemStyling(JSON.parse(gridItemMetadataString));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gridItemMetadataString]);
+
+  // Fill-viewport: a single item can be configured to fill the content area
+  // below the header. Only applies on the main dashboard surface, in view mode.
+  const fillViewportRequested =
+    !!gridItemStyling?.fillViewport && !!enableFillViewport;
+
+  // When more than one item on the tab has fill on, only the first in grid
+  // order renders as fill; the rest fall back to normal grid sizing.
+  const isFirstFillItem = (() => {
+    if (!fillViewportRequested) return false;
+    const activeGridItems = getActiveTab?.()?.gridItems ?? [];
+    const firstFill = activeGridItems.find((gi) => {
+      try {
+        return JSON.parse(gi.metadata_string)?.fillViewport;
+      } catch {
+        return false;
+      }
+    });
+    return firstFill?.i === gridItemI;
+  })();
+
+  const fillViewportActive =
+    fillViewportRequested && isFirstFillItem && !isEditing;
+  // The tab bar (44px) is shown in view mode only when more than one tab exists.
+  const fillSubtract =
+    (tabs?.length ?? 0) > 1
+      ? "var(--ts-header-height) + 44px"
+      : "var(--ts-header-height)";
 
   async function deleteGridItem(e) {
     if (await confirm("Are you sure you want to delete the item?")) {
@@ -456,9 +518,17 @@ const DashboardItem = () => {
         $borderProps={gridItemStyling?.border}
         $backgroundColorProps={gridItemStyling?.backgroundColor}
         $boxShadowProps={gridItemStyling?.boxShadow}
+        $fillViewport={fillViewportActive}
+        $fillSubtract={fillSubtract}
         aria-label="gridItemDiv"
         className="no-caret"
       >
+        {isEditing && fillViewportRequested && (
+          <FillViewportBadge aria-label="fill-viewport-indicator">
+            Fill Viewport
+            {isFirstFillItem ? "" : " (inactive — another item fills)"}
+          </FillViewportBadge>
+        )}
         <StyledContainer
           fluid
           className="h-100 gridVisualization"

--- a/reactapp/components/dashboard/DashboardLayout.js
+++ b/reactapp/components/dashboard/DashboardLayout.js
@@ -194,6 +194,9 @@ const DashboardLayout = ({
           gridItemIndex: index,
           gridItemUUID: item.uuid,
           shouldLoad: shouldLoad,
+          // Fill-viewport only applies on the main dashboard surface, not when
+          // this layout is reused inside the popup modal / popup editor.
+          enableFillViewport: tabId !== "popup",
         }}
       >
         <DashboardItem />

--- a/reactapp/components/modals/DataViewer/SettingsPane.js
+++ b/reactapp/components/modals/DataViewer/SettingsPane.js
@@ -170,6 +170,17 @@ function SettingsPane({
     });
   };
 
+  const onFillViewportChange = (checked) => {
+    setSettings((prev) => {
+      if (checked) {
+        return { ...prev, fillViewport: true };
+      } else {
+        const { fillViewport, ...rest } = prev;
+        return rest;
+      }
+    });
+  };
+
   const onEnforceAspectRatioChange = (checked) => {
     if (
       checked &&
@@ -226,6 +237,20 @@ function SettingsPane({
         onChange={onAttributionChange}
         divProps={{ style: { marginBottom: ".5rem" } }}
       />
+      <CheckboxInput
+        label="Fill Viewport"
+        type="checkbox"
+        value={!!settings.fillViewport}
+        onChange={onFillViewportChange}
+        divProps={{ style: { marginBottom: ".25rem" } }}
+      />
+      <small
+        className="no-caret"
+        style={{ display: "block", marginBottom: ".5rem", color: "#666" }}
+      >
+        Fills the screen below the navigation when viewed, on any screen size.
+        Covers other items on the tab.
+      </small>
       <CustomMessaging
         vizInputsValues={vizInputsValues}
         initialCustomMessaging={settings.customMessaging}
@@ -240,6 +265,7 @@ function SettingsPane({
                 type="checkbox"
                 value={!!settings.enforceAspectRatio}
                 onChange={onEnforceAspectRatioChange}
+                inputProps={{ disabled: !!settings.fillViewport }}
                 divProps={{ style: { marginBottom: "1rem" } }}
               />
             )}


### PR DESCRIPTION
Add a "Fill Viewport" toggle to the DataViewer settings pane that renders one grid item at 100% width and the full height of the dashboard content area below the top nav, on any screen size. This solves dashboards built on a large monitor overflowing on a smaller laptop.

- SettingsPane: unconditional "Fill Viewport" checkbox for all viz types, persisted in metadata_string; disables the image-only "Enforce Aspect Ratio" control while on without dropping its stored value.
- DashboardItem: position:fixed render override reusing the existing --ts-header-height variable (subtracting the tab bar when shown). Applies in view mode only; shows an indicator badge while editing. First fill item on a tab wins when several are set.
- DashboardLayout: gates fill to the main dashboard surface (tabId !== "popup") so the layout's popup/editor reuse is unaffected.

Frontend-only; metadata_string is pass-through JSON.