### PR TITLE
Fill viewport fix

### DIFF
--- a/reactapp/__tests__/components/inputs/RuleEditor.test.js
+++ b/reactapp/__tests__/components/inputs/RuleEditor.test.js
@@ -1084,7 +1084,7 @@ describe("RuleEditor", () => {
     );
   });
 
-  it("adds an extra AND condition when the + AND condition button is clicked", async () => {
+  it("adds an extra condition when the + condition button is clicked", async () => {
     const mockOnChange = jest.fn();
 
     render(
@@ -1100,7 +1100,7 @@ describe("RuleEditor", () => {
     );
 
     const addBtn = screen.getByRole("button", {
-      name: /add and condition/i,
+      name: /add condition/i,
     });
     fireEvent.click(addBtn);
 
@@ -1129,6 +1129,113 @@ describe("RuleEditor", () => {
         { field: "", type: "isNull", value: "", valueIsField: false },
       ],
     });
+  });
+
+  it("shows the AND/OR toggle only when a rule has extra conditions", async () => {
+    const { unmount } = render(
+      <TestingComponent
+        initialRule={{
+          geometryType: "point",
+          conditionField: "type",
+          conditionType: "=",
+          conditionValue: "gage",
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /toggle match logic/i }),
+    ).not.toBeInTheDocument();
+    unmount();
+
+    render(
+      <TestingComponent
+        initialRule={{
+          geometryType: "point",
+          conditionField: "type",
+          conditionType: "=",
+          conditionValue: "gage",
+          conditions: [{ field: "active", type: "=", value: "true" }],
+        }}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /toggle match logic/i });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("AND");
+  });
+
+  it("toggles conditionCombinator when the AND/OR label is clicked", async () => {
+    const mockOnChange = jest.fn();
+
+    render(
+      <TestingComponent
+        initialRule={{
+          geometryType: "point",
+          conditionField: "type",
+          conditionType: "=",
+          conditionValue: "gage",
+          conditions: [{ field: "active", type: "=", value: "true" }],
+        }}
+        onRuleChange={mockOnChange}
+      />,
+    );
+
+    // Default is AND; clicking flips to OR.
+    fireEvent.click(
+      screen.getByRole("button", { name: /toggle match logic/i }),
+    );
+    expect(mockOnChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ conditionCombinator: "OR" }),
+    );
+
+    // Now showing OR; clicking flips back to AND.
+    const toggle = screen.getByRole("button", { name: /toggle match logic/i });
+    expect(toggle).toHaveTextContent("OR");
+    fireEvent.click(toggle);
+    expect(mockOnChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ conditionCombinator: "AND" }),
+    );
+  });
+
+  it("uses a list value input and clears valueIsField for the 'is in' operator", async () => {
+    const mockOnChange = jest.fn();
+
+    render(
+      <TestingComponent
+        initialRule={{
+          geometryType: "point",
+          conditionField: "buildCat",
+          conditionType: "=",
+          conditionValue: "",
+          conditionValueIsField: true,
+        }}
+        onRuleChange={mockOnChange}
+      />,
+    );
+
+    const condSelect = screen.getByRole("combobox", { name: /^Condition$/i });
+    await selectEvent.select(condSelect, "is in");
+
+    expect(mockOnChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        conditionType: "in",
+        conditionValueIsField: false,
+      }),
+    );
+
+    // Value Source selector is hidden; a plain list input is shown instead.
+    expect(screen.queryByLabelText(/valuesource/i)).not.toBeInTheDocument();
+    const listInput = screen.getByLabelText("Values Input");
+    fireEvent.change(listInput, { target: { value: "0, 36, 42" } });
+
+    expect(mockOnChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        conditionType: "in",
+        conditionValue: "0, 36, 42",
+        conditionValueIsField: false,
+      }),
+    );
   });
 
   it("hides the Value input when condition is isNull or isNotNull", async () => {

--- a/reactapp/__tests__/components/inputs/dateUtils.test.js
+++ b/reactapp/__tests__/components/inputs/dateUtils.test.js
@@ -167,6 +167,7 @@ describe("isPreset", () => {
   it("returns false for dates, relative inputs, and variables", () => {
     expect(isPreset("2025-08-15T09:37:00")).toBe(false);
     expect(isPreset("now-1D")).toBe(false);
+    // eslint-disable-next-line
     expect(isPreset("${variable}")).toBe(false);
     expect(isPreset("")).toBe(false);
   });

--- a/reactapp/__tests__/components/map/LegendRenderer.test.js
+++ b/reactapp/__tests__/components/map/LegendRenderer.test.js
@@ -1365,6 +1365,78 @@ test("LegendSymbol, linestring", async () => {
   expect(lineElement).not.toHaveAttribute("stroke-dasharray");
 });
 
+test("LegendRenderer; styleJSON rule label joins extra conditions with combinator", async () => {
+  const legend = {
+    styleJSON: {
+      rules: [
+        {
+          geometryType: "point",
+          conditionField: "buildCat",
+          conditionType: "=",
+          conditionValue: "0",
+          conditionCombinator: "OR",
+          conditions: [
+            { field: "risk", type: "=", value: "high" },
+            // Malformed extra condition (missing field/type) -> empty
+            // description, exercising the falsy branch that skips it.
+            { field: "", type: "" },
+          ],
+          fill: "#f50000",
+        },
+      ],
+      default: {
+        point: {
+          fill: "#00ff00",
+        },
+      },
+    },
+    title: "test",
+  };
+  render(<LegendRenderer legend={legend} />);
+
+  // Two items (default + rule) -> multi-item list render path.
+  const items = screen.queryAllByRole("listitem");
+  expect(items).toHaveLength(2);
+
+  // The rule's extra condition (from rule.conditions[]) is joined with the
+  // OR combinator into the legend label.
+  expect(
+    screen.getByText("Point: buildCat = 0 OR risk = high"),
+  ).toBeInTheDocument();
+});
+
+test("LegendRenderer; styleJSON rule label renders all condition operators", async () => {
+  const legend = {
+    styleJSON: {
+      rules: [
+        {
+          geometryType: "point",
+          conditionField: "buildCat",
+          conditionType: "in",
+          conditionValue: "0, 36",
+          conditions: [
+            { field: "risk", type: "notIn", value: "low" },
+            { field: "name", type: "isNull" },
+            { field: "code", type: "isNotNull" },
+          ],
+          fill: "#f50000",
+        },
+      ],
+      default: {
+        point: { fill: "#00ff00" },
+      },
+    },
+    title: "test",
+  };
+  render(<LegendRenderer legend={legend} />);
+
+  expect(
+    screen.getByText(
+      "Point: buildCat in 0, 36 AND risk not in low AND name is null/empty AND code is not null/empty",
+    ),
+  ).toBeInTheDocument();
+});
+
 test("LegendSymbol, linestring with strokeDash", async () => {
   render(<LegendSymbol symbol="linestring" color="blue" strokeDash="5,5" />);
 

--- a/reactapp/__tests__/components/map/ModuleLoader.test.js
+++ b/reactapp/__tests__/components/map/ModuleLoader.test.js
@@ -845,6 +845,34 @@ describe("matchesCondition", () => {
     expect(matchesCondition(-1, "isNotNull")).toBe(true);
     expect(matchesCondition("x", "isNotNull")).toBe(true);
   });
+
+  it("handles 'in' list membership (numeric coercion)", () => {
+    expect(matchesCondition(36, "in", "0, 36, 42")).toBe(true);
+    expect(matchesCondition("36", "in", "0, 36, 42")).toBe(true);
+    expect(matchesCondition(5, "in", "0, 36, 42")).toBe(false);
+  });
+
+  it("handles 'in' list membership (string values)", () => {
+    expect(matchesCondition("high", "in", "low, high")).toBe(true);
+    expect(matchesCondition("medium", "in", "low, high")).toBe(false);
+  });
+
+  it("handles 'notIn' list membership", () => {
+    expect(matchesCondition(5, "notIn", "0, 36, 42")).toBe(true);
+    expect(matchesCondition(36, "notIn", "0, 36, 42")).toBe(false);
+  });
+
+  it("returns false for an empty or whitespace-only list", () => {
+    expect(matchesCondition(1, "in", "")).toBe(false);
+    expect(matchesCondition(1, "in", "  ,  ")).toBe(false);
+    expect(matchesCondition(1, "notIn", "")).toBe(false);
+  });
+
+  it("returns false when the list value is not a string", () => {
+    expect(matchesCondition(1, "in", 1)).toBe(false);
+    expect(matchesCondition(1, "in", undefined)).toBe(false);
+    expect(matchesCondition(1, "notIn", null)).toBe(false);
+  });
 });
 
 describe("ruleMatches", () => {
@@ -892,6 +920,54 @@ describe("ruleMatches", () => {
   it("does not match when no conditions are defined", () => {
     expect(ruleMatches({}, { type: "a" })).toBe(false);
     expect(ruleMatches({ conditions: [] }, { type: "a" })).toBe(false);
+  });
+
+  it("ORs conditions when conditionCombinator is OR", () => {
+    const rule = {
+      conditionCombinator: "OR",
+      conditionField: "buildCat",
+      conditionType: "=",
+      conditionValue: "0",
+      conditions: [{ field: "buildCat", type: "=", value: "36" }],
+    };
+    expect(ruleMatches(rule, { buildCat: 0 })).toBe(true);
+    expect(ruleMatches(rule, { buildCat: 36 })).toBe(true);
+    expect(ruleMatches(rule, { buildCat: 5 })).toBe(false);
+  });
+
+  it("ORs conditions across different fields", () => {
+    const rule = {
+      conditionCombinator: "OR",
+      conditionField: "buildCat",
+      conditionType: "=",
+      conditionValue: "0",
+      conditions: [{ field: "risk", type: "=", value: "high" }],
+    };
+    expect(ruleMatches(rule, { buildCat: 5, risk: "high" })).toBe(true);
+    expect(ruleMatches(rule, { buildCat: 0, risk: "low" })).toBe(true);
+    expect(ruleMatches(rule, { buildCat: 5, risk: "low" })).toBe(false);
+  });
+
+  it("defaults to AND when conditionCombinator is unset or invalid", () => {
+    const rule = {
+      conditionCombinator: "bogus",
+      conditionField: "type",
+      conditionType: "=",
+      conditionValue: "a",
+      conditions: [{ field: "active", type: "=", value: "true" }],
+    };
+    expect(ruleMatches(rule, { type: "a", active: "true" })).toBe(true);
+    expect(ruleMatches(rule, { type: "a", active: "false" })).toBe(false);
+  });
+
+  it("matches a rule using the 'in' list operator", () => {
+    const rule = {
+      conditionField: "buildCat",
+      conditionType: "in",
+      conditionValue: "0, 36, 42",
+    };
+    expect(ruleMatches(rule, { buildCat: 36 })).toBe(true);
+    expect(ruleMatches(rule, { buildCat: 5 })).toBe(false);
   });
 
   it("skips malformed entries in conditions[]", () => {

--- a/reactapp/__tests__/components/modals/MapLayer/StylePane.test.js
+++ b/reactapp/__tests__/components/modals/MapLayer/StylePane.test.js
@@ -641,3 +641,37 @@ test("StylePane calls getStyleFields for URL-based GeoJSON (no early bail-out)",
 
   getStyleFieldsSpy.mockRestore();
 });
+
+test("StylePane round-trips conditionCombinator and 'in' operator rules", async () => {
+  const combinatorStyle = {
+    rules: [
+      {
+        geometryType: "point",
+        conditionCombinator: "OR",
+        conditionField: "BuildCat",
+        conditionType: "in",
+        conditionValue: "0, 36, 42",
+        conditions: [{ field: "risk", type: "=", value: "high" }],
+        fill: "#ff0000",
+      },
+    ],
+    default: {},
+  };
+
+  render(<TestingComponent sourceProps={{ type: "GeoJSON" }} />);
+  const textArea = screen.getByLabelText("style-text-area");
+  fireEvent.change(textArea, {
+    target: { value: JSON.stringify(combinatorStyle) },
+  });
+
+  // Switch to rules mode; the rule (including the new fields) must survive
+  // the parse -> state -> re-serialize round-trip unchanged.
+  const rulesRadio = await screen.findByLabelText("Rule-based Editor");
+  await userEvent.click(rulesRadio);
+
+  await waitFor(() => {
+    expect(JSON.parse(screen.getByTestId("style").textContent)).toStrictEqual(
+      combinatorStyle,
+    );
+  });
+});

--- a/reactapp/components/dashboard/DashboardItem.js
+++ b/reactapp/components/dashboard/DashboardItem.js
@@ -67,10 +67,10 @@ const StyledDiv = styled.div`
     props.$fillViewport &&
     css`
       position: fixed;
-      top: var(--ts-header-height);
+      top: calc(${props.$fillOffset});
       left: 0;
       width: 100vw;
-      height: calc(100vh - (${props.$fillSubtract}));
+      height: calc(100vh - (${props.$fillOffset}));
       z-index: 1020;
     `}
 `;
@@ -376,8 +376,11 @@ const DashboardItem = () => {
 
   const fillViewportActive =
     fillViewportRequested && isFirstFillItem && !isEditing;
-  // The tab bar (44px) is shown in view mode only when more than one tab exists.
-  const fillSubtract =
+  // Offset below the header, plus the tab bar (44px) when it is shown — which in
+  // view mode is only when more than one tab exists. Used for both the top edge
+  // (so the fill starts below the tab bar) and the height (so it does not
+  // overflow the bottom).
+  const fillOffset =
     tabs.length > 1
       ? "var(--ts-header-height) + 44px"
       : "var(--ts-header-height)";
@@ -519,7 +522,7 @@ const DashboardItem = () => {
         $backgroundColorProps={gridItemStyling?.backgroundColor}
         $boxShadowProps={gridItemStyling?.boxShadow}
         $fillViewport={fillViewportActive}
-        $fillSubtract={fillSubtract}
+        $fillOffset={fillOffset}
         aria-label="gridItemDiv"
         className="no-caret"
       >

--- a/reactapp/components/inputs/RuleEditor.js
+++ b/reactapp/components/inputs/RuleEditor.js
@@ -35,7 +35,7 @@ const XButton = styled.button`
   margin-right: 4px;
 `;
 
-const AndLabel = styled.span`
+const AndLabel = styled.button`
   font-weight: 600;
   font-size: 12px;
   color: #555;
@@ -43,6 +43,11 @@ const AndLabel = styled.span`
   border: 1px solid #ccc;
   border-radius: 4px;
   background: #eef;
+  cursor: pointer;
+  &:hover {
+    background: #dde;
+    border-color: #99a;
+  }
 `;
 
 const AddConditionButton = styled.button`
@@ -171,22 +176,31 @@ const CONDITION_OPTIONS = [
   { value: "<=", label: "≤" },
   { value: ">", label: ">" },
   { value: ">=", label: "≥" },
+  { value: "in", label: "is in" },
+  { value: "notIn", label: "is not in" },
   { value: "isNull", label: "is null/empty" },
   { value: "isNotNull", label: "is not null/empty" },
 ];
 
 const VALUELESS_CONDITIONS = ["isNull", "isNotNull"];
 
+// List operators take a comma-separated list of literals; a field reference
+// as the comparison value makes no sense for them, so the value source
+// selector is hidden and the value is always a plain literal string.
+const LIST_CONDITIONS = ["in", "notIn"];
+
 const VALUE_SOURCE_OPTIONS = [
   { value: "literal", label: "Literal" },
   { value: "field", label: "Field" },
 ];
+
 
 const RULE_METADATA_KEYS = [
   "conditionField",
   "conditionType",
   "conditionValue",
   "conditionValueIsField",
+  "conditionCombinator",
   "conditions",
   "geometryType",
   "iconUrl",
@@ -814,6 +828,7 @@ function ConditionRow({
   onChange,
 }) {
   const valueless = VALUELESS_CONDITIONS.includes(type);
+  const isList = LIST_CONDITIONS.includes(type);
   const source = valueIsField ? "field" : "literal";
 
   const emit = (next) =>
@@ -845,7 +860,17 @@ function ConditionRow({
         creatable={false}
         divProps={{ style: { marginBottom: 0 } }}
       />
-      {!valueless && (
+      {!valueless && isList && (
+        <NormalInput
+          label="Values"
+          value={value || ""}
+          type="text"
+          placeholder="0, 36, 42"
+          onChange={(e) => emit({ value: e.target.value })}
+          labelProps={{ style: { marginBottom: 0 } }}
+        />
+      )}
+      {!valueless && !isList && (
         <>
           <DataSelect
             label="Value Source"
@@ -905,26 +930,29 @@ const RuleConditionEditor = ({
   const conditionValue = rule.conditionValue || "";
   const ruleName = rule.name || "";
   const extraConditions = rule.conditions || [];
+  const combinator = rule.conditionCombinator === "OR" ? "OR" : "AND";
 
   const updateFirstCondition = (next) => {
     const valueless = VALUELESS_CONDITIONS.includes(next.type);
+    const isList = LIST_CONDITIONS.includes(next.type);
     onChange({
       ...rule,
       conditionField: next.field,
       conditionType: next.type,
       conditionValue: valueless ? "" : next.value,
-      conditionValueIsField: valueless ? false : !!next.valueIsField,
+      conditionValueIsField: valueless || isList ? false : !!next.valueIsField,
     });
   };
 
   const updateExtraCondition = (i, next) => {
     const valueless = VALUELESS_CONDITIONS.includes(next.type);
+    const isList = LIST_CONDITIONS.includes(next.type);
     const conditions = [...extraConditions];
     conditions[i] = {
       field: next.field,
       type: next.type,
       value: valueless ? "" : next.value,
-      valueIsField: valueless ? false : !!next.valueIsField,
+      valueIsField: valueless || isList ? false : !!next.valueIsField,
     };
     onChange({ ...rule, conditions });
   };
@@ -935,6 +963,13 @@ const RuleConditionEditor = ({
       { field: "", type: "=", value: "" },
     ];
     onChange({ ...rule, conditions });
+  };
+
+  const toggleCombinator = () => {
+    onChange({
+      ...rule,
+      conditionCombinator: combinator === "OR" ? "AND" : "OR",
+    });
   };
 
   const removeExtraCondition = (i) => {
@@ -982,7 +1017,14 @@ const RuleConditionEditor = ({
         </ConditionRowWrapper>
         {extraConditions.map((c, i) => (
           <ConditionRowWrapper key={i}>
-            <AndLabel>AND</AndLabel>
+            <AndLabel
+              type="button"
+              onClick={toggleCombinator}
+              aria-label={`Toggle match logic, currently ${combinator}`}
+              title="Click to toggle between AND and OR"
+            >
+              {combinator}
+            </AndLabel>
             <ConditionRow
               field={c.field || ""}
               type={c.type || "="}
@@ -1006,9 +1048,9 @@ const RuleConditionEditor = ({
           <AddConditionButton
             type="button"
             onClick={addExtraCondition}
-            aria-label="Add AND condition"
+            aria-label="Add condition"
           >
-            + AND condition
+            + condition
           </AddConditionButton>
         </ConditionRowWrapper>
       </Section>

--- a/reactapp/components/inputs/RuleEditor.js
+++ b/reactapp/components/inputs/RuleEditor.js
@@ -194,7 +194,6 @@ const VALUE_SOURCE_OPTIONS = [
   { value: "field", label: "Field" },
 ];
 
-
 const RULE_METADATA_KEYS = [
   "conditionField",
   "conditionType",

--- a/reactapp/components/map/LegendRenderer.js
+++ b/reactapp/components/map/LegendRenderer.js
@@ -566,6 +566,34 @@ function LegendRenderer({ legend }) {
         });
       }
     }
+    // Build a readable description for a single condition.
+    const describeCondition = (field, type, value) => {
+      if (!field || !type) return "";
+      if (type === "isNull") return `${field} is null/empty`;
+      if (type === "isNotNull") return `${field} is not null/empty`;
+      if (type === "in") return `${field} in ${value}`;
+      if (type === "notIn") return `${field} not in ${value}`;
+      return `${field} ${type} ${value}`;
+    };
+    // Join a rule's conditions (flat + extra) with its combinator word.
+    const describeConditions = (rule) => {
+      const parts = [];
+      const first = describeCondition(
+        rule.conditionField,
+        rule.conditionType,
+        rule.conditionValue,
+      );
+      if (first) parts.push(first);
+      if (Array.isArray(rule.conditions)) {
+        for (const c of rule.conditions) {
+          const part = describeCondition(c.field, c.type, c.value);
+          if (part) parts.push(part);
+        }
+      }
+      const combinator = rule.conditionCombinator === "OR" ? "OR" : "AND";
+      return parts.join(` ${combinator} `);
+    };
+
     // Rules (merge with default for geometry type)
     for (const rule of rules) {
       const geom = rule.geometryType || "point";
@@ -579,11 +607,13 @@ function LegendRenderer({ legend }) {
       const hatchSpacing = merged.hatchSpacing;
       const strokeDash = merged.strokeDash;
       const strokeWidth = merged.strokeWidth;
+      const geomLabel = geom.charAt(0).toUpperCase() + geom.slice(1);
+      const conditionText = describeConditions(rule);
       let label = rule.name
         ? rule.name
-        : rule.conditionField && rule.conditionType && rule.conditionValue
-          ? `${geom.charAt(0).toUpperCase() + geom.slice(1)}: ${rule.conditionField} ${rule.conditionType} ${rule.conditionValue}`
-          : `${geom.charAt(0).toUpperCase() + geom.slice(1)} (Rule)`;
+        : conditionText
+          ? `${geomLabel}: ${conditionText}`
+          : `${geomLabel} (Rule)`;
       const hatchDirection = merged.hatchDirection;
       const dotSpacing = merged.dotSpacing;
       const dotRadius = merged.dotRadius;

--- a/reactapp/components/map/ModuleLoader.js
+++ b/reactapp/components/map/ModuleLoader.js
@@ -417,12 +417,26 @@ export function matchesCondition(featureValue, type, conditionValue) {
     return a !== null && a !== undefined && a !== "";
   }
 
-  const b =
-    typeof conditionValue === "string" && !isNaN(conditionValue)
-      ? Number(conditionValue)
-      : conditionValue;
+  const coerce = (v) => (typeof v === "string" && !isNaN(v) ? Number(v) : v);
 
-  const av = typeof a === "string" && !isNaN(a) ? Number(a) : a;
+  const av = coerce(a);
+
+  // List membership: conditionValue is a comma-separated list of literals.
+  if (type === "in" || type === "notIn") {
+    const list =
+      typeof conditionValue === "string"
+        ? conditionValue
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s !== "")
+            .map(coerce)
+        : [];
+    if (list.length === 0) return false;
+    const found = list.includes(av);
+    return type === "in" ? found : !found;
+  }
+
+  const b = coerce(conditionValue);
 
   switch (type) {
     case "=":
@@ -492,7 +506,10 @@ export function ruleMatches(rule, properties) {
 
   if (conditions.length === 0) return false;
 
-  return conditions.every((c) => evaluateCondition(c, properties));
+  const combinator = rule.conditionCombinator === "OR" ? "OR" : "AND";
+  return combinator === "OR"
+    ? conditions.some((c) => evaluateCondition(c, properties))
+    : conditions.every((c) => evaluateCondition(c, properties));
 }
 
 export function resolveSize(feature, rules, defaultSize) {


### PR DESCRIPTION
# Layer style rules: OR combinator + "is in" operator (and viewport fill fix)

## Summary

Adds two complementary ways to express layer-styling conditions that weren't
possible before, and includes a small fix for the fill-viewport top/bottom
offset so it lines up with the tab bar.

Branch contains two logically independent changes:

1. **Style-rule matching** — OR combinator + `is in` / `is not in` operator.
2. **Fill viewport** — fix so the fixed fill element spans the correct region
   below the header/tab bar.

---

## 1. Style rules: OR combinator + list membership

### Why

Layer styling rules previously combined multiple conditions with **AND only**
(`conditions.every(...)`), and there was no list-membership operator. You
couldn't express "style if `BuildCat = 0` **or** `BuildCat = 36`", nor "style
if `BuildCat` is one of 0/36/42" without stacking many rules.

### What changed

- **Per-rule AND/OR combinator.** When a rule has more than one condition, a
  clickable **AND/OR** label appears between conditions. Clicking it toggles the
  whole rule between matching **ALL** (`.every`) and **ANY** (`.some`) of its
  conditions. This enables OR across *different* fields
  (e.g. `BuildCat = 0` OR `RiskLevel = high`).
- **`is in` / `is not in` operator.** A single condition matches against a
  comma-separated list of literals (e.g. `BuildCat is in 0, 36, 42`). The value
  input is a plain list field (no field-reference source, since a list literal
  is expected); numeric-looking entries are coerced before comparison.

Both settings persist through the existing style-JSON round-trip — the new
`conditionCombinator` key is registered as rule metadata so it is never treated
as a style property. Legend labels now join a rule's conditions with its
combinator word and render the new operators readably
(e.g. `Point: BuildCat in 0, 36, 42 OR RiskLevel = high`).

### Files

- `reactapp/components/map/ModuleLoader.js` — `matchesCondition` handles
  `in`/`notIn`; `ruleMatches` honors `conditionCombinator` (AND default, OR).
- `reactapp/components/inputs/RuleEditor.js` — new operators, clickable
  combinator toggle, list-value input, `conditionCombinator` metadata key.
- `reactapp/components/map/LegendRenderer.js` — combinator-aware, operator-aware
  legend labels.

### Not changed (by design)

`resolveSize` (threshold-based point sizing) still reads only a rule's flat
first condition and ignores extra conditions — matching its prior behavior. It
does not honor the combinator or `in`/`notIn`.

---

## 2. Fill-viewport offset fix

`fix viewport so tabs still show` — the fixed fill element now uses the same
offset for both its top edge and height, so it spans exactly from below the
header (plus the tab bar, when shown) to the bottom of the viewport. Previously
the multi-tab case reserved the tab-bar height in `height` but not `top`,
leaving a gap equal to the tab-bar height at the bottom.

File: `reactapp/components/dashboard/DashboardItem.js`.

> Note for reviewers: this fix is in the React source but the compiled bundle in
> `public/frontend/` is stale — run `npm run build` before deploying so the fix
> ships.

---

## Testing

- Unit tests added/extended across the evaluator, rule editor UI, and style-pane
  serialization:
  - `ModuleLoader.test.js` — `in`/`notIn` (numeric, string, empty and
    non-string lists), OR combinator, default-to-AND.
  - `RuleEditor.test.js` — clickable AND/OR toggle (both directions),
    visibility only with multiple conditions, `is in` value input behavior.
  - `StylePane.test.js` — `conditionCombinator` + `in` rule round-trips through
    stringify → parse unchanged.
  - `LegendRenderer.test.js` — combinator-joined labels and all operator renders.
- `ModuleLoader.js` and `LegendRenderer.js` are at **100%** statement/branch/
  function/line coverage.
- Full suite passes when run serially (`npm run test:serial`); a few unrelated
  heavy suites time out only under full parallel load.

## Manual verification

1. On a map layer, open the style editor in **rules** mode.
2. Add a rule with two conditions on different fields, click the label to switch
   to **OR**, confirm features matching *either* are styled.
3. Add a rule using **is in** with a comma list and confirm same-field
   membership styling. Check the legend labels reflect both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
