### PR TITLE
Snap-to-river selection for the GEOGLOWS map (+ CSV export)

### DIFF
--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -853,6 +853,49 @@ test("queryLayerFeatures ImageArcGISRest", async () => {
   global.fetch.mockRestore?.();
 });
 
+test("queryLayerFeatures ImageArcGISRest uses per-layer clickTolerance", async () => {
+  const mockArgisResults = [{ attributes: { name: "x" } }];
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ results: mockArgisResults }),
+    }),
+  );
+  const mockMap = {
+    getSize: jest.fn(() => [100, 200]),
+    getView: jest.fn(() => ({
+      calculateExtent: jest.fn(() => [1, 2, 3, 4]),
+      getResolution: jest.fn(() => 500),
+      getProjection: jest.fn(() => ({ getCode: jest.fn(() => "EPSG:4326") })),
+      getZoom: jest.fn(() => 10),
+    })),
+  };
+
+  const layerConfig = JSON.parse(JSON.stringify(layerConfigImageArcGISRest));
+  layerConfig.configuration.props.minZoomQuery = 0; // ensure identify runs
+  layerConfig.configuration.props.clickTolerance = 25;
+
+  await queryLayerFeatures(layerConfig, mockMap, [0, 0], [639, 366]);
+
+  const params = new URLSearchParams({
+    f: "json",
+    tolerance: 25,
+    returnGeometry: true,
+    geometryType: "esriGeometryPoint",
+    sr: "4326",
+    geometry: "0,0",
+    mapExtent: "1,2,3,4",
+    returnFieldName: true,
+    imageDisplay: "100, 200, 500",
+    layers: "visible",
+  });
+  const featureQueryUrl =
+    layerConfig.configuration.props.source.props.url + "/identify";
+  expect(global.fetch).toHaveBeenCalledWith(
+    `${featureQueryUrl}?${params.toString()}`,
+  );
+  global.fetch.mockRestore?.();
+});
+
 test("queryLayerFeatures ImageArcGISRest, show layer", async () => {
   const mockArgisResults = [
     {

--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -25,6 +25,7 @@ import {
   createSnapLayer,
   addSnapPreview,
   buildSnapFeatureResult,
+  shouldSnapSelect,
 } from "components/map/utilities";
 import Feature from "ol/Feature";
 import VectorSource from "ol/source/Vector.js";
@@ -4051,6 +4052,36 @@ describe("createSnapLayer", () => {
     expect(layer).toBeInstanceOf(VectorLayer);
     expect(layer.get("name")).toBe("Snap Preview");
     expect(layer.getSource().getFeatures()).toHaveLength(0);
+  });
+});
+
+describe("shouldSnapSelect", () => {
+  const snapLayer = {
+    configuration: { props: { name: "Geoglows Streamflow", snapToFeatures: true } },
+  };
+  const clickSnap = { feature: {}, layerName: "Geoglows Streamflow" };
+
+  test("true when snap active and layer is the snap source", () => {
+    expect(shouldSnapSelect(snapLayer, clickSnap)).toBe(true);
+  });
+
+  test("false when there is no active snap", () => {
+    expect(shouldSnapSelect(snapLayer, null)).toBe(false);
+    expect(shouldSnapSelect(snapLayer, { layerName: "Geoglows Streamflow" })).toBe(
+      false,
+    );
+  });
+
+  test("false when the layer is not snap-enabled", () => {
+    const plain = { configuration: { props: { name: "Geoglows Streamflow" } } };
+    expect(shouldSnapSelect(plain, clickSnap)).toBe(false);
+  });
+
+  test("false when the layer name does not match the snap source", () => {
+    const other = {
+      configuration: { props: { name: "Other Layer", snapToFeatures: true } },
+    };
+    expect(shouldSnapSelect(other, clickSnap)).toBe(false);
   });
 });
 

--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -18,9 +18,17 @@ import {
   buildShiftedMercatorWKT,
   rewriteArcGISExportUrlForAntimeridian,
   shiftEPSG3857ExtentAndPoint,
+  layerDefsToWhere,
+  fetchLayerVectorFeatures,
+  findSnapFeature,
+  findBestSnap,
+  createSnapLayer,
+  addSnapPreview,
+  buildSnapFeatureResult,
 } from "components/map/utilities";
+import Feature from "ol/Feature";
 import VectorSource from "ol/source/Vector.js";
-import { LineString, Point, MultiPolygon, Polygon } from "ol/geom";
+import { LineString, MultiLineString, Point, MultiPolygon, Polygon } from "ol/geom";
 import VectorLayer from "ol/layer/Vector.js";
 import {
   layerConfigGeoJSON,
@@ -3809,5 +3817,330 @@ describe("shiftEPSG3857ExtentAndPoint", () => {
     const newCenterX = (newExtent[0] + newExtent[2]) / 2;
     expect(newCenterX).toBeGreaterThan(-MERCATOR_HALF_WORLD);
     expect(newCenterX).toBeLessThan(MERCATOR_HALF_WORLD);
+  });
+});
+
+describe("layerDefsToWhere", () => {
+  test("extracts the where clause for the matching sublayer", () => {
+    expect(layerDefsToWhere("0: rivercountry='Peru'", 0)).toBe(
+      "rivercountry='Peru'",
+    );
+  });
+
+  test("defaults to sublayer 0", () => {
+    expect(layerDefsToWhere("0: x=1")).toBe("x=1");
+  });
+
+  test("picks the matching entry from a multi-entry definition", () => {
+    expect(layerDefsToWhere("1: a=1;0: b=2", 0)).toBe("b=2");
+  });
+
+  test("skips malformed entries with no colon", () => {
+    expect(layerDefsToWhere("garbage;0: c=3", 0)).toBe("c=3");
+  });
+
+  test("returns 1=1 when the sublayer has no filter", () => {
+    expect(layerDefsToWhere("1: x=1", 0)).toBe("1=1");
+  });
+
+  test("returns 1=1 for empty / non-string input", () => {
+    expect(layerDefsToWhere("")).toBe("1=1");
+    expect(layerDefsToWhere(null)).toBe("1=1");
+    expect(layerDefsToWhere(undefined)).toBe("1=1");
+    expect(layerDefsToWhere(123)).toBe("1=1");
+  });
+});
+
+describe("fetchLayerVectorFeatures", () => {
+  const geojsonOneLine = {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { comid: 123, rivercountry: "Peru" },
+        geometry: { type: "LineString", coordinates: [[0, 0], [0, 1]] },
+      },
+    ],
+  };
+
+  const layerInfo = {
+    configuration: {
+      props: {
+        querySublayer: 0,
+        source: {
+          props: {
+            url: "https://svc/MapServer",
+            params: { LAYERDEFS: "0: rivercountry='Peru'" },
+          },
+        },
+      },
+    },
+  };
+
+  afterEach(() => {
+    global.fetch?.mockRestore?.();
+  });
+
+  test("queries the sublayer /query endpoint and parses features (4326)", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(geojsonOneLine) }),
+    );
+    const map = {
+      getView: jest.fn(() => ({
+        getProjection: jest.fn(() => ({ getCode: jest.fn(() => "EPSG:4326") })),
+        calculateExtent: jest.fn(() => [-10, -10, 10, 10]),
+      })),
+    };
+
+    const features = await fetchLayerVectorFeatures(layerInfo, map);
+
+    const params = new URLSearchParams({
+      f: "geojson",
+      where: "rivercountry='Peru'",
+      geometry: "-10,-10,10,10",
+      geometryType: "esriGeometryEnvelope",
+      spatialRel: "esriSpatialRelIntersects",
+      inSR: "4326",
+      outSR: "4326",
+      outFields: "*",
+      returnGeometry: "true",
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://svc/MapServer/0/query?${params}`,
+    );
+    expect(features).toHaveLength(1);
+    expect(features[0].getGeometry().getType()).toBe("LineString");
+    expect(features[0].get("comid")).toBe(123);
+  });
+
+  test("uses the map projection SR and extent for a 3857 view", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(geojsonOneLine) }),
+    );
+    const map = {
+      getView: jest.fn(() => ({
+        getProjection: jest.fn(() => ({ getCode: jest.fn(() => "EPSG:3857") })),
+        calculateExtent: jest.fn(() => [1, 2, 3, 4]),
+      })),
+    };
+
+    await fetchLayerVectorFeatures(layerInfo, map);
+
+    const calledUrl = global.fetch.mock.calls[0][0];
+    expect(calledUrl).toContain("inSR=3857");
+    expect(calledUrl).toContain("geometry=1%2C2%2C3%2C4");
+  });
+
+  test("returns [] and skips fetch when the source url is missing", async () => {
+    global.fetch = jest.fn();
+    const result = await fetchLayerVectorFeatures(
+      { configuration: { props: {} } },
+      { getView: jest.fn() },
+    );
+    expect(result).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("returns [] when the fetch rejects", async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error("network")));
+    const map = {
+      getView: jest.fn(() => ({
+        getProjection: jest.fn(() => ({ getCode: jest.fn(() => "EPSG:4326") })),
+        calculateExtent: jest.fn(() => [-1, -1, 1, 1]),
+      })),
+    };
+    expect(await fetchLayerVectorFeatures(layerInfo, map)).toEqual([]);
+  });
+
+  test("returns [] when the response has no features array", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({}) }),
+    );
+    const map = {
+      getView: jest.fn(() => ({
+        getProjection: jest.fn(() => ({ getCode: jest.fn(() => "EPSG:4326") })),
+        calculateExtent: jest.fn(() => [-1, -1, 1, 1]),
+      })),
+    };
+    expect(await fetchLayerVectorFeatures(layerInfo, map)).toEqual([]);
+  });
+});
+
+describe("findSnapFeature", () => {
+  // Identity pixel mapping: pixel distance == map-coordinate distance, so the
+  // snap radius is deterministic in these tests. Plain function (not jest.fn)
+  // so the suite's mock reset can't wipe the implementation.
+  const identityMap = { getPixelFromCoordinate: (c) => (c ? [...c] : null) };
+
+  const sourceWithVerticalLine = () => {
+    const source = new VectorSource({});
+    source.addFeature(
+      new Feature({ geometry: new LineString([[0, 0], [0, 100]]) }),
+    );
+    return source;
+  };
+
+  test("returns the nearest feature when within the pixel radius", () => {
+    const source = sourceWithVerticalLine();
+    const result = findSnapFeature(source, [5, 50], identityMap, 15);
+    expect(result).not.toBeNull();
+    expect(result.pixelDistance).toBeCloseTo(5);
+    expect(result.coordinate[0]).toBeCloseTo(0);
+    expect(result.coordinate[1]).toBeCloseTo(50);
+  });
+
+  test("returns null when the nearest feature is beyond the radius", () => {
+    const source = sourceWithVerticalLine();
+    expect(findSnapFeature(source, [50, 50], identityMap, 15)).toBeNull();
+    // same cursor, tighter radius
+    expect(findSnapFeature(source, [5, 50], identityMap, 3)).toBeNull();
+  });
+
+  test("returns null when the source is empty or missing", () => {
+    expect(findSnapFeature(new VectorSource({}), [5, 50], identityMap)).toBeNull();
+    expect(findSnapFeature(null, [5, 50], identityMap)).toBeNull();
+    expect(findSnapFeature(sourceWithVerticalLine(), null, identityMap)).toBeNull();
+  });
+
+  test("returns null when a coordinate cannot be projected to a pixel", () => {
+    const source = sourceWithVerticalLine();
+    const map = { getPixelFromCoordinate: jest.fn(() => null) };
+    expect(findSnapFeature(source, [5, 50], map)).toBeNull();
+  });
+});
+
+describe("findBestSnap", () => {
+  const identityMap = { getPixelFromCoordinate: (c) => (c ? [...c] : null) };
+  const makeCache = (layerName, x) => {
+    const source = new VectorSource({});
+    source.addFeature(
+      new Feature({ geometry: new LineString([[x, 0], [x, 100]]) }),
+    );
+    return { layerName, source };
+  };
+
+  test("returns the closest qualifying feature across caches", () => {
+    const caches = [makeCache("A", 0), makeCache("B", 10)];
+    const best = findBestSnap(caches, [4, 50], identityMap, 15);
+    expect(best).not.toBeNull();
+    expect(best.layerName).toBe("A");
+    expect(best.pixelDistance).toBeCloseTo(4);
+  });
+
+  test("compares distances regardless of cache order", () => {
+    const caches = [makeCache("B", 10), makeCache("A", 0)];
+    const best = findBestSnap(caches, [4, 50], identityMap, 15);
+    expect(best.layerName).toBe("A");
+  });
+
+  test("returns null when nothing is within the radius", () => {
+    const caches = [makeCache("A", 0), makeCache("B", 10)];
+    expect(findBestSnap(caches, [50, 50], identityMap, 15)).toBeNull();
+  });
+
+  test("returns null for empty / missing caches", () => {
+    expect(findBestSnap([], [4, 50], identityMap)).toBeNull();
+    expect(findBestSnap(null, [4, 50], identityMap)).toBeNull();
+    expect(findBestSnap(undefined, [4, 50], identityMap)).toBeNull();
+  });
+});
+
+describe("createSnapLayer", () => {
+  test("returns a named vector layer with an empty source", () => {
+    const layer = createSnapLayer();
+    expect(layer).toBeInstanceOf(VectorLayer);
+    expect(layer.get("name")).toBe("Snap Preview");
+    expect(layer.getSource().getFeatures()).toHaveLength(0);
+  });
+});
+
+describe("buildSnapFeatureResult", () => {
+  const geoglowsLayer = {
+    attributeVariables: { "Flow Forecast (m³/sec)": { comid: "River ID" } },
+    configuration: { props: { name: "Geoglows Streamflow" } },
+  };
+
+  test("maps layerName from the attributeVariables key and strips geometry from attributes", () => {
+    const feature = new Feature({
+      geometry: new LineString([[0, 0], [0, 10]]),
+      comid: 12345,
+      rivercountry: "Peru",
+    });
+    const result = buildSnapFeatureResult(feature, geoglowsLayer);
+    expect(result.layerName).toBe("Flow Forecast (m³/sec)");
+    expect(result.attributes).toEqual({ comid: 12345, rivercountry: "Peru" });
+    expect(result.attributes.geometry).toBeUndefined();
+    expect(result.geometry).toEqual({
+      type: "LineString",
+      coordinates: [[0, 0], [0, 10]],
+    });
+  });
+
+  test("falls back to the configured layer name when no attributeVariables", () => {
+    const feature = new Feature({
+      geometry: new LineString([[0, 0], [1, 1]]),
+      comid: 7,
+    });
+    const result = buildSnapFeatureResult(feature, {
+      configuration: { props: { name: "Geoglows Streamflow" } },
+    });
+    expect(result.layerName).toBe("Geoglows Streamflow");
+    expect(result.attributes).toEqual({ comid: 7 });
+  });
+
+  test("preserves MultiLineString geometry type", () => {
+    const feature = new Feature({
+      geometry: new MultiLineString([[[0, 0], [0, 1]], [[2, 2], [2, 3]]]),
+      comid: 9,
+    });
+    const result = buildSnapFeatureResult(feature, geoglowsLayer);
+    expect(result.geometry.type).toBe("MultiLineString");
+    expect(result.geometry.coordinates).toHaveLength(2);
+  });
+});
+
+describe("addSnapPreview", () => {
+  const lineFeature = () =>
+    new Feature({ geometry: new LineString([[0, 0], [0, 10]]) });
+
+  test("draws the feature outline and a dot at the snapped point", () => {
+    const layer = createSnapLayer();
+    addSnapPreview(layer, lineFeature(), [3, 4]);
+    const feats = layer.getSource().getFeatures();
+    expect(feats).toHaveLength(2);
+    const types = feats.map((f) => f.getGeometry().getType()).sort();
+    expect(types).toEqual(["LineString", "Point"]);
+    const point = feats.find((f) => f.getGeometry().getType() === "Point");
+    expect(point.getGeometry().getCoordinates()).toEqual([3, 4]);
+  });
+
+  test("clears any previous preview before drawing", () => {
+    const layer = createSnapLayer();
+    addSnapPreview(layer, lineFeature(), [3, 4]);
+    addSnapPreview(layer, lineFeature(), [5, 6]);
+    expect(layer.getSource().getFeatures()).toHaveLength(2);
+  });
+
+  test("draws only the dot when there is no feature", () => {
+    const layer = createSnapLayer();
+    addSnapPreview(layer, null, [3, 4]);
+    const feats = layer.getSource().getFeatures();
+    expect(feats).toHaveLength(1);
+    expect(feats[0].getGeometry().getType()).toBe("Point");
+  });
+
+  test("draws only the outline when there is no coordinate", () => {
+    const layer = createSnapLayer();
+    addSnapPreview(layer, lineFeature(), null);
+    const feats = layer.getSource().getFeatures();
+    expect(feats).toHaveLength(1);
+    expect(feats[0].getGeometry().getType()).toBe("LineString");
+  });
+
+  test("clears the preview when given nothing", () => {
+    const layer = createSnapLayer();
+    addSnapPreview(layer, lineFeature(), [3, 4]);
+    addSnapPreview(layer, null, null);
+    expect(layer.getSource().getFeatures()).toHaveLength(0);
   });
 });

