### PR TITLE
Added fallback_version to setuptools_scm configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ exclude = ["docs*", "tests*", "reactapp*", "claude*"]
 [tool.setuptools_scm]
 write_to = "tethysapp/tethysdash/_version.py"
 local_scheme = "no-local-version"
+fallback_version = "0.0.0"
 
 [tool.setuptools.package-data]
 # The key "" applies to all packages


### PR DESCRIPTION
This pull request adds a fallback_version for app installs in environments without git metadata such as when COPY'd into a docker image as a git submodule.