### PR TITLE
Feat/subplot toggle

### DIFF
--- a/reactapp/__tests__/components/visualizations/BasePlot.subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/BasePlot.subplotToggle.test.js
@@ -75,8 +75,20 @@ const figure = () => ({
 // own `domain` (mirrors the CW3E "MRR" figure).
 const figureWithTable = () => ({
   data: [
-    { name: "Reflectivity", type: "heatmap", xaxis: "x", yaxis: "y" }, // 0
-    { name: "Vertical Velocity", type: "heatmap", xaxis: "x", yaxis: "y3" }, // 1
+    {
+      name: "Reflectivity",
+      type: "heatmap",
+      xaxis: "x",
+      yaxis: "y",
+      colorbar: { len: 0.37, y: 0.815, yanchor: "middle" },
+    }, // 0
+    {
+      name: "Vertical Velocity",
+      type: "heatmap",
+      xaxis: "x",
+      yaxis: "y3",
+      colorbar: { len: 0.35, y: 0.425, yanchor: "middle" },
+    }, // 1
     {
       name: "MRR Table",
       type: "table",
@@ -238,6 +250,9 @@ describe("BasePlot subplot toggle", () => {
     // its bottom stays above the table band [0, 0.16] — no overlap.
     expect(layout.yaxis.domain[0]).toBeCloseTo(0.25, 6);
     expect(layout.yaxis.domain[0]).toBeGreaterThanOrEqual(0.16);
+    // Its colorbar grows to track the expanded band.
+    expect(data[0].colorbar.len).toBeCloseTo(0.75, 6);
+    expect(data[0].colorbar.y).toBeCloseTo(0.625, 6);
   });
 
   it("coexists with a vertical line without crashing", () => {

--- a/reactapp/__tests__/components/visualizations/BasePlot.subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/BasePlot.subplotToggle.test.js
@@ -71,6 +71,54 @@ const figure = () => ({
   },
 });
 
+// Two stacked heatmaps (shared x-domain) + a go.Table footer positioned by its
+// own `domain` (mirrors the CW3E "MRR" figure).
+const figureWithTable = () => ({
+  data: [
+    { name: "Reflectivity", type: "heatmap", xaxis: "x", yaxis: "y" }, // 0
+    { name: "Vertical Velocity", type: "heatmap", xaxis: "x", yaxis: "y3" }, // 1
+    {
+      name: "MRR Table",
+      type: "table",
+      domain: { x: [0, 1], y: [0, 0.16] },
+      header: {},
+      cells: {},
+    }, // 2
+  ],
+  layout: {
+    xaxis: { domain: [0, 1], anchor: "y" },
+    yaxis: {
+      domain: [0.63, 1.0],
+      anchor: "x",
+      title: { text: "Reflectivity" },
+    },
+    yaxis3: {
+      domain: [0.25, 0.6],
+      anchor: "x",
+      title: { text: "Vertical Velocity" },
+    },
+  },
+});
+
+const renderFigure = ({ data, layout }, metadata) =>
+  render(
+    <VariableInputsContext.Provider
+      value={{ variableInputDateFormats: {}, variableInputValues: {} }}
+    >
+      <GridItemContext.Provider value={{ gridItemArgsString: "{}" }}>
+        <DataViewerModeContext.Provider value={{ mode: "default" }}>
+          <BasePlot
+            data={data}
+            layout={layout}
+            config={{ responsive: true }}
+            visualizationRef={createRef()}
+            metadata={metadata}
+          />
+        </DataViewerModeContext.Provider>
+      </GridItemContext.Provider>
+    </VariableInputsContext.Provider>,
+  );
+
 const renderPlot = (metadata) => {
   const { data, layout } = figure();
   return render(
@@ -169,6 +217,27 @@ describe("BasePlot subplot toggle", () => {
 
     // Wind cannot be hidden — its traces remain visible.
     expect(global.__plotProps.data[4].visible).toBe(true);
+  });
+
+  it("does not overlap a go.Table footer when a heatmap is toggled off", () => {
+    renderFigure(figureWithTable(), { toggle_subplots: true });
+    fireEvent.click(screen.getByLabelText("Toggle subplots"));
+
+    // Only the two heatmaps are offered — the unlabeled table is not.
+    expect(screen.getByLabelText("Reflectivity")).toBeInTheDocument();
+    expect(screen.getByLabelText("Vertical Velocity")).toBeInTheDocument();
+    expect(screen.queryByLabelText("MRR Table")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Vertical Velocity")); // hide it
+
+    const { data, layout } = global.__plotProps;
+    expect(data[1].visible).toBe(false); // Vertical Velocity hidden
+    expect(data[0].visible).toBe(true); // Reflectivity still shown
+    expect(data[2].visible).not.toBe(false); // table trace never hidden
+    // The remaining heatmap expands to the cartesian envelope [0.25, 1.0] and
+    // its bottom stays above the table band [0, 0.16] — no overlap.
+    expect(layout.yaxis.domain[0]).toBeCloseTo(0.25, 6);
+    expect(layout.yaxis.domain[0]).toBeGreaterThanOrEqual(0.16);
   });
 
   it("coexists with a vertical line without crashing", () => {

--- a/reactapp/__tests__/components/visualizations/subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/subplotToggle.test.js
@@ -68,6 +68,35 @@ const grid2x2 = () => ({
   },
 });
 
+// Two vertically-stacked heatmaps (shared x-domain) + a go.Table footer that
+// positions itself with its own `domain`, mirroring the CW3E "MRR" figure.
+const verticalStackWithTable = () => ({
+  data: [
+    { name: "Reflectivity", type: "heatmap", xaxis: "x", yaxis: "y" }, // 0
+    { name: "Vertical Velocity", type: "heatmap", xaxis: "x", yaxis: "y3" }, // 1
+    {
+      name: "MRR Table",
+      type: "table",
+      domain: { x: [0, 1], y: [0, 0.16] }, // footer band
+      header: {},
+      cells: {},
+    }, // 2
+  ],
+  layout: {
+    xaxis: { domain: [0, 1], anchor: "y" },
+    yaxis: {
+      domain: [0.63, 1.0],
+      anchor: "x",
+      title: { text: "Reflectivity" },
+    },
+    yaxis3: {
+      domain: [0.25, 0.6],
+      anchor: "x",
+      title: { text: "Vertical Velocity" },
+    },
+  },
+});
+
 // --- Tests ---------------------------------------------------------------
 
 describe("axis ref helpers", () => {
@@ -367,6 +396,118 @@ describe("applySubplotToggle", () => {
   });
 });
 
+describe("domain-based traces (go.Table etc.)", () => {
+  it("classifies a go.Table as its own non-cartesian pane with the trace's domain", () => {
+    const { data, layout } = verticalStackWithTable();
+    const panes = derivePanes(data, layout);
+    expect(panes).toHaveLength(3);
+
+    const table = panes.find((p) => p.kind === "nonCartesian");
+    expect(table).toBeDefined();
+    // Its own pane — not grouped with the row-1 Reflectivity heatmap.
+    expect(table.traceIndices).toEqual([2]);
+    expect(table.id).toBe("np:domain:table:2");
+    // Rect read from the trace's own `domain`, not from `layout`.
+    expect(table.rect.y).toEqual([0, 0.16]);
+    // The Reflectivity pane keeps only its own trace.
+    const reflectivity = panes.find((p) => p.primaryYKey === "yaxis");
+    expect(reflectivity.traceIndices).toEqual([0]);
+  });
+
+  it("does not offer an unlabeled domain pane as a toggle, but labeled ones are", () => {
+    const { data, layout } = verticalStackWithTable();
+    const unlabeled = derivePanes(data, layout).find(
+      (p) => p.kind === "nonCartesian",
+    );
+    expect(unlabeled.toggleable).toBe(false);
+    // Cartesian panes stay toggleable.
+    expect(
+      derivePanes(data, layout)
+        .filter((p) => p.kind === "cartesian")
+        .every((p) => p.toggleable),
+    ).toBe(true);
+
+    // Labelled by trace type...
+    const byType = derivePanes(data, layout, {
+      labels: { table: "MRR Table" },
+    }).find((p) => p.kind === "nonCartesian");
+    expect(byType.toggleable).toBe(true);
+    expect(byType.label).toBe("MRR Table");
+
+    // ...or by pane id.
+    const byId = derivePanes(data, layout, {
+      labels: { "domain:table:2": "Footer" },
+    }).find((p) => p.kind === "nonCartesian");
+    expect(byId.toggleable).toBe(true);
+    expect(byId.label).toBe("Footer");
+  });
+
+  it("scene/geo panes stay toggleable regardless of labels", () => {
+    const panes = derivePanes([
+      { type: "scatter3d", scene: "scene" },
+      { type: "scattergeo", geo: "geo2" },
+    ]);
+    expect(panes.every((p) => p.toggleable)).toBe(true);
+  });
+
+  it("still classifies the cartesian stack as vertical, ignoring the table", () => {
+    const { data, layout } = verticalStackWithTable();
+    expect(classifyArrangement(derivePanes(data, layout))).toBe("vertical");
+  });
+
+  it("reflows only within the cartesian envelope, preserving the table band", () => {
+    const { data, layout } = verticalStackWithTable();
+    const panes = derivePanes(data, layout);
+    const reflectivity = panes.find((p) => p.primaryYKey === "yaxis");
+    const table = panes.find((p) => p.kind === "nonCartesian");
+    const tableTop = table.rect.y[1]; // 0.16
+
+    // Hide Vertical Velocity; keep Reflectivity (+ the always-visible table).
+    const domains = reflowDomains(
+      panes,
+      [reflectivity.id, table.id],
+      "vertical",
+    );
+    // The lone visible heatmap fills the cartesian envelope [0.25, 1.0], NOT
+    // [0, 1] — its bottom stays above the table band.
+    expect(domains.yaxis[0]).toBeCloseTo(0.25, 6);
+    expect(domains.yaxis[1]).toBeCloseTo(1.0, 6);
+    expect(domains.yaxis[0]).toBeGreaterThanOrEqual(tableTop);
+  });
+
+  it("keeps the table visible and unoverlapped when a heatmap is toggled off", () => {
+    const { data, layout } = verticalStackWithTable();
+    const panes = derivePanes(data, layout);
+    const reflectivity = panes.find((p) => p.primaryYKey === "yaxis");
+    const table = panes.find((p) => p.kind === "nonCartesian");
+
+    const out = applySubplotToggle(data, layout, [reflectivity.id, table.id]);
+    // Vertical Velocity hidden, Reflectivity + table still visible.
+    expect(out.data[1].visible).toBe(false);
+    expect(out.data[0].visible).toBe(true);
+    expect(out.data[2].visible).not.toBe(false); // table trace untouched
+    // Reflectivity expanded but not over the table.
+    expect(out.layout.yaxis.domain[0]).toBeCloseTo(0.25, 6);
+    expect(out.layout.yaxis.domain[0]).toBeGreaterThanOrEqual(table.rect.y[1]);
+  });
+
+  it("unions the bands of multiple domain traces", () => {
+    const data = [
+      { name: "H", type: "heatmap", xaxis: "x", yaxis: "y" },
+      { name: "T1", type: "table", domain: { x: [0, 0.5], y: [0, 0.15] } },
+      { name: "T2", type: "table", domain: { x: [0.5, 1], y: [0, 0.15] } },
+    ];
+    const layout = { xaxis: { domain: [0, 1] }, yaxis: { domain: [0.25, 1] } };
+    const panes = derivePanes(data, layout);
+    const tables = panes.filter((p) => p.kind === "nonCartesian");
+    expect(tables).toHaveLength(2); // distinct panes, distinct ids
+    expect(tables.map((p) => p.id)).toEqual([
+      "np:domain:table:1",
+      "np:domain:table:2",
+    ]);
+  });
+});
+
 describe("annotation / shape / image association", () => {
   // verticalStackWithOverlays + layout items anchored various ways.
   const withItems = () => {
@@ -524,6 +665,9 @@ describe("branch coverage", () => {
   });
 
   it("reflowDomains splits evenly when bands sum to ~0 (lines 287-290)", () => {
+    // Zero-width bands => zero-width cartesian envelope, so the even-split
+    // branch runs but there is no space to distribute; both collapse to the
+    // envelope point (here 0).
     const panes = [
       { id: "a", kind: "cartesian", primaryYKey: "yaxis", rect: { y: [0, 0] } },
       {
@@ -534,8 +678,8 @@ describe("branch coverage", () => {
       },
     ];
     const out = reflowDomains(panes, ["a", "b"], "vertical");
-    expect(out.yaxis).toEqual([0, 0.5]);
-    expect(out.yaxis3).toEqual([0.5, 1]);
+    expect(out.yaxis).toEqual([0, 0]);
+    expect(out.yaxis3).toEqual([0, 0]);
   });
 
   it("associateItemToPane prefers the x-axis for a horizontal strip (line 333)", () => {

--- a/reactapp/__tests__/components/visualizations/subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/subplotToggle.test.js
@@ -5,6 +5,7 @@ import {
   derivePanes,
   classifyArrangement,
   reflowDomains,
+  reflowColorbar,
   applySubplotToggle,
   associateItemToPane,
 } from "components/visualizations/subplotToggle";
@@ -72,8 +73,22 @@ const grid2x2 = () => ({
 // positions itself with its own `domain`, mirroring the CW3E "MRR" figure.
 const verticalStackWithTable = () => ({
   data: [
-    { name: "Reflectivity", type: "heatmap", xaxis: "x", yaxis: "y" }, // 0
-    { name: "Vertical Velocity", type: "heatmap", xaxis: "x", yaxis: "y3" }, // 1
+    {
+      name: "Reflectivity",
+      type: "heatmap",
+      xaxis: "x",
+      yaxis: "y",
+      // Colorbar sized/positioned to the row-1 band [0.63, 1.0].
+      colorbar: { len: 0.37, y: 0.815, yanchor: "middle" },
+    }, // 0
+    {
+      name: "Vertical Velocity",
+      type: "heatmap",
+      xaxis: "x",
+      yaxis: "y3",
+      // Colorbar sized/positioned to the row-2 band [0.25, 0.6].
+      colorbar: { len: 0.35, y: 0.425, yanchor: "middle" },
+    }, // 1
     {
       name: "MRR Table",
       type: "table",
@@ -283,6 +298,63 @@ describe("reflowDomains", () => {
   });
 });
 
+describe("reflowColorbar", () => {
+  it("scales len and maps y for a per-subplot bar (middle anchor)", () => {
+    // Row-1 band [0.63, 1.0] (h 0.37) expands to the full envelope [0.25, 1.0].
+    const cb = { len: 0.37, y: 0.815, yanchor: "middle" };
+    const out = reflowColorbar(cb, [0.63, 1.0], [0.25, 1.0]);
+    expect(out.len).toBeCloseTo(0.75, 6); // fills the new band
+    expect(out.y).toBeCloseTo(0.625, 6); // recentred on [0.25, 1.0]
+    // Original untouched (new object).
+    expect(cb.len).toBe(0.37);
+  });
+
+  it("respects top and bottom anchors when testing containment", () => {
+    const top = reflowColorbar(
+      { len: 0.3, y: 1.0, yanchor: "top" }, // extent [0.7, 1.0]
+      [0.7, 1.0],
+      [0.5, 1.0],
+    );
+    expect(top.len).toBeCloseTo(0.5, 6); // 0.3 * (0.5 / 0.3) = 0.5
+    expect(top.y).toBeCloseTo(1.0, 6); // top edge maps to new top
+
+    const bottom = reflowColorbar(
+      { len: 0.3, y: 0.0, yanchor: "bottom" }, // extent [0, 0.3]
+      [0, 0.3],
+      [0, 0.6],
+    );
+    expect(bottom.len).toBeCloseTo(0.6, 6);
+    expect(bottom.y).toBeCloseTo(0.0, 6);
+  });
+
+  it("leaves a figure-wide shared bar alone (extent not within the band)", () => {
+    // Full-height bar (len 1, centred) doesn't belong to a 0.37-tall subplot.
+    expect(
+      reflowColorbar({ len: 1, y: 0.5 }, [0.63, 1.0], [0.25, 1.0]),
+    ).toBeNull();
+  });
+
+  it("ignores bars without both len and y, pixel lengths, and non-paper refs", () => {
+    expect(reflowColorbar({ len: 0.3 }, [0.63, 1], [0.25, 1])).toBeNull();
+    expect(reflowColorbar({ y: 0.8 }, [0.63, 1], [0.25, 1])).toBeNull();
+    expect(
+      reflowColorbar(
+        { len: 0.37, y: 0.815, lenmode: "pixels" },
+        [0.63, 1],
+        [0.25, 1],
+      ),
+    ).toBeNull();
+    expect(
+      reflowColorbar(
+        { len: 0.37, y: 0.815, yref: "container" },
+        [0.63, 1],
+        [0.25, 1],
+      ),
+    ).toBeNull();
+    expect(reflowColorbar(undefined, [0.63, 1], [0.25, 1])).toBeNull();
+  });
+});
+
 describe("applySubplotToggle", () => {
   it("is a no-op when all panes are visible", () => {
     const { data, layout } = verticalStackWithOverlays();
@@ -489,6 +561,18 @@ describe("domain-based traces (go.Table etc.)", () => {
     // Reflectivity expanded but not over the table.
     expect(out.layout.yaxis.domain[0]).toBeCloseTo(0.25, 6);
     expect(out.layout.yaxis.domain[0]).toBeGreaterThanOrEqual(table.rect.y[1]);
+    // The visible heatmap's colorbar grows to track the expanded band, and the
+    // table (no colorbar) is untouched.
+    expect(out.data[0].colorbar.len).toBeCloseTo(0.75, 6);
+    expect(out.data[0].colorbar.y).toBeCloseTo(0.625, 6);
+    expect(out.data[2].colorbar).toBeUndefined();
+  });
+
+  it("leaves colorbars untouched when the figure is not reflowed (all visible)", () => {
+    const { data, layout } = verticalStackWithTable();
+    const out = applySubplotToggle(data, layout, null);
+    expect(out.data).toBe(data); // pristine reference
+    expect(out.data[0].colorbar.len).toBe(0.37);
   });
 
   it("unions the bands of multiple domain traces", () => {

--- a/reactapp/components/visualizations/BasePlot.js
+++ b/reactapp/components/visualizations/BasePlot.js
@@ -388,6 +388,14 @@ const BasePlot = ({
         : [],
     [subplotToggleEnabled, data, layout, subplotLabels],
   );
+  // Only toggleable panes are offered in the control. Non-toggleable panes
+  // (e.g. an unlabeled go.Table footer) stay in `panes` — so they keep their
+  // own reserved band and are never grouped with a cartesian pane — but they
+  // are always visible and never appear as a checkbox.
+  const toggleablePanes = useMemo(
+    () => panes.filter((p) => p.toggleable),
+    [panes],
+  );
   const paneIdsKey = panes.map((p) => p.id).join("|");
   const [visiblePaneIds, setVisiblePaneIds] = useState(() =>
     panes.map((p) => p.id),
@@ -430,13 +438,18 @@ const BasePlot = ({
         if (checked) {
           next.add(paneId);
         } else {
-          if (prev.length <= 1) return prev; // keep at least one pane visible
+          // Keep at least one TOGGLEABLE pane visible. Counting only toggleable
+          // panes means an always-visible footer (e.g. a go.Table) can't stand
+          // in for the last subplot and let every heatmap be hidden.
+          const toggleableIds = new Set(toggleablePanes.map((p) => p.id));
+          const visibleToggleable = prev.filter((id) => toggleableIds.has(id));
+          if (visibleToggleable.length <= 1) return prev;
           next.delete(paneId);
         }
         return panes.map((p) => p.id).filter((id) => next.has(id));
       });
     },
-    [panes],
+    [panes, toggleablePanes],
   );
 
   // istanbul ignore next - functons tested separately, this is just cleanup
@@ -543,7 +556,7 @@ const BasePlot = ({
       />
       {subplotToggleEnabled && (
         <SubplotToggleControl
-          panes={panes}
+          panes={toggleablePanes}
           visiblePaneIds={visiblePaneIds}
           onToggle={handleSubplotToggle}
         />

--- a/reactapp/components/visualizations/subplotToggle.js
+++ b/reactapp/components/visualizations/subplotToggle.js
@@ -369,6 +369,61 @@ export const reflowDomains = (panes, visibleIds, axis) => {
   return result;
 };
 
+// Tolerance for deciding a colorbar "belongs to" a pane's band (see
+// `reflowColorbar`). Loose enough to absorb the small overshoot plugins leave
+// between a colorbar and its subplot edge, tight enough to reject a
+// figure-wide shared bar.
+const CB_BAND_TOL = 0.02;
+
+/**
+ * The paper-y extent [lo, hi] a colorbar occupies, from its `len` (fraction
+ * mode), `y`, and `yanchor`. Returns null when `len`/`y` are not both explicit
+ * or the length is in pixels — in those cases the bar is not a rescalable
+ * per-subplot bar and must be left untouched.
+ */
+const colorbarYExtent = (cb) => {
+  if (typeof cb.len !== "number" || typeof cb.y !== "number") return null;
+  if (cb.lenmode === "pixels") return null; // absolute length: don't rescale
+  const anchor = cb.yanchor || "middle";
+  if (anchor === "top") return [cb.y - cb.len, cb.y];
+  if (anchor === "bottom") return [cb.y, cb.y + cb.len];
+  return [cb.y - cb.len / 2, cb.y + cb.len / 2]; // middle
+};
+
+/**
+ * Rescale/reposition a per-subplot colorbar (e.g. a heatmap's) so it tracks its
+ * pane's reflowed y-band. Vertical stacks only: a horizontal strip shares the
+ * y-domain, so colorbar length is unaffected by reflow.
+ *
+ * The colorbar's length scales with the band and its anchor `y` maps linearly
+ * from the old band into the new one, preserving the plugin's chosen alignment.
+ * Returns a NEW colorbar object, or null when the bar is not scoped to this
+ * pane (a figure-wide shared bar, a pixel-length bar, or one anchored to
+ * something other than the paper) and must be left untouched.
+ *
+ * @param {Object|undefined} cb - the trace's original `colorbar`
+ * @param {[number, number]} oldBand - the pane's original y-domain
+ * @param {[number, number]} newBand - the pane's reflowed y-domain
+ */
+export const reflowColorbar = (cb, oldBand, newBand) => {
+  if (!cb || typeof cb !== "object") return null;
+  if (cb.yref && cb.yref !== "paper") return null; // container-ref: out of scope
+  const extent = colorbarYExtent(cb);
+  if (!extent) return null;
+  const [o0, o1] = oldBand;
+  // Only touch a bar whose original extent sits within this pane's band; a
+  // figure-wide shared bar (extent ~[0,1]) is left alone.
+  if (extent[0] < o0 - CB_BAND_TOL || extent[1] > o1 + CB_BAND_TOL) return null;
+  const oldH = o1 - o0;
+  if (oldH < EPS) return null;
+  const scale = (newBand[1] - newBand[0]) / oldH;
+  return {
+    ...cb,
+    len: cb.len * scale,
+    y: newBand[0] + (cb.y - o0) * scale,
+  };
+};
+
 const cloneAxis = (layout, key, override) => ({
   ...(layout[key] || {}),
   ...override,
@@ -449,18 +504,55 @@ export const applySubplotToggle = (data, layout, visiblePaneIds, options) => {
 
   const isVisible = (p) => visibleSet.has(p.id);
 
-  // Per-trace visibility.
+  // Reflow (1-D arrangements only): compute the new base-axis domains up front
+  // so both the axis overrides and the colorbar reflow below can use them.
+  const reflowed = arrangement === "vertical" || arrangement === "horizontal";
+  const domains = reflowed
+    ? reflowDomains(
+        panes,
+        panes.filter(isVisible).map((p) => p.id),
+        arrangement,
+      )
+    : {};
+
+  // Per-trace colorbar overrides: a vertically-stacked heatmap's colorbar is
+  // sized/positioned to its subplot band, so when the band reflows the bar must
+  // be rescaled to keep tracking the (now larger) subplot — otherwise it stays
+  // at its original small height beside the expanded plot. Horizontal strips
+  // share the y-domain, so colorbar length is unaffected and left alone.
+  const traceColorbars = {};
+  if (arrangement === "vertical") {
+    panes.forEach((p) => {
+      if (p.kind !== "cartesian" || !isVisible(p)) return;
+      const newBand = domains[p.primaryYKey];
+      if (!newBand) return;
+      p.traceIndices.forEach((i) => {
+        const next = reflowColorbar(
+          data[i] && data[i].colorbar,
+          p.rect.y,
+          newBand,
+        );
+        if (next) traceColorbars[i] = next;
+      });
+    });
+  }
+
+  // Per-trace visibility (+ colorbar overrides).
   const traceVisible = {};
   panes.forEach((p) => {
     p.traceIndices.forEach((i) => {
       traceVisible[i] = isVisible(p);
     });
   });
-  const newData = data.map((t, i) =>
-    i in traceVisible && t.visible !== traceVisible[i]
-      ? { ...t, visible: traceVisible[i] }
-      : t,
-  );
+  const newData = data.map((t, i) => {
+    const flip = i in traceVisible && t.visible !== traceVisible[i];
+    const cb = traceColorbars[i];
+    if (!flip && !cb) return t;
+    const next = { ...t };
+    if (flip) next.visible = traceVisible[i];
+    if (cb) next.colorbar = cb;
+    return next;
+  });
 
   // Axis overrides: visibility for exclusive axes...
   const overrides = {};
@@ -472,10 +564,7 @@ export const applySubplotToggle = (data, layout, visiblePaneIds, options) => {
   });
 
   // ...and reflowed domains for visible panes (1-D arrangements only).
-  const reflowed = arrangement === "vertical" || arrangement === "horizontal";
   if (reflowed) {
-    const visibleIds = panes.filter(isVisible).map((p) => p.id);
-    const domains = reflowDomains(panes, visibleIds, arrangement);
     Object.entries(domains).forEach(([key, domain]) => {
       overrides[key] = { ...overrides[key], domain };
     });

--- a/reactapp/components/visualizations/subplotToggle.js
+++ b/reactapp/components/visualizations/subplotToggle.js
@@ -67,15 +67,43 @@ export const resolveBaseAxis = (ref, layout, seen) => {
   return ref;
 };
 
+// Trace types positioned by their own `domain: {x, y}` rather than by an x/y
+// axis pair or a named subplot. Left to the cartesian default they would be
+// misgrouped onto the base "x"/"y" pane (see the subplot-toggle brainstorm):
+// e.g. a go.Table footer would ride along with the first heatmap and get
+// overlapped on reflow. Each becomes its own non-cartesian pane instead.
+const DOMAIN_TRACE_TYPES = new Set([
+  "table",
+  "pie",
+  "sunburst",
+  "treemap",
+  "icicle",
+  "funnelarea",
+  "parcoords",
+  "parcats",
+  "sankey",
+  "indicator",
+]);
+
 /**
  * Determine which subplot a trace belongs to. Non-cartesian traces
- * (3D/polar/geo/mapbox/ternary/smith) reference a named subplot; cartesian
- * traces reference an x/y axis pair (defaulting to "x"/"y").
+ * (3D/polar/geo/mapbox/ternary/smith) reference a named subplot; domain-based
+ * traces (table/pie/sankey/...) carry their own `domain` and share no named
+ * subplot, so each gets a stable per-trace id; cartesian traces reference an
+ * x/y axis pair (defaulting to "x"/"y").
  */
-const getTracePlacement = (trace) => {
+const getTracePlacement = (trace, traceIndex) => {
   if (trace.scene) return { kind: "nonCartesian", id: trace.scene };
   if (trace.geo) return { kind: "nonCartesian", id: trace.geo };
   if (trace.subplot) return { kind: "nonCartesian", id: trace.subplot };
+  if (DOMAIN_TRACE_TYPES.has(trace.type)) {
+    return {
+      kind: "nonCartesian",
+      id: `domain:${trace.type}:${traceIndex}`,
+      domainFromTrace: true,
+      traceType: trace.type,
+    };
+  }
   return {
     kind: "cartesian",
     xref: trace.xaxis || "x",
@@ -115,12 +143,19 @@ export const derivePanes = (data, layout, options) => {
   const order = [];
   const groups = new Map();
   data.forEach((trace, i) => {
-    const place = getTracePlacement(trace);
+    const place = getTracePlacement(trace, i);
     let key;
     let meta;
     if (place.kind === "nonCartesian") {
       key = `np:${place.id}`;
       meta = { kind: "nonCartesian", subplotId: place.id };
+      if (place.domainFromTrace) {
+        // Domain-based trace: its rect comes from the trace's own `domain`
+        // (there is no `layout[subplotId]`), and it is only offered as a toggle
+        // when the plugin explicitly labels it (by pane id or trace type).
+        meta.domain = trace.domain || {};
+        meta.traceType = place.traceType;
+      }
     } else {
       const baseX = resolveBaseAxis(place.xref, layout);
       const baseY = resolveBaseAxis(place.yref, layout);
@@ -152,10 +187,16 @@ export const derivePanes = (data, layout, options) => {
 
   return order.map((key, idx) => {
     const g = groups.get(key);
-    const label = (explicitKeys, fallbackKey) => {
+    // Returns the first explicit label matching any candidate key, else null.
+    const explicitLabelFor = (explicitKeys) => {
       for (const k of explicitKeys) {
         if (k != null && explicitLabels[k]) return explicitLabels[k];
       }
+      return null;
+    };
+    const label = (explicitKeys, fallbackKey) => {
+      const explicit = explicitLabelFor(explicitKeys);
+      if (explicit) return explicit;
       const titled =
         layout[fallbackKey] &&
         layout[fallbackKey].title &&
@@ -165,11 +206,24 @@ export const derivePanes = (data, layout, options) => {
     };
 
     if (g.kind === "nonCartesian") {
-      const dom = (layout[g.subplotId] && layout[g.subplotId].domain) || {};
+      // Domain-based traces read their rect from the trace's own `domain`;
+      // scene/geo/subplot panes read it from `layout[subplotId].domain`.
+      const dom =
+        g.domain || (layout[g.subplotId] && layout[g.subplotId].domain) || {};
+      // A domain pane (table/pie/...) is only toggleable when the plugin
+      // explicitly labels it (by pane id or trace type); scene/geo/subplot
+      // panes stay toggleable as in v1.
+      const domainLabelKeys = g.domain
+        ? [g.subplotId, g.traceType]
+        : [g.subplotId];
+      const toggleable = g.domain
+        ? explicitLabelFor(domainLabelKeys) != null
+        : true;
       return {
         id: key,
-        label: label([g.subplotId], g.subplotId),
+        label: label(domainLabelKeys, g.subplotId),
         kind: "nonCartesian",
+        toggleable,
         traceIndices: g.traceIndices,
         // Non-cartesian subplots have no simple layout-level `visible`; v1
         // toggles trace visibility only and leaves the (empty) frame.
@@ -196,6 +250,7 @@ export const derivePanes = (data, layout, options) => {
       id: key,
       label: label([g.baseY, primaryYKey, g.baseX, primaryXKey], primaryYKey),
       kind: "cartesian",
+      toggleable: true,
       traceIndices: g.traceIndices,
       exclusiveAxisKeys: exclusiveRefs.map(axisRefToLayoutKey),
       primaryXKey,
@@ -227,14 +282,21 @@ const pairwiseDisjoint = (domains) => {
 
 /**
  * Decide whether the panes form a 1-D arrangement reflow can act on.
+ *
+ * Classification looks at the CARTESIAN panes only. A non-cartesian pane (e.g. a
+ * go.Table footer positioned by its own `domain`) no longer disables reflow of
+ * the cartesian stack above/below it — reflow simply stays within the cartesian
+ * envelope (see `reflowDomains`) so the reserved band is never overrun.
+ *
  * @returns {"vertical"|"horizontal"|"none"}
  */
 export const classifyArrangement = (panes) => {
-  if (!panes || panes.length < 2) return "none";
-  if (panes.some((p) => p.kind === "nonCartesian")) return "none";
+  if (!panes) return "none";
+  const cartesian = panes.filter((p) => p.kind === "cartesian");
+  if (cartesian.length < 2) return "none";
 
-  const xs = panes.map((p) => p.rect.x);
-  const ys = panes.map((p) => p.rect.y);
+  const xs = cartesian.map((p) => p.rect.x);
+  const ys = cartesian.map((p) => p.rect.y);
 
   if (allEqual(xs) && pairwiseDisjoint(ys)) return "vertical";
   if (allEqual(ys) && pairwiseDisjoint(xs)) return "horizontal";
@@ -276,14 +338,25 @@ export const reflowDomains = (panes, visibleIds, axis) => {
   const visible = sortedAll.filter((p) => visibleSet.has(p.id));
   if (!visible.length) return {};
 
+  // Reflow envelope: the paper band the cartesian stack may occupy — the union
+  // of ALL cartesian panes' ORIGINAL bands, not the full `[0, 1]` paper. Paper
+  // outside this band is reserved for domain-based traces (e.g. a go.Table
+  // footer), so a lone visible pane expands to fill the cartesian region only
+  // and never overlaps the reserved band. For a pure cartesian stack that
+  // already spans `[0, 1]`, the envelope equals `[0, 1]` and behavior is
+  // unchanged. `cartesian` is non-empty here (visible ⊆ cartesian).
+  const envMin = Math.min(...cartesian.map((p) => p.rect[dim][0]));
+  const envMax = Math.max(...cartesian.map((p) => p.rect[dim][1]));
+  const envSpan = Math.max(0, envMax - envMin);
+
   const sumBands = visible.reduce(
     (acc, p) => acc + (p.rect[dim][1] - p.rect[dim][0]),
     0,
   );
-  const available = Math.max(0, 1 - gap * (visible.length - 1));
+  const available = Math.max(0, envSpan - gap * (visible.length - 1));
 
   const result = {};
-  let cursor = 0;
+  let cursor = envMin;
   visible.forEach((p) => {
     const band = p.rect[dim][1] - p.rect[dim][0];
     const size =


### PR DESCRIPTION
# feat(visualizations): fix subplot-toggle reflow for domain traces + colorbars

## Summary

Extends the existing subplot show/hide feature so it behaves correctly for
Plotly figures that mix a cartesian subplot stack with **domain-positioned
traces** (e.g. a `go.Table` footer) and with **per-subplot colorbars** (e.g.
stacked heatmaps). Toggling a subplot off now:

- expands the remaining subplot(s) into the freed space **without overlapping**
  a table/pie/sankey footer, and
- **rescales each heatmap's colorbar** so it keeps tracking the enlarged plot.

Purely a TethysDash-side reflow concern — no backend or plugin changes. Plugins
keep supplying a standard Plotly figure.

## Problem

A `type: "plotly"` figure with two stacked `secondary_y` heatmaps plus a
`go.Table` footer (`toggle_subplots: true`) broke when a heatmap was toggled off:

1. **`go.Table` was misclassified as a cartesian pane.** A table has no
   `scene`/`geo`/`subplot` and no `xaxis`/`yaxis` — it positions itself with a
   `domain`. It fell through to the cartesian default and got grouped onto the
   base `x`/`y` pane, so (a) reflow ignored its reserved band and drew the
   visible heatmap over it, and (b) toggling that heatmap off also hid the table.
2. **Reflow filled the whole paper `[0, 1]`**, reserving nothing for the table,
   so even a correctly-classified table would still be overlapped.
3. **Colorbars didn't follow the reflow.** A stacked heatmap's colorbar is sized
   (`len`) and positioned (`y`) to its original subplot band; after reflow those
   values were stale, leaving a short colorbar beside an enlarged plot.

The misclassification affects every domain-positioned trace type, not just
tables: `table`, `pie`, `sunburst`, `treemap`, `icicle`, `funnelarea`,
`parcoords`, `parcats`, `sankey`, `indicator`.

## What changed

All changes are in `reactapp/components/visualizations/`.

### 1. Classify domain traces as their own panes — `subplotToggle.js`

- New `DOMAIN_TRACE_TYPES` set; `getTracePlacement` now returns a non-cartesian
  placement with a stable per-trace id (`domain:<type>:<index>`) for these
  types, reading each pane's `rect` from the **trace's own `domain`**.
- Each pane carries a `toggleable` flag. Domain panes are toggleable **only when
  the plugin explicitly labels them** (by pane id or trace type); otherwise they
  stay always-visible and are not offered as a checkbox. Cartesian and
  scene/geo/subplot panes stay toggleable as before.

### 2. Reflow within the cartesian envelope — `subplotToggle.js`

- `classifyArrangement` now classifies on the **cartesian panes only**, so a
  table footer no longer forces `"none"` (which would disable the desired
  expansion).
- `reflowDomains` lays panes out within the **cartesian envelope** — the union
  of all cartesian panes' original bands — instead of `[0, 1]`. A lone visible
  heatmap fills the cartesian region only, preserving the paper reserved for the
  table. Pure cartesian stacks that already span `[0, 1]` are unchanged.

### 3. Reflow per-subplot colorbars — `subplotToggle.js`

- New `reflowColorbar(cb, oldBand, newBand)`: scales a heatmap colorbar's `len`
  by the band-height ratio and maps its anchor `y` into the new band (respecting
  `yanchor`). `applySubplotToggle` applies it to visible traces on a vertical
  reflow.
- Scoped to genuine per-subplot bars — a bar is **left untouched** if it lacks
  explicit `len`/`y`, uses `lenmode: "pixels"`, has a non-`paper` `yref`, or is a
  figure-wide shared bar (its extent falls outside the pane's band). Horizontal
  strips share the y-domain, so colorbar length is unaffected and skipped.

### 4. Control wiring — `BasePlot.js`

- Only `toggleable` panes are passed to `SubplotToggleControl`; always-visible
  domain footers never appear as a checkbox.
- The "keep at least one pane visible" guard now counts **toggleable** panes, so
  an always-visible footer can't stand in for the last subplot and let every
  chart be hidden.

Reflow stays **stateless/idempotent** — everything recomputes from the pristine
figure on each toggle, so the initial (all-visible) render is pixel-identical to
what the plugin produced.

## Behavior (acceptance criteria)

For a figure of 2 stacked heatmaps + a `go.Table` footer, `toggle_subplots: true`:

- Both visible → unchanged from before.
- One heatmap hidden → the remaining heatmap expands to fill only the cartesian
  envelope; the table stays in its band and is **not** overlapped; its colorbar
  grows to track the enlarged band.
- Toggling a heatmap never hides the table.
- The unlabeled table is not offered as a toggle checkbox.
- No regression for pure cartesian stacks/strips (envelope equals the full
  range, colorbars untouched when not reflowed).

## Testing

- `subplotToggle.test.js`, `BasePlot.subplotToggle.test.js`,
  `SubplotToggleControl.test.js` extended with `go.Table` and colorbar cases
  (distinct non-cartesian pane, `toggleable` gating, cartesian-envelope reflow,
  colorbar rescale, shared-bar rejection).
- Full `reactapp/__tests__/components/visualizations/` suite: **462 passing**.
- ESLint clean, Prettier applied.

## Caveats

- Colorbar reflow keys off the standard pattern where the plugin sets
  `colorbar.len`/`y` as **paper fractions** aligned to each subplot. Bars
  positioned another way (pixel lengths, a single shared bar) are safely left
  as-is rather than mis-scaled — worth a quick visual check against the live MRR
  figure.
- Horizontal-strip colorbar **repositioning** (x) is intentionally out of scope;
  only length matters for the reported case and it's unaffected by x-reflow.

## Files

- `reactapp/components/visualizations/subplotToggle.js`
- `reactapp/components/visualizations/BasePlot.js`
- `reactapp/__tests__/components/visualizations/subplotToggle.test.js`
- `reactapp/__tests__/components/visualizations/BasePlot.subplotToggle.test.js`