--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -22,6 +22,7 @@ import {
   fetchLayerVectorFeatures,
   findSnapFeature,
   findBestSnap,
+  findSnapFeatures,
   createSnapLayer,
   addSnapPreview,
   buildSnapFeatureResult,
@@ -4069,6 +4070,57 @@ describe("findBestSnap", () => {
     expect(findBestSnap([], [4, 50], identityMap)).toBeNull();
     expect(findBestSnap(null, [4, 50], identityMap)).toBeNull();
     expect(findBestSnap(undefined, [4, 50], identityMap)).toBeNull();
+  });
+});
+
+describe("findSnapFeatures", () => {
+  // Identity pixels + unit resolution → pixel distance == map distance.
+  const gatherMap = {
+    getPixelFromCoordinate: (c) => (c ? [...c] : null),
+    getView: () => ({ getResolution: () => 1 }),
+  };
+  const cacheWithLine = (layerName, x) => {
+    const source = new VectorSource({});
+    source.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [x, 0],
+          [x, 100],
+        ]),
+      }),
+    );
+    return { layerName, source };
+  };
+
+  test("returns every feature within the radius, nearest first", () => {
+    const caches = [cacheWithLine("A", 0), cacheWithLine("B", 20)];
+    const hits = findSnapFeatures(caches, [5, 50], gatherMap, 35);
+    expect(hits).toHaveLength(2);
+    expect(hits.map((h) => h.layerName)).toEqual(["A", "B"]);
+    expect(hits[0].pixelDistance).toBeCloseTo(5);
+    expect(hits[1].pixelDistance).toBeCloseTo(15);
+  });
+
+  test("excludes features beyond the gather radius", () => {
+    const caches = [cacheWithLine("A", 0), cacheWithLine("B", 20)];
+    const hits = findSnapFeatures(caches, [5, 50], gatherMap, 10);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].layerName).toBe("A");
+  });
+
+  test("returns [] for empty caches or an unprojectable coordinate", () => {
+    expect(findSnapFeatures([], [5, 50], gatherMap, 35)).toEqual([]);
+    expect(findSnapFeatures(null, [5, 50], gatherMap, 35)).toEqual([]);
+    expect(
+      findSnapFeatures([cacheWithLine("A", 0)], null, gatherMap, 35),
+    ).toEqual([]);
+    const nullPixelMap = {
+      getPixelFromCoordinate: () => null,
+      getView: () => ({ getResolution: () => 1 }),
+    };
+    expect(
+      findSnapFeatures([cacheWithLine("A", 0)], [5, 50], nullPixelMap, 35),
+    ).toEqual([]);
   });
 });
 

--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -29,7 +29,13 @@ import {
 } from "components/map/utilities";
 import Feature from "ol/Feature";
 import VectorSource from "ol/source/Vector.js";
-import { LineString, MultiLineString, Point, MultiPolygon, Polygon } from "ol/geom";
+import {
+  LineString,
+  MultiLineString,
+  Point,
+  MultiPolygon,
+  Polygon,
+} from "ol/geom";
 import VectorLayer from "ol/layer/Vector.js";
 import {
   layerConfigGeoJSON,
@@ -3859,7 +3865,13 @@ describe("fetchLayerVectorFeatures", () => {
       {
         type: "Feature",
         properties: { comid: 123, rivercountry: "Peru" },
-        geometry: { type: "LineString", coordinates: [[0, 0], [0, 1]] },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [0, 1],
+          ],
+        },
       },
     ],
   };
@@ -3976,7 +3988,12 @@ describe("findSnapFeature", () => {
   const sourceWithVerticalLine = () => {
     const source = new VectorSource({});
     source.addFeature(
-      new Feature({ geometry: new LineString([[0, 0], [0, 100]]) }),
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
     );
     return source;
   };
@@ -3998,9 +4015,13 @@ describe("findSnapFeature", () => {
   });
 
   test("returns null when the source is empty or missing", () => {
-    expect(findSnapFeature(new VectorSource({}), [5, 50], identityMap)).toBeNull();
+    expect(
+      findSnapFeature(new VectorSource({}), [5, 50], identityMap),
+    ).toBeNull();
     expect(findSnapFeature(null, [5, 50], identityMap)).toBeNull();
-    expect(findSnapFeature(sourceWithVerticalLine(), null, identityMap)).toBeNull();
+    expect(
+      findSnapFeature(sourceWithVerticalLine(), null, identityMap),
+    ).toBeNull();
   });
 
   test("returns null when a coordinate cannot be projected to a pixel", () => {
@@ -4015,7 +4036,12 @@ describe("findBestSnap", () => {
   const makeCache = (layerName, x) => {
     const source = new VectorSource({});
     source.addFeature(
-      new Feature({ geometry: new LineString([[x, 0], [x, 100]]) }),
+      new Feature({
+        geometry: new LineString([
+          [x, 0],
+          [x, 100],
+        ]),
+      }),
     );
     return { layerName, source };
   };
@@ -4057,7 +4083,9 @@ describe("createSnapLayer", () => {
 
 describe("shouldSnapSelect", () => {
   const snapLayer = {
-    configuration: { props: { name: "Geoglows Streamflow", snapToFeatures: true } },
+    configuration: {
+      props: { name: "Geoglows Streamflow", snapToFeatures: true },
+    },
   };
   const clickSnap = { feature: {}, layerName: "Geoglows Streamflow" };
 
@@ -4067,9 +4095,9 @@ describe("shouldSnapSelect", () => {
 
   test("false when there is no active snap", () => {
     expect(shouldSnapSelect(snapLayer, null)).toBe(false);
-    expect(shouldSnapSelect(snapLayer, { layerName: "Geoglows Streamflow" })).toBe(
-      false,
-    );
+    expect(
+      shouldSnapSelect(snapLayer, { layerName: "Geoglows Streamflow" }),
+    ).toBe(false);
   });
 
   test("false when the layer is not snap-enabled", () => {
@@ -4093,7 +4121,10 @@ describe("buildSnapFeatureResult", () => {
 
   test("maps layerName from the attributeVariables key and strips geometry from attributes", () => {
     const feature = new Feature({
-      geometry: new LineString([[0, 0], [0, 10]]),
+      geometry: new LineString([
+        [0, 0],
+        [0, 10],
+      ]),
       comid: 12345,
       rivercountry: "Peru",
     });
@@ -4103,13 +4134,19 @@ describe("buildSnapFeatureResult", () => {
     expect(result.attributes.geometry).toBeUndefined();
     expect(result.geometry).toEqual({
       type: "LineString",
-      coordinates: [[0, 0], [0, 10]],
+      coordinates: [
+        [0, 0],
+        [0, 10],
+      ],
     });
   });
 
   test("falls back to the configured layer name when no attributeVariables", () => {
     const feature = new Feature({
-      geometry: new LineString([[0, 0], [1, 1]]),
+      geometry: new LineString([
+        [0, 0],
+        [1, 1],
+      ]),
       comid: 7,
     });
     const result = buildSnapFeatureResult(feature, {
@@ -4121,7 +4158,16 @@ describe("buildSnapFeatureResult", () => {
 
   test("preserves MultiLineString geometry type", () => {
     const feature = new Feature({
-      geometry: new MultiLineString([[[0, 0], [0, 1]], [[2, 2], [2, 3]]]),
+      geometry: new MultiLineString([
+        [
+          [0, 0],
+          [0, 1],
+        ],
+        [
+          [2, 2],
+          [2, 3],
+        ],
+      ]),
       comid: 9,
     });
     const result = buildSnapFeatureResult(feature, geoglowsLayer);
@@ -4132,7 +4178,12 @@ describe("buildSnapFeatureResult", () => {
 
 describe("addSnapPreview", () => {
   const lineFeature = () =>
-    new Feature({ geometry: new LineString([[0, 0], [0, 10]]) });
+    new Feature({
+      geometry: new LineString([
+        [0, 0],
+        [0, 10],
+      ]),
+    });
 
   test("draws the feature outline and a dot at the snapped point", () => {
     const layer = createSnapLayer();

--- a/reactapp/__tests__/components/visualizations/BasePlot.csvDownload.test.js
+++ b/reactapp/__tests__/components/visualizations/BasePlot.csvDownload.test.js
@@ -1,0 +1,136 @@
+import {
+  buildCsvFromGraphDiv,
+  downloadCsvFromGraphDiv,
+} from "components/visualizations/BasePlot";
+
+jest.mock("plotly.js-strict-dist-min", () => ({
+  relayout: jest.fn(),
+  purge: jest.fn(),
+}));
+
+describe("buildCsvFromGraphDiv", () => {
+  it("serializes cartesian traces to a wide CSV keyed by x", () => {
+    const gd = {
+      data: [
+        { x: [1, 2], y: [10, 20], name: "A", type: "scatter" },
+        { x: [1, 2], y: [30, 40], name: "B", type: "scatter" },
+      ],
+    };
+    expect(buildCsvFromGraphDiv(gd)).toBe("x,A,B\n1,10,30\n2,20,40");
+  });
+
+  it("skips legend-hidden and non-visible traces", () => {
+    const gd = {
+      data: [
+        { x: [1], y: [10], name: "A", type: "scatter" },
+        { x: [1], y: [99], name: "B", type: "scatter", visible: "legendonly" },
+        { x: [1], y: [88], name: "C", type: "scatter", visible: false },
+      ],
+    };
+    expect(buildCsvFromGraphDiv(gd)).toBe("x,A\n1,10");
+  });
+
+  it("falls back to series_<i> when a trace has no name", () => {
+    const gd = { data: [{ x: [1], y: [5], type: "scatter" }] };
+    expect(buildCsvFromGraphDiv(gd)).toBe("x,series_0\n1,5");
+  });
+
+  it("serializes a plotly table trace from header/cells", () => {
+    const gd = {
+      data: [
+        {
+          type: "table",
+          header: { values: ["col1", "col2"] },
+          cells: {
+            values: [
+              ["a", "b"],
+              ["1", "2"],
+            ],
+          },
+        },
+      ],
+    };
+    expect(buildCsvFromGraphDiv(gd)).toBe("col1,col2\na,1\nb,2");
+  });
+
+  it("quotes values containing commas or quotes", () => {
+    const gd = {
+      data: [{ x: ["a,b", 'c"d'], y: [1, 2], name: "n", type: "scatter" }],
+    };
+    expect(buildCsvFromGraphDiv(gd)).toBe('x,n\n"a,b",1\n"c""d",2');
+  });
+
+  it("decodes plotly base64 typed-array (bdata) numeric columns", () => {
+    const b64 = (arr) => Buffer.from(arr.buffer).toString("base64");
+    const gd = {
+      data: [
+        {
+          x: ["2000-01-01", "2000-01-02"],
+          y: { dtype: "f8", bdata: b64(Float64Array.from([10, 20])) },
+          name: "A",
+          type: "scatter",
+        },
+        {
+          x: ["2000-01-01", "2000-01-02"],
+          y: { dtype: "f8", bdata: b64(Float64Array.from([30, 40])) },
+          name: "B",
+          type: "scatter",
+        },
+      ],
+    };
+    expect(buildCsvFromGraphDiv(gd)).toBe(
+      "x,A,B\n2000-01-01,10,30\n2000-01-02,20,40",
+    );
+  });
+
+  it("reads already-decoded TypedArray x/y", () => {
+    const gd = {
+      data: [
+        { x: [1, 2], y: Float64Array.from([5, 6]), name: "A", type: "scatter" },
+      ],
+    };
+    expect(buildCsvFromGraphDiv(gd)).toBe("x,A\n1,5\n2,6");
+  });
+
+  it("returns an empty string when there are no visible traces", () => {
+    expect(buildCsvFromGraphDiv({ data: [] })).toBe("");
+    expect(buildCsvFromGraphDiv({})).toBe("");
+    expect(buildCsvFromGraphDiv(undefined)).toBe("");
+  });
+});
+
+describe("downloadCsvFromGraphDiv", () => {
+  let clickSpy;
+
+  beforeEach(() => {
+    clickSpy = jest.fn();
+    global.URL.createObjectURL = jest.fn(() => "blob:url");
+    global.URL.revokeObjectURL = jest.fn();
+    const realCreate = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag) => {
+      const el = realCreate(tag);
+      if (tag === "a") el.click = clickSpy;
+      return el;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("triggers a CSV download for the visible data", () => {
+    downloadCsvFromGraphDiv({
+      data: [{ x: [1], y: [2], name: "A", type: "scatter" }],
+      layout: { title: { text: "My Plot" } },
+    });
+    expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:url");
+  });
+
+  it("does nothing when there is no visible data", () => {
+    downloadCsvFromGraphDiv({ data: [] });
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+});

--- a/reactapp/components/map/Map.js
+++ b/reactapp/components/map/Map.js
@@ -54,6 +54,7 @@ const MapComponent = ({
   drawing,
   onMapClick,
   onMapHover,
+  onMapMoveEnd,
   visualizationRef,
   dataviewerViz,
   runtimeLayerState,
@@ -63,6 +64,7 @@ const MapComponent = ({
   const mapDivRef = useRef();
   const onMapClickCurrent = useRef();
   const onMapHoverCurrent = useRef();
+  const onMapMoveEndCurrent = useRef();
   const [zoom, setZoom] = useState(4.5);
   const [lonLat, setLonLat] = useState([-10686671.12, 4721671.57]);
   const [projection, setProjection] = useState("EPSG:3857");
@@ -577,6 +579,18 @@ const MapComponent = ({
           visualizationRef.current.on("pointermove", onMapHoverCurrent.current);
         }
 
+        // Mirror the hover registration for the map's moveend so the snapping
+        // feature cache can refresh when the view changes (pan/zoom).
+        if (onMapMoveEnd) {
+          if (onMapMoveEndCurrent.current) {
+            visualizationRef.current.un("moveend", onMapMoveEndCurrent.current);
+          }
+          onMapMoveEndCurrent.current = function () {
+            onMapMoveEnd(visualizationRef.current);
+          };
+          visualizationRef.current.on("moveend", onMapMoveEndCurrent.current);
+        }
+
         // update the layerControlUpdate so that the layer controls are triggered to rerender with the new layers
         setLayerControlUpdate(!layerControlUpdate);
 
@@ -678,6 +692,7 @@ MapComponent.propTypes = {
   layerControl: PropTypes.bool, // deterimines if a layer control menu should be present
   onMapClick: PropTypes.func, // function for when user click on the map
   onMapHover: PropTypes.func, // function for when user moves the cursor over the map
+  onMapMoveEnd: PropTypes.func, // function for when the map view finishes moving (pan/zoom)
   visualizationRef: PropTypes.shape({ current: PropTypes.any }), // react ref pointing to the ol Map
   dataviewerViz: PropTypes.bool, // determines if the map is in the dataviewer so that it doesnt affect the main map
   mapDrawing: mapDrawingPropType,

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -5,7 +5,7 @@ import Feature from "ol/Feature";
 import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import { LineString, MultiPolygon, Polygon, Point } from "ol/geom";
-import { Stroke, Style, Circle } from "ol/style";
+import { Stroke, Style, Circle, Fill } from "ol/style";
 import Icon from "ol/style/Icon";
 import { toGeometry } from "ol/render/Feature";
 import GeoJSONFormat from "ol/format/GeoJSON";
@@ -735,6 +735,182 @@ async function getESRILayerFeatures(
   }
 
   return featureQueryJson.results;
+}
+
+// --- Feature snapping (Approach A) ---------------------------------------
+//
+// For ESRI Map/Image-service layers flagged `snapToFeatures`, we pull the
+// underlying polylines for the current view from the MapServer sublayer
+// `/query` endpoint and snap the cursor to the nearest one. This replaces the
+// fixed pixel `clickTolerance` used by `/identify`, which behaves poorly across
+// zoom levels (too tight when zoomed out, too loose when zoomed in).
+
+// Parse an ArcGIS LAYERDEFS value ("<layerId>: <whereClause>", optionally
+// ";"-separated) into just the SQL WHERE clause for the given sublayer.
+// Returns "1=1" when no matching filter is set so the query is unfiltered.
+export function layerDefsToWhere(layerDefs, sublayer = 0) {
+  if (!layerDefs || typeof layerDefs !== "string") return "1=1";
+  for (const entry of layerDefs.split(";")) {
+    const idx = entry.indexOf(":");
+    if (idx === -1) continue;
+    const id = entry.slice(0, idx).trim();
+    const clause = entry.slice(idx + 1).trim();
+    if (id === String(sublayer) && clause) return clause;
+  }
+  return "1=1";
+}
+
+// Query the MapServer sublayer for features intersecting the current map extent
+// and return them as OpenLayers Features in the map projection. Returns [] on
+// any failure so callers can degrade gracefully (e.g., fall back to /identify).
+export async function fetchLayerVectorFeatures(layerInfo, map) {
+  const props = layerInfo?.configuration?.props ?? {};
+  const sourceUrl = props.source?.props?.url ?? "";
+  if (!sourceUrl) return [];
+  const sublayer = props.querySublayer ?? 0;
+  const where = layerDefsToWhere(
+    props.source?.props?.params?.LAYERDEFS,
+    sublayer,
+  );
+
+  const view = map.getView();
+  const projectionCode = view.getProjection().getCode();
+  const inSR = projectionCode.split(":")[1];
+  const rawExtent = view.calculateExtent();
+  // Mirror /identify's antimeridian handling so a view panned past the
+  // antimeridian still queries the correct world-copy.
+  const extent =
+    projectionCode === "EPSG:3857"
+      ? shiftEPSG3857ExtentAndPoint(rawExtent, [
+          (rawExtent[0] + rawExtent[2]) / 2,
+          (rawExtent[1] + rawExtent[3]) / 2,
+        ]).extent
+      : rawExtent;
+
+  const params = new URLSearchParams({
+    f: "geojson",
+    where,
+    geometry: extent.join(","),
+    geometryType: "esriGeometryEnvelope",
+    spatialRel: "esriSpatialRelIntersects",
+    inSR,
+    outSR: "4326", // f=geojson coordinates come back as EPSG:4326
+    outFields: "*",
+    returnGeometry: "true",
+  });
+
+  let geojson;
+  try {
+    const resp = await fetch(`${sourceUrl}/${sublayer}/query?${params}`);
+    geojson = await resp.json();
+  } catch (error) {
+    console.error("Vector feature query failed:", error);
+    return [];
+  }
+  if (!geojson || !Array.isArray(geojson.features)) return [];
+
+  try {
+    return new GeoJSONFormat().readFeatures(geojson, {
+      dataProjection: "EPSG:4326",
+      featureProjection: projectionCode,
+    });
+  } catch (error) {
+    console.error("Failed to parse vector features:", error);
+    return [];
+  }
+}
+
+// Find the vector feature nearest to `coordinate` whose closest point is within
+// `snapPx` screen pixels. Returns { feature, coordinate: <snapped>,
+// pixelDistance } or null when nothing qualifies. Pixel-space (not map-space)
+// distance keeps the snap radius consistent regardless of zoom level.
+export function findSnapFeature(vectorSource, coordinate, map, snapPx = 15) {
+  if (!vectorSource || !coordinate) return null;
+  const feature = vectorSource.getClosestFeatureToCoordinate(coordinate);
+  const geometry = feature?.getGeometry?.();
+  if (!geometry) return null;
+  const snappedCoord = geometry.getClosestPoint(coordinate);
+  const cursorPixel = map.getPixelFromCoordinate(coordinate);
+  const snappedPixel = map.getPixelFromCoordinate(snappedCoord);
+  if (!cursorPixel || !snappedPixel) return null;
+  const dx = cursorPixel[0] - snappedPixel[0];
+  const dy = cursorPixel[1] - snappedPixel[1];
+  const pixelDistance = Math.sqrt(dx * dx + dy * dy);
+  if (pixelDistance > snapPx) return null;
+  return { feature, coordinate: snappedCoord, pixelDistance };
+}
+
+// Snap across multiple cached vector sources, returning the closest qualifying
+// feature. `caches` is an array of { layerName, source }. Returns
+// { layerName, feature, coordinate, pixelDistance } or null when nothing snaps.
+export function findBestSnap(caches, coordinate, map, snapPx = 15) {
+  let best = null;
+  for (const cache of caches ?? []) {
+    const hit = findSnapFeature(cache?.source, coordinate, map, snapPx);
+    if (hit && (!best || hit.pixelDistance < best.pixelDistance)) {
+      best = { ...hit, layerName: cache.layerName };
+    }
+  }
+  return best;
+}
+
+// Dedicated layer for the hover snap preview — visually distinct (cyan) from
+// the dark-blue click/selection highlight so the two never clobber each other.
+// The line traces the snapped feature; the filled dot marks the exact point the
+// cursor clipped to.
+export function createSnapLayer() {
+  const color = "#00c2d1";
+  return new VectorLayer({
+    source: new VectorSource({}),
+    style: new Style({
+      stroke: new Stroke({ color, width: 4 }),
+      image: new Circle({
+        radius: 6,
+        fill: new Fill({ color }),
+        stroke: new Stroke({ color: "#ffffff", width: 2 }),
+      }),
+    }),
+    zIndex: 101,
+    name: "Snap Preview",
+  });
+}
+
+// Render the snap preview into `snapLayer`: the snapped feature outline plus a
+// dot marking the exact on-geometry point the cursor clipped to. Clears any
+// previous preview first. Safe to call with a null feature and/or coordinate.
+export function addSnapPreview(snapLayer, feature, coordinate) {
+  const source = snapLayer.getSource();
+  source.clear();
+  if (feature) source.addFeature(feature.clone());
+  if (coordinate) {
+    source.addFeature(new Feature({ geometry: new Point(coordinate) }));
+  }
+}
+
+// Build an ESRI-identify-shaped result ({ layerName, attributes, geometry })
+// from a locally-snapped vector feature, so a snapped click can select the
+// river WITHOUT an ESRI /identify round-trip (which is slow on a cache miss and
+// intermittently returns empty even for an on-geometry point). `layerName` must
+// equal the layer's attributeVariables key (which is the identify sub-layer
+// name) so the downstream variable-input mapping fires; it falls back to the
+// configured layer name when no attributeVariables are set.
+export function buildSnapFeatureResult(feature, layer) {
+  const attrVars =
+    layer?.attributeVariables && typeof layer.attributeVariables === "object"
+      ? layer.attributeVariables
+      : {};
+  const layerName =
+    Object.keys(attrVars)[0] ?? layer?.configuration?.props?.name ?? "";
+  const attributes = { ...feature.getProperties() };
+  delete attributes.geometry;
+  const geom = feature.getGeometry();
+  return {
+    layerName,
+    attributes,
+    geometry: geom
+      ? { type: geom.getType(), coordinates: geom.getCoordinates() }
+      : null,
+  };
 }
 
 async function getImageWMSLayerFeatures(sourceUrl, sourceParams, map, pixel) {

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -893,8 +893,8 @@ export function addSnapPreview(snapLayer, feature, coordinate) {
 export function shouldSnapSelect(layer, clickSnap) {
   return Boolean(
     clickSnap?.feature &&
-      layer?.configuration?.props?.snapToFeatures &&
-      layer.configuration.props.name === clickSnap.layerName,
+    layer?.configuration?.props?.snapToFeatures &&
+    layer.configuration.props.name === clickSnap.layerName,
   );
 }
 

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -854,6 +854,50 @@ export function findBestSnap(caches, coordinate, map, snapPx = 15) {
   return best;
 }
 
+// Gather ALL cached features whose closest point is within `gatherPx` screen
+// pixels of `coordinate`, sorted nearest-first. Used on click to surface the
+// connected reaches at a confluence (the nearest snapped river plus the ones it
+// merges into/from) as separate popup entries — the wider gather radius mirrors
+// the old /identify pixel tolerance, while the hover snap stays tight.
+export function findSnapFeatures(caches, coordinate, map, gatherPx = 35) {
+  if (!coordinate) return [];
+  const cursorPixel = map.getPixelFromCoordinate(coordinate);
+  const resolution = map.getView().getResolution();
+  if (!cursorPixel || !resolution) return [];
+  const r = gatherPx * resolution;
+  const extent = [
+    coordinate[0] - r,
+    coordinate[1] - r,
+    coordinate[0] + r,
+    coordinate[1] + r,
+  ];
+  const results = [];
+  for (const cache of caches ?? []) {
+    const source = cache?.source;
+    if (!source?.forEachFeatureInExtent) continue;
+    source.forEachFeatureInExtent(extent, (feature) => {
+      const geometry = feature.getGeometry?.();
+      if (!geometry) return;
+      const snapped = geometry.getClosestPoint(coordinate);
+      const px = map.getPixelFromCoordinate(snapped);
+      if (!px) return;
+      const dx = cursorPixel[0] - px[0];
+      const dy = cursorPixel[1] - px[1];
+      const pixelDistance = Math.sqrt(dx * dx + dy * dy);
+      if (pixelDistance <= gatherPx) {
+        results.push({
+          feature,
+          coordinate: snapped,
+          pixelDistance,
+          layerName: cache.layerName,
+        });
+      }
+    });
+  }
+  results.sort((a, b) => a.pixelDistance - b.pixelDistance);
+  return results;
+}
+
 // Dedicated layer for the hover snap preview — visually distinct (cyan) from
 // the dark-blue click/selection highlight so the two never clobber each other.
 // The line traces the snapped feature; the filled dot marks the exact point the

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -571,6 +571,7 @@ export async function queryLayerFeatures(layerInfo, map, coordinate, pixel) {
         sourceParams,
         map,
         coordinate,
+        layerInfo.configuration.props.clickTolerance ?? 10,
       );
     } else if (sourceType === "WMS") {
       features = await getImageWMSLayerFeatures(
@@ -693,7 +694,13 @@ function getVectorTileLayerFeatures(map, pixel) {
   return features;
 }
 
-async function getESRILayerFeatures(sourceUrl, sourceParams, map, coordinate) {
+async function getESRILayerFeatures(
+  sourceUrl,
+  sourceParams,
+  map,
+  coordinate,
+  tolerance = 10,
+) {
   // setup fetch request with params
   const featureQueryUrl = sourceUrl + "/identify";
   const view = map.getView();
@@ -705,7 +712,7 @@ async function getESRILayerFeatures(sourceUrl, sourceParams, map, coordinate) {
       : { extent: rawExtent, point: coordinate };
   const params = new URLSearchParams({
     f: "json",
-    tolerance: 10, // Pixel tolerance
+    tolerance, // Pixel tolerance (per-layer via clickTolerance prop, default 10)
     returnGeometry: true,
     geometryType: "esriGeometryPoint",
     sr: projectionCode.split(":")[1],

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -887,6 +887,17 @@ export function addSnapPreview(snapLayer, feature, coordinate) {
   }
 }
 
+// Whether a click should select `layer` from the local snapped feature (vs an
+// ESRI /identify). True only when there's an active snap whose source layer is
+// this snap-enabled layer.
+export function shouldSnapSelect(layer, clickSnap) {
+  return Boolean(
+    clickSnap?.feature &&
+      layer?.configuration?.props?.snapToFeatures &&
+      layer.configuration.props.name === clickSnap.layerName,
+  );
+}
+
 // Build an ESRI-identify-shaped result ({ layerName, attributes, geometry })
 // from a locally-snapped vector feature, so a snapped click can select the
 // river WITHOUT an ESRI /identify round-trip (which is slow on a cache miss and

--- a/reactapp/components/visualizations/BasePlot.js
+++ b/reactapp/components/visualizations/BasePlot.js
@@ -33,6 +33,119 @@ const Plot = createPlotlyComponent(Plotly);
 
 const EMPTY_VERTICAL_LINE = Object.freeze({});
 
+// --- CSV download modebar button ---------------------------------------------
+// Serialize the currently-visible traces of a plotly figure to CSV. Only traces
+// the user can actually see are included (legend-hidden traces are skipped),
+// matching the "download the data visible to the user" intent.
+const csvEscape = (v) => {
+  if (v === undefined || v === null) return "";
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+
+// Plotly.py encodes numeric arrays as base64 typed-arrays ({ dtype, bdata });
+// plotly.js keeps that raw object on gd.data. Decode it (and handle real
+// TypedArrays) so numeric x/y values are not lost in the exported CSV.
+const DTYPE_TO_TYPED_ARRAY = {
+  f8: Float64Array,
+  f4: Float32Array,
+  i1: Int8Array,
+  i2: Int16Array,
+  i4: Int32Array,
+  u1: Uint8Array,
+  u2: Uint16Array,
+  u4: Uint32Array,
+};
+
+const decodeTypedArray = (spec) => {
+  const Ctor = DTYPE_TO_TYPED_ARRAY[spec.dtype];
+  if (!Ctor || typeof spec.bdata !== "string") return [];
+  const binary = atob(spec.bdata);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return Array.from(new Ctor(bytes.buffer));
+};
+
+const toArray = (v) => {
+  if (Array.isArray(v)) return v;
+  if (ArrayBuffer.isView(v)) return Array.from(v);
+  if (v && typeof v === "object" && typeof v.bdata === "string" && v.dtype) {
+    return decodeTypedArray(v);
+  }
+  return [];
+};
+
+export const buildCsvFromGraphDiv = (gd) => {
+  const traces = (gd?.data || []).filter(
+    (t) => t && t.visible !== false && t.visible !== "legendonly",
+  );
+  if (!traces.length) return "";
+
+  // Table traces (e.g. the exceedance table) carry header/cells, not x/y.
+  const tableTraces = traces.filter((t) => t.type === "table");
+  if (tableTraces.length) {
+    const lines = [];
+    tableTraces.forEach((t) => {
+      const headers = (t.header?.values || []).map((h) =>
+        Array.isArray(h) ? h.join(" ") : h,
+      );
+      const columns = (t.cells?.values || []).map(toArray);
+      const rowCount = columns.reduce((m, c) => Math.max(m, c.length), 0);
+      lines.push(headers.map(csvEscape).join(","));
+      for (let r = 0; r < rowCount; r++) {
+        lines.push(columns.map((c) => csvEscape(c[r])).join(","));
+      }
+    });
+    return lines.join("\n");
+  }
+
+  // Cartesian traces: wide table keyed by x, one column per trace.
+  const header = ["x", ...traces.map((t, i) => t.name || `series_${i}`)];
+  const rowsByX = new Map();
+  traces.forEach((t, i) => {
+    const xs = toArray(t.x);
+    const ys = toArray(t.y);
+    xs.forEach((xv, j) => {
+      const key = String(xv);
+      if (!rowsByX.has(key)) rowsByX.set(key, { x: xv });
+      rowsByX.get(key)[i] = ys[j];
+    });
+  });
+  const lines = [header.map(csvEscape).join(",")];
+  for (const row of rowsByX.values()) {
+    lines.push(
+      [csvEscape(row.x), ...traces.map((_, i) => csvEscape(row[i]))].join(","),
+    );
+  }
+  return lines.join("\n");
+};
+
+export const downloadCsvFromGraphDiv = (gd) => {
+  const csv = buildCsvFromGraphDiv(gd);
+  if (!csv) return;
+  const rawTitle = gd?.layout?.title?.text || gd?.layout?.title || "plot_data";
+  const filename =
+    String(rawTitle)
+      .replace(/[^\w.-]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "plot_data";
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${filename}.csv`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const csvDownloadButton = {
+  name: "downloadCsv",
+  title: "Download data as CSV",
+  icon: Plotly.Icons?.disk,
+  click: (gd) => downloadCsvFromGraphDiv(gd),
+};
+
 const StyledPlot = styled(Plot)`
   width: 100%;
   height: 100%;
@@ -428,6 +541,19 @@ const BasePlot = ({
     return merged;
   }, [toggledLayout, width, height, verticalLineShapes]);
 
+  // Merge the always-on "Download data as CSV" modebar button into the plugin's
+  // config (plugins may send no config at all, e.g. geoglows plots).
+  const plotConfig = useMemo(() => {
+    const base = config || {};
+    const existing = Array.isArray(base.modeBarButtonsToAdd)
+      ? base.modeBarButtonsToAdd
+      : [];
+    if (existing.some((b) => b && b.name === csvDownloadButton.name)) {
+      return base;
+    }
+    return { ...base, modeBarButtonsToAdd: [...existing, csvDownloadButton] };
+  }, [config]);
+
   // Ref to track the original vertical line shape
   const verticalLineOriginalRef = useRef(null);
 
@@ -551,7 +677,7 @@ const BasePlot = ({
         ref={visualizationRef}
         data={plotData}
         layout={plotLayout}
-        config={config}
+        config={plotConfig}
         onRelayout={handleRelayout}
       />
       {subplotToggleEnabled && (

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -636,8 +636,12 @@ const MapVisualization = ({
     return snapLayer.current;
   };
 
-  const clearSnap = () => {
+  // Clears the snap preview and resets the pointer-cursor affordance — the one
+  // place snap visual state is torn down, so no clear path can leak the cursor.
+  const clearSnap = (map) => {
     snapLayer.current?.getSource().clear();
+    const targetEl = map?.getTargetElement?.();
+    if (targetEl) targetEl.style.cursor = "";
   };
 
   // moveend handler: rebuild the vector cache for visible snap-enabled layers
@@ -667,10 +671,7 @@ const MapVisualization = ({
     });
     if (snapLayers.length === 0) {
       snapCachesRef.current = [];
-      clearSnap();
-      // Snapping is off here; drop any lingering pointer-cursor affordance.
-      const targetEl = map.getTargetElement?.();
-      if (targetEl) targetEl.style.cursor = "";
+      clearSnap(map);
       return;
     }
     const caches = await Promise.all(
@@ -696,13 +697,13 @@ const MapVisualization = ({
       caches && caches.length
         ? findBestSnap(caches, coordinate, map, SNAP_PIXELS)
         : null;
-    // Affordance: pointer cursor when a click would select a snapped river.
-    const targetEl = map.getTargetElement?.();
-    if (targetEl) targetEl.style.cursor = best ? "pointer" : "";
     if (!best) {
-      clearSnap();
+      clearSnap(map);
       return;
     }
+    // Affordance: pointer cursor when a click would select a snapped river.
+    const targetEl = map.getTargetElement?.();
+    if (targetEl) targetEl.style.cursor = "pointer";
     addSnapPreview(ensureSnapLayer(map), best.feature, best.coordinate);
   };
 

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -17,6 +17,7 @@ import {
   createSnapLayer,
   addSnapPreview,
   buildSnapFeatureResult,
+  shouldSnapSelect,
   fetchLayerVectorFeatures,
   findBestSnap,
   configurationPropType,
@@ -242,6 +243,7 @@ const MapVisualization = ({
   const highlightLayer = useRef();
   const snapLayer = useRef(null);
   const snapCachesRef = useRef([]);
+  const snapRefreshId = useRef(0);
   const currentLayers = useRef([]);
   const currentBaseMap = useRef();
   const mapAttributeVariablesRef = useRef({});
@@ -619,11 +621,11 @@ const MapVisualization = ({
     }
   };
 
-  // --- Feature snapping (Approach A, hybrid) -----------------------------
+  // --- Feature snapping (Approach A) -------------------------------------
   // Maintain a hidden vector cache of snap-enabled layers' features for the
-  // current view, snap the cursor to the nearest one on hover, and on click run
-  // the normal /identify at the snapped on-line point so a small tolerance
-  // resolves the river regardless of zoom.
+  // current view, snap the cursor to the nearest one on hover, and on a snapped
+  // click select the river directly from that local feature (no ESRI /identify,
+  // which is slow on a cache miss and sometimes returns empty on-geometry).
   const SNAP_PIXELS = 15;
 
   const ensureSnapLayer = (map) => {
@@ -642,6 +644,9 @@ const MapVisualization = ({
   // that are zoomed to their query level. Below that zoom snapping is off and
   // the first click still auto-zooms via queryLayerFeatures.
   const refreshSnapCaches = async (map) => {
+    // Generation token: a slower fetch from an earlier view must not overwrite
+    // a newer one (moveend can fire again before the async /query resolves).
+    const refreshId = (snapRefreshId.current += 1);
     const olVisibility = new Map();
     map
       .getLayers()
@@ -663,15 +668,22 @@ const MapVisualization = ({
     if (snapLayers.length === 0) {
       snapCachesRef.current = [];
       clearSnap();
+      // Snapping is off here; drop any lingering pointer-cursor affordance.
+      const targetEl = map.getTargetElement?.();
+      if (targetEl) targetEl.style.cursor = "";
       return;
     }
-    snapCachesRef.current = await Promise.all(
+    const caches = await Promise.all(
       snapLayers.map(async (layer) => {
         const source = new VectorSource();
         source.addFeatures(await fetchLayerVectorFeatures(layer, map));
         return { layerName: layer.configuration.props.name, source };
       }),
     );
+    // Discard if a newer refresh started while this one was in flight.
+    if (refreshId === snapRefreshId.current) {
+      snapCachesRef.current = caches;
+    }
   };
 
   // pointermove handler (synchronous, immediate so the highlight tracks the
@@ -828,13 +840,11 @@ const MapVisualization = ({
         // the already-loaded vector feature instead of an ESRI /identify. This
         // is instant and reliable — /identify is slow on a cache miss and
         // sometimes returns empty even for an exactly-on-geometry point.
-        const snapped =
-          clickSnap?.feature &&
-          layer.configuration?.props?.snapToFeatures &&
-          layer.configuration?.props?.name === clickSnap.layerName;
-        const features = snapped
+        // Other layers query at the TRUE click coordinate (evt.coordinate), not
+        // the snapped point, so the snap can't shift their identify results.
+        const features = shouldSnapSelect(layer, clickSnap)
           ? [buildSnapFeatureResult(clickSnap.feature, layer)]
-          : await queryLayerFeatures(layer, map, coordinate, pixel);
+          : await queryLayerFeatures(layer, map, evt.coordinate, pixel);
         if (!Array.isArray(features)) return features;
         return features.map((feature) =>
           feature && typeof feature === "object"

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -1141,7 +1141,9 @@ const MapVisualization = ({
         drawing={drawing}
         onMapClick={inDataViewerMode ? () => {} : onMapClick}
         onMapHover={inDataViewerMode ? () => {} : onMapHover}
-        onMapMoveEnd={inDataViewerMode ? () => {} : (map) => refreshSnapCaches(map)}
+        onMapMoveEnd={
+          inDataViewerMode ? () => {} : (map) => refreshSnapCaches(map)
+        }
         visualizationRef={visualizationRef}
         data-testid="backlayer-map"
         dataviewerViz={dataviewerViz}

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -14,6 +14,11 @@ import {
   createHighlightLayer,
   addHighlightFeatures,
   createMarkerLayer,
+  createSnapLayer,
+  addSnapPreview,
+  buildSnapFeatureResult,
+  fetchLayerVectorFeatures,
+  findBestSnap,
   configurationPropType,
   mapDrawingPropType,
   loadLayerJSONs,
@@ -44,6 +49,7 @@ import "swiper/css/pagination";
 import "swiper/css/navigation";
 import { Pagination, Navigation } from "swiper/modules";
 import Overlay from "ol/Overlay";
+import VectorSource from "ol/source/Vector";
 import { FaTimes } from "react-icons/fa";
 
 const FixedTable = styled(Table)`
@@ -234,6 +240,8 @@ const MapVisualization = ({
   const [activeFeatureIndex, setActiveFeatureIndex] = useState(0);
   const markerLayer = useRef();
   const highlightLayer = useRef();
+  const snapLayer = useRef(null);
+  const snapCachesRef = useRef([]);
   const currentLayers = useRef([]);
   const currentBaseMap = useRef();
   const mapAttributeVariablesRef = useRef({});
@@ -611,6 +619,81 @@ const MapVisualization = ({
     }
   };
 
+  // --- Feature snapping (Approach A, hybrid) -----------------------------
+  // Maintain a hidden vector cache of snap-enabled layers' features for the
+  // current view, snap the cursor to the nearest one on hover, and on click run
+  // the normal /identify at the snapped on-line point so a small tolerance
+  // resolves the river regardless of zoom.
+  const SNAP_PIXELS = 15;
+
+  const ensureSnapLayer = (map) => {
+    if (!snapLayer.current) {
+      snapLayer.current = createSnapLayer();
+      map.addLayer(snapLayer.current);
+    }
+    return snapLayer.current;
+  };
+
+  const clearSnap = () => {
+    snapLayer.current?.getSource().clear();
+  };
+
+  // moveend handler: rebuild the vector cache for visible snap-enabled layers
+  // that are zoomed to their query level. Below that zoom snapping is off and
+  // the first click still auto-zooms via queryLayerFeatures.
+  const refreshSnapCaches = async (map) => {
+    const olVisibility = new Map();
+    map
+      .getLayers()
+      .getArray()
+      .forEach((olLayer) => {
+        const name = olLayer.get("name");
+        if (name) olVisibility.set(name, olLayer.getVisible());
+      });
+    const zoom = map.getView().getZoom();
+    const snapLayers = layers.filter((item) => {
+      if (!item.configuration?.props?.snapToFeatures) return false;
+      const name = item.configuration?.props?.name;
+      if (name && olVisibility.has(name) && olVisibility.get(name) !== true) {
+        return false;
+      }
+      const minZoom = parseFloat(item.configuration.props.minZoomQuery ?? 0);
+      return zoom >= minZoom;
+    });
+    if (snapLayers.length === 0) {
+      snapCachesRef.current = [];
+      clearSnap();
+      return;
+    }
+    snapCachesRef.current = await Promise.all(
+      snapLayers.map(async (layer) => {
+        const source = new VectorSource();
+        source.addFeatures(await fetchLayerVectorFeatures(layer, map));
+        return { layerName: layer.configuration.props.name, source };
+      }),
+    );
+  };
+
+  // pointermove handler (synchronous, immediate so the highlight tracks the
+  // cursor): draw the snap preview + pointer cursor for the nearest feature.
+  // The click recomputes its own snap from the click coordinate, so this only
+  // drives the hover visual — it deliberately keeps no state the click reads.
+  const updateSnap = (map, coordinate) => {
+    const caches = snapCachesRef.current;
+    const best =
+      caches && caches.length
+        ? findBestSnap(caches, coordinate, map, SNAP_PIXELS)
+        : null;
+    // Affordance: pointer cursor when a click would select a snapped river.
+    const targetEl = map.getTargetElement?.();
+    if (targetEl) targetEl.style.cursor = best ? "pointer" : "";
+    if (!best) {
+      clearSnap();
+      return;
+    }
+    addSnapPreview(ensureSnapLayer(map), best.feature, best.coordinate);
+  };
+
   const onMapClick = async (map, evt) => {
     // istanbul ignore next
     if (drawing.current || isProcessing) return;
@@ -650,8 +733,19 @@ const MapVisualization = ({
 
     setIsProcessing(true);
 
-    const coordinate = evt.coordinate;
+    // Recompute the snap from the ACTUAL click coordinate rather than trusting
+    // the pointermove-maintained hover state: OL fires `singleclick` ~250ms
+    // after the click, and a stray pointermove in that window (e.g. the user
+    // moving off right after clicking) would otherwise clear the snap and force
+    // a slow, sometimes-empty /identify. Recomputing here is race-free.
+    const clickSnap =
+      snapCachesRef.current && snapCachesRef.current.length
+        ? findBestSnap(snapCachesRef.current, evt.coordinate, map, SNAP_PIXELS)
+        : null;
+    const coordinate = clickSnap?.coordinate ?? evt.coordinate;
     const pixel = evt.pixel;
+    // The click owns the selection highlight from here; drop the hover preview.
+    snapLayer.current?.getSource().clear();
 
     // istanbul ignore next
     if (spinnerOverlayRef.current) {
@@ -730,12 +824,17 @@ const MapVisualization = ({
     // variables / omitted-attrs on that sub-layer.
     const queryCalls = queryableLayers.map(async (layer) => {
       try {
-        const features = await queryLayerFeatures(
-          layer,
-          map,
-          coordinate,
-          pixel,
-        );
+        // For a snap-enabled layer with an active snap, select the river from
+        // the already-loaded vector feature instead of an ESRI /identify. This
+        // is instant and reliable — /identify is slow on a cache miss and
+        // sometimes returns empty even for an exactly-on-geometry point.
+        const snapped =
+          clickSnap?.feature &&
+          layer.configuration?.props?.snapToFeatures &&
+          layer.configuration?.props?.name === clickSnap.layerName;
+        const features = snapped
+          ? [buildSnapFeatureResult(clickSnap.feature, layer)]
+          : await queryLayerFeatures(layer, map, coordinate, pixel);
         if (!Array.isArray(features)) return features;
         return features.map((feature) =>
           feature && typeof feature === "object"
@@ -943,6 +1042,10 @@ const MapVisualization = ({
       return;
     }
 
+    // Snap the preview to the nearest snap-enabled feature immediately (not
+    // debounced) so the highlight tracks the cursor responsively.
+    updateSnap(map, evt.coordinate);
+
     // Debounce: restart the timer on every move so the query only fires once
     // the cursor settles for HOVER_DEBOUNCE_MS. Capture coordinate/pixel by
     // value so the deferred call uses the LAST cursor position, not stale.
@@ -1027,6 +1130,7 @@ const MapVisualization = ({
         drawing={drawing}
         onMapClick={inDataViewerMode ? () => {} : onMapClick}
         onMapHover={inDataViewerMode ? () => {} : onMapHover}
+        onMapMoveEnd={inDataViewerMode ? () => {} : (map) => refreshSnapCaches(map)}
         visualizationRef={visualizationRef}
         data-testid="backlayer-map"
         dataviewerViz={dataviewerViz}

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -20,6 +20,7 @@ import {
   shouldSnapSelect,
   fetchLayerVectorFeatures,
   findBestSnap,
+  findSnapFeatures,
   configurationPropType,
   mapDrawingPropType,
   loadLayerJSONs,
@@ -627,6 +628,9 @@ const MapVisualization = ({
   // click select the river directly from that local feature (no ESRI /identify,
   // which is slow on a cache miss and sometimes returns empty on-geometry).
   const SNAP_PIXELS = 15;
+  // Wider radius (mirrors the old /identify tolerance) for gathering the
+  // connected reaches at a confluence into the click popup's swiper.
+  const GATHER_PIXELS = 35;
 
   const ensureSnapLayer = (map) => {
     if (!snapLayer.current) {
@@ -755,6 +759,17 @@ const MapVisualization = ({
       snapCachesRef.current && snapCachesRef.current.length
         ? findBestSnap(snapCachesRef.current, evt.coordinate, map, SNAP_PIXELS)
         : null;
+    // When a snap is active, gather the connected reaches within the wider
+    // radius (nearest-first) so a confluence click yields multiple popup
+    // entries the user can page between — restoring the pre-snap behavior.
+    const snapSiblings = clickSnap
+      ? findSnapFeatures(
+          snapCachesRef.current,
+          evt.coordinate,
+          map,
+          GATHER_PIXELS,
+        )
+      : [];
     const coordinate = clickSnap?.coordinate ?? evt.coordinate;
     const pixel = evt.pixel;
     // The click owns the selection highlight from here; drop the hover preview.
@@ -844,7 +859,9 @@ const MapVisualization = ({
         // Other layers query at the TRUE click coordinate (evt.coordinate), not
         // the snapped point, so the snap can't shift their identify results.
         const features = shouldSnapSelect(layer, clickSnap)
-          ? [buildSnapFeatureResult(clickSnap.feature, layer)]
+          ? snapSiblings
+              .filter((g) => g.layerName === layer.configuration.props.name)
+              .map((g) => buildSnapFeatureResult(g.feature, layer))
           : await queryLayerFeatures(layer, map, evt.coordinate, pixel);
         if (!Array.isArray(features)) return features;
         return features.map((feature) =>


### PR DESCRIPTION
## Summary
- Replace the fixed pixel clickTolerance with cursor snapping: cache river vectors per view, snap the cursor to the nearest reach, and select from the local feature (no /identify) - instant and reliable across zoom levels.
- Restore connected-river switching at confluences via the popup swiper.
- Add the Plotly 'Download data as CSV' modebar button.

## Test plan
- Full jest suite (2143) + eslint + prettier all green; rebased onto latest main.