### PR TITLE
Fix/map popup stale visualization

### DIFF
--- a/reactapp/__tests__/components/modals/DataViewer/SettingsPane.test.js
+++ b/reactapp/__tests__/components/modals/DataViewer/SettingsPane.test.js
@@ -36,6 +36,20 @@ const TestingComponent = ({
 
 TestingComponent.displayName = "TestingComponent";
 
+// Settings updates can land asynchronously after an interaction — most
+// notably ColorPicker debounces its onChange, so the state write outlives
+// the userEvent call that triggered it. Always retry the content assertion
+// instead of racing the re-render: a bare
+// `expect(await screen.findByTestId("settings"))` resolves as soon as the
+// element exists (it always does) and then asserts only once, which flaked
+// in CI whenever the machine was slow enough for the trailing debounce to
+// lose the race.
+const expectSettings = async (expectedText) => {
+  await waitFor(() => {
+    expect(screen.getByTestId("settings")).toHaveTextContent(expectedText);
+  });
+};
+
 test("Settings Pane", async () => {
   render(
     createLoadedComponent({
@@ -76,16 +90,14 @@ test("Settings Pane with visualizationRef Element", async () => {
   fireEvent.change(refreshRateInput, { target: { value: -2 } });
   expect(refreshRateInput.value).toBe("0");
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
 
   fireEvent.change(refreshRateInput, { target: { value: 2 } });
   await waitFor(() => {
     expect(refreshRateInput.value).toBe("2");
   });
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       refreshRate: 2,
     }),
@@ -128,7 +140,7 @@ test("Settings Pane with visualizationRef Image Element with current settings", 
   fireEvent.click(enforceAspectRationInput);
   expect(enforceAspectRationInput).toBeChecked();
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       refreshRate: 5,
       aspectRatio: 0.5,
@@ -158,9 +170,7 @@ test("Settings Pane with visualizationRef Image Element but no natural width", a
   );
   expect(enforceAspectRationInput).not.toBeInTheDocument();
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
 });
 
 test("Settings configure border", async () => {
@@ -173,9 +183,7 @@ test("Settings configure border", async () => {
     }),
   );
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
 
   const leftBorderButton = await screen.findByLabelText("left Border Button");
   expect(leftBorderButton).toBeInTheDocument();
@@ -209,7 +217,7 @@ test("Settings configure border", async () => {
 
   await userEvent.click(allBorderButton);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: { border: `${defaultBorderWidth}px solid ${defaultBorderColor}` },
     }),
@@ -223,7 +231,7 @@ test("Settings configure border", async () => {
 
   await userEvent.click(leftBorderButton);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: {
         "border-top": "1px solid black",
@@ -249,7 +257,7 @@ test("Settings with border", async () => {
     }),
   );
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: { border: "4px solid #ff6161" },
     }),
@@ -289,7 +297,7 @@ test("Settings with border", async () => {
     "#ff6161",
   );
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: { border: "4px solid #ff6161" },
     }),
@@ -311,7 +319,7 @@ test("Settings with border", async () => {
   expect(widthInput.value).toBe("4");
   fireEvent.change(widthInput, { target: { value: 20 } });
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: { border: "20px dashed #0000ff" },
     }),
@@ -319,9 +327,7 @@ test("Settings with border", async () => {
 
   await userEvent.click(removeBordersButton);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
 });
 
 test("Settings with top and bottom border", async () => {
@@ -367,7 +373,7 @@ test("Settings with top and bottom border", async () => {
     "#ff6161",
   );
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: {
         "border-top": "2px solid #7fc066",
@@ -389,7 +395,7 @@ test("Settings with backgroundColor", async () => {
     }),
   );
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       backgroundColor: "#ff6161",
     }),
@@ -413,22 +419,18 @@ test("Settings with backgroundColor", async () => {
   await userEvent.type(hexInput, "#0000ff");
   await userEvent.tab();
 
-  await waitFor(async () => {
-    expect(await screen.findByTestId("settings")).toHaveTextContent(
-      JSON.stringify({
-        backgroundColor: "#0000ff",
-      }),
-    );
-  });
+  await expectSettings(
+    JSON.stringify({
+      backgroundColor: "#0000ff",
+    }),
+  );
 
   // change to transparent
   await userEvent.clear(hexInput);
   await userEvent.type(hexInput, "#00000000");
   await userEvent.tab();
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
 });
 
 test("Settings with box shadow", async () => {
@@ -448,7 +450,7 @@ test("Settings with box shadow", async () => {
 
   await userEvent.click(boxShadowCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
     }),
@@ -456,9 +458,7 @@ test("Settings with box shadow", async () => {
 
   await userEvent.click(boxShadowCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
 });
 
 test("Settings with box shadow and border", async () => {
@@ -482,7 +482,7 @@ test("Settings with box shadow and border", async () => {
 
   await userEvent.click(boxShadowCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: { border: "4px solid #ff6161" },
       boxShadow: "0 4px 8px #ff6161",
@@ -491,7 +491,7 @@ test("Settings with box shadow and border", async () => {
 
   await userEvent.click(boxShadowCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: { border: "4px solid #ff6161" },
     }),
@@ -524,7 +524,7 @@ test("Settings with box shadow and top and bottom border", async () => {
 
   await userEvent.click(boxShadowCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: {
         "border-top": "2px solid #7fc066",
@@ -561,7 +561,7 @@ test("Settings with box shadow and left and right border", async () => {
 
   await userEvent.click(boxShadowCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: {
         "border-left": "2px solid #7fc066",
@@ -600,7 +600,7 @@ test("Settings with box shadow and change border", async () => {
 
   await userEvent.click(boxShadowCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       border: {
         "border-left": "2px solid #7fc066",
@@ -618,17 +618,15 @@ test("Settings with box shadow and change border", async () => {
   await userEvent.type(hexInput, "#FF0000");
   await userEvent.tab();
 
-  await waitFor(async () => {
-    expect(await screen.findByTestId("settings")).toHaveTextContent(
-      JSON.stringify({
-        border: {
-          "border-left": "2px solid #FF0000",
-          "border-right": "4px solid #ff6161",
-        },
-        boxShadow: "4px 0 8px #ff6161,-4px 0 8px #FF0000",
-      }),
-    );
-  });
+  await expectSettings(
+    JSON.stringify({
+      border: {
+        "border-left": "2px solid #FF0000",
+        "border-right": "4px solid #ff6161",
+      },
+      boxShadow: "4px 0 8px #ff6161,-4px 0 8px #FF0000",
+    }),
+  );
 });
 
 test("Settings with attribution", async () => {
@@ -649,16 +647,12 @@ test("Settings with attribution", async () => {
 
   await userEvent.click(attributionCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({ attribution: false }),
-  );
+  await expectSettings(JSON.stringify({ attribution: false }));
   expect(attributionCheckbox.checked).toBe(false);
 
   await userEvent.click(attributionCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
   expect(attributionCheckbox.checked).toBe(true);
 });
 
@@ -676,16 +670,12 @@ test("Settings with existing attribution", async () => {
     "Show Attribution Input",
   );
   expect(attributionCheckbox).toBeInTheDocument();
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({ attribution: false }),
-  );
+  await expectSettings(JSON.stringify({ attribution: false }));
   expect(attributionCheckbox.checked).toBe(false);
 
   await userEvent.click(attributionCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
   expect(attributionCheckbox.checked).toBe(true);
 });
 
@@ -705,7 +695,7 @@ test("Settings with custom messaging", async () => {
     }),
   );
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       customMessaging: { error: "some custom error message" },
     }),
@@ -719,7 +709,7 @@ test("Settings with custom messaging", async () => {
     target: { value: "a new custom message" },
   });
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       customMessaging: { error: "a new custom message" },
     }),
@@ -729,9 +719,7 @@ test("Settings with custom messaging", async () => {
     target: { value: "" },
   });
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
 });
 
 test("SettingsPane renders PlotlySettings when visualizationRef.current.el.className includes 'plotly'", async () => {
@@ -779,16 +767,12 @@ test("Settings with fill viewport", async () => {
 
   await userEvent.click(fillViewportCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({ fillViewport: true }),
-  );
+  await expectSettings(JSON.stringify({ fillViewport: true }));
   expect(fillViewportCheckbox.checked).toBe(true);
 
   await userEvent.click(fillViewportCheckbox);
 
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
-    JSON.stringify({}),
-  );
+  await expectSettings(JSON.stringify({}));
   expect(fillViewportCheckbox.checked).toBe(false);
 });
 
@@ -824,7 +808,7 @@ test("Fill viewport disables aspect ratio control without losing it", async () =
 
   // Aspect ratio control becomes disabled, and its stored keys are preserved.
   expect(enforceAspectRatioInput).toBeDisabled();
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({
       aspectRatio: 0.5,
       enforceAspectRatio: true,
@@ -836,7 +820,7 @@ test("Fill viewport disables aspect ratio control without losing it", async () =
   await userEvent.click(fillViewportCheckbox);
   expect(enforceAspectRatioInput).not.toBeDisabled();
   expect(enforceAspectRatioInput).toBeChecked();
-  expect(await screen.findByTestId("settings")).toHaveTextContent(
+  await expectSettings(
     JSON.stringify({ aspectRatio: 0.5, enforceAspectRatio: true }),
   );
 });

--- a/reactapp/__tests__/components/visualizations/Base.test.js
+++ b/reactapp/__tests__/components/visualizations/Base.test.js
@@ -1819,3 +1819,67 @@ describe("featurePending placeholder", () => {
     spyGetVisualization.mockRestore();
   });
 });
+
+describe("source change with identical resolved args", () => {
+  // Regression test: popup gridItems from different map layers share RGL `i`
+  // keys, so a BaseVisualization instance can be reused for a different
+  // source whose resolved args are deep-equal (e.g. colocated stations whose
+  // plots share {station, start_time, end_time}). The fetch guard must treat
+  // the source as part of the request identity, or the previous source's
+  // data stays on screen.
+  it("BaseVisualization re-fetches when only the source changes", async () => {
+    const spyGetVisualization = jest
+      .spyOn(utilities, "getVisualization")
+      .mockImplementation(() => Promise.resolve());
+
+    const buildGridItemValue = (source) => ({
+      gridItemSource: source,
+      gridItemArgsString: JSON.stringify({
+        station: "CFC",
+        start_time: "01/13/2025T00:00",
+        end_time: "01/15/2025T00:00",
+      }),
+      gridItemMetadataString: JSON.stringify({}),
+      gridItemUUID: "source-swap-1",
+      shouldLoad: true,
+    });
+
+    const { rerender } = render(
+      createLoadedComponent({
+        children: (
+          <GridItemContext.Provider value={buildGridItemValue("mrr_plot")}>
+            <BaseVisualization />
+          </GridItemContext.Provider>
+        ),
+      }),
+    );
+
+    await waitFor(() => expect(spyGetVisualization).toHaveBeenCalled());
+    const callsBefore = spyGetVisualization.mock.calls.length;
+    expect(spyGetVisualization.mock.calls.at(-1)[0].itemData.source).toBe(
+      "mrr_plot",
+    );
+
+    rerender(
+      createLoadedComponent({
+        children: (
+          <GridItemContext.Provider
+            value={buildGridItemValue("disdrometer_plot")}
+          >
+            <BaseVisualization />
+          </GridItemContext.Provider>
+        ),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(spyGetVisualization.mock.calls.length).toBeGreaterThan(
+        callsBefore,
+      ),
+    );
+    expect(spyGetVisualization.mock.calls.at(-1)[0].itemData.source).toBe(
+      "disdrometer_plot",
+    );
+    spyGetVisualization.mockRestore();
+  });
+});

--- a/reactapp/__tests__/components/visualizations/subplotToggle.test.js
+++ b/reactapp/__tests__/components/visualizations/subplotToggle.test.js
@@ -876,6 +876,62 @@ describe("branch coverage", () => {
       )?.id,
     ).toBe(vPanes[1].id);
   });
+
+  it("defaults a domain-based trace's missing `domain` to the full paper (line 156)", () => {
+    // A go.Table with no explicit domain: `trace.domain || {}` falls back and
+    // the pane rect defaults to the whole paper.
+    const panes = derivePanes(
+      [{ type: "table" }],
+      {},
+      {
+        labels: { table: "Stats" },
+      },
+    );
+    expect(panes).toHaveLength(1);
+    expect(panes[0].kind).toBe("nonCartesian");
+    expect(panes[0].toggleable).toBe(true); // labeled by trace type
+    expect(panes[0].rect).toEqual({ x: [0, 1], y: [0, 1] });
+  });
+
+  it("classifyArrangement returns none for a missing panes list (line 294)", () => {
+    expect(classifyArrangement(null)).toBe("none");
+    expect(classifyArrangement(undefined)).toBe("none");
+  });
+
+  it("reflowColorbar leaves a bar on a zero-height band untouched (line 418)", () => {
+    // Degenerate original band [0.5, 0.5]: a tiny bar passes the band-tolerance
+    // check, but the scale factor is undefined (0/0) -> null, bar untouched.
+    expect(
+      reflowColorbar({ len: 0.02, y: 0.5 }, [0.5, 0.5], [0.2, 0.8]),
+    ).toBeNull();
+  });
+
+  it("applies a colorbar override without flipping an explicitly-visible trace (line 552)", () => {
+    // Vertical stack where the surviving pane's trace already carries
+    // `visible: true`: its visibility must NOT be rewritten (flip=false) while
+    // its colorbar still reflows with the expanded band (cb truthy).
+    const data = [
+      {
+        xaxis: "x",
+        yaxis: "y",
+        visible: true,
+        colorbar: { len: 0.28, y: 0.85 },
+      },
+      { xaxis: "x", yaxis: "y2" },
+    ];
+    const layout = {
+      xaxis: { domain: [0, 1] },
+      yaxis: { domain: [0.7, 1], anchor: "x" },
+      yaxis2: { domain: [0, 0.3], anchor: "x" },
+    };
+    const panes = derivePanes(data, layout);
+    const out = applySubplotToggle(data, layout, [panes[0].id]);
+    expect(out.data[0]).not.toBe(data[0]); // cloned for the colorbar override
+    expect(out.data[0].visible).toBe(true); // not flipped
+    // Band [0.7, 1] expands to the full envelope [0, 1] -> scale 1/0.3.
+    expect(out.data[0].colorbar.len).toBeCloseTo(0.28 / 0.3, 10);
+    expect(out.data[1].visible).toBe(false);
+  });
 });
 
 // Helper: id of the first pane for a figure (keeps the line-385 test terse).

--- a/reactapp/components/visualizations/Base.js
+++ b/reactapp/components/visualizations/Base.js
@@ -309,6 +309,13 @@ const BaseVisualization = () => {
     variableInputSliderMeta,
   } = useContext(VariableInputsContext);
   const gridItemArgsWithVariableInputs = useRef(0);
+  // Source of the last fetch, tracked alongside the args above. Args alone
+  // under-identify a request: when this component instance is reused for a
+  // different source (popup gridItems share RGL `i` keys across layers) two
+  // plugins can resolve to deep-equal args — e.g. colocated popup layers
+  // whose plots share {station, start_time, end_time} — and the fetch would
+  // be skipped, leaving the previous source's data on screen.
+  const gridItemSourceFetched = useRef(null);
   const gridItemMetadataWithVariableInputs = useRef(0);
   const customMessages = useRef({});
   const [refreshCount, setRefreshCount] = useState(0);
@@ -426,6 +433,7 @@ const BaseVisualization = () => {
             gridItemArgsWithVariableInputs.current,
             updatedGridItemArgs,
           ) ||
+            gridItemSourceFetched.current !== gridItemSource ||
             !valuesEqual(customMessages.current, customMessaging)))) &&
       shouldLoad
     ) {
@@ -435,6 +443,7 @@ const BaseVisualization = () => {
       itemData.args = updatedGridItemArgs;
       itemData.requestId = requestId.current;
       gridItemArgsWithVariableInputs.current = updatedGridItemArgs;
+      gridItemSourceFetched.current = gridItemSource;
       customMessages.current = customMessaging;
 
       // Edit-time gate: when args reference `${feature.<key>}` and no

--- a/reactapp/components/visualizations/Map.js
+++ b/reactapp/components/visualizations/Map.js
@@ -1056,6 +1056,12 @@ const MapVisualization = ({
       >
         {activeModalFeature ? (
           <PopupModalChrome
+            // Remount the body when the carousel switches entries. Different
+            // layers' popupConfigs reuse the same gridItem `i` keys ("1",
+            // "2", ...), so without a remount React reuses the embedded
+            // visualization instances — and their last-fetched state — across
+            // layers with different popup layouts.
+            key={`${activeModalLayer?.configuration?.props?.name ?? ""}:${safeActiveFeatureIndex}`}
             feature={activeModalFeature}
             popupConfig={activeModalPopupConfig}
           />

--- a/reactapp/components/visualizations/subplotToggle.js
+++ b/reactapp/components/visualizations/subplotToggle.js
@@ -525,6 +525,10 @@ export const applySubplotToggle = (data, layout, visiblePaneIds, options) => {
     panes.forEach((p) => {
       if (p.kind !== "cartesian" || !isVisible(p)) return;
       const newBand = domains[p.primaryYKey];
+      // Safety rail, unreachable today: reflowDomains assigns a domain to
+      // every visible cartesian pane (same visibility predicate, same key),
+      // so a missing band can only mean a refactor broke that invariant.
+      // istanbul ignore if
       if (!newBand) return;
       p.traceIndices.forEach((i) => {
         const next = reflowColorbar(

--- a/tethysapp/tethysdash/plugin_helpers.py
+++ b/tethysapp/tethysdash/plugin_helpers.py
@@ -233,7 +233,7 @@ class TethysDashPlugin(base.DataSource):
         result = {}
         for key, value in self.received_args.items():
             if key.startswith(prefix):
-                leaf = key[len(prefix):]
+                leaf = key[len(prefix) :]
                 if "." not in leaf:
                     result[leaf] = value
         return result

--- a/tethysapp/tethysdash/tests/integrated_tests/test_controllers.py
+++ b/tethysapp/tethysdash/tests/integrated_tests/test_controllers.py
@@ -11,7 +11,10 @@ from datetime import datetime, timedelta
 import types
 from tethysapp.tethysdash.exceptions import VisualizationError
 import uuid
-from tethysapp.tethysdash.controllers import VisualizationConsumer, _get_main_bundle_path
+from tethysapp.tethysdash.controllers import (
+    VisualizationConsumer,
+    _get_main_bundle_path,
+)
 from channels.layers import get_channel_layer
 
 

--- a/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
+++ b/tethysapp/tethysdash/tests/unit_tests/test_plugin_helpers.py
@@ -1158,9 +1158,7 @@ def test_date_preset_sentinels_match_frontend():
     assert array_match, "Could not find DATE_PRESETS in dateUtils.js"
 
     # DATE_PRESETS references string constants (e.g. LATEST_PRESET); resolve them.
-    const_values = dict(
-        re.findall(r'export const (\w+)\s*=\s*"([^"]+)"', date_utils)
-    )
+    const_values = dict(re.findall(r'export const (\w+)\s*=\s*"([^"]+)"', date_utils))
     frontend_presets = set()
     for token in array_match.group(1).split(","):
         token = token.strip()


### PR DESCRIPTION
# fix(map): stale popup visualization when switching between colocated layers

## Summary

Fixes a bug where a map popup modal keeps showing the *previous* layer's
visualization after the user navigates the multi-feature carousel back to a
layer they already viewed. Also brings `subplotToggle.js` to 100% branch
coverage.

Frontend-only — no backend, plugin, or API changes.

## Problem

A map grid item with per-layer modal popups (e.g. the CW3E observation map with
separate MicroRain Radar and Disdrometer layers) exhibited a stale-data bug:

1. Click a point → MicroRain Radar popup loads correctly.
2. Carousel to the colocated Disdrometer point → Disdrometer popup loads
   correctly.
3. Carousel **back** to the MicroRain Radar → the plot does **not** reload and
   keeps showing the Disdrometer figure.

### Root cause

Two behaviors combined:

- **Component instances are reused across carousel entries.** The popup body
  (`DashboardLayout`) keys its embedded grid children by the react-grid-layout
  item id (`i`). Every layer's `popupConfig` uses the same ids (`"1"` for the
  plot, `"2"` for the date range), so React keeps the same `BaseVisualization`
  instances alive across the switch — including their "last fetched" refs and
  current `vizData`.

- **The re-fetch guard only compared args, not the source.** In `Base.js` the
  fetch fired only when the newly resolved args differed from the last-fetched
  args. The two plots take identical arg shapes (`{station, start_time,
  end_time}`), the station is the same colocated site, and the date values are
  forced equal by the date-range input's rename-migration (it copies the old
  variable's value onto the new variable name when the variable names change).
  So on the way back the resolved args were deep-equal to what was just
  fetched → the guard saw no change → no fetch → stale figure.

The first switch works only because the target layer's date variables don't
exist in context yet, so args briefly differ; on the way back they already
persist, so the skip happens. That asymmetry was the tell.

## Fix

**1. Source is part of the request identity** (`Base.js`)
Track the source of the last fetch in a new `gridItemSourceFetched` ref and
re-fetch when it changes, even if the resolved args are deep-equal. Two
different plugins with coincidentally-equal args are different requests. This
also protects the main dashboard surface, not just popups.

**2. Remount the popup body on carousel switch** (`Map.js`)
Key `PopupModalChrome` by the active layer name + carousel index so the embedded
visualizations fully reset when the active feature/layer changes. This is
defense-in-depth against instance reuse and also fixes the stale `requestId`
ref, which had been routing WebSocket progress messages under the wrong grid
item's id after a switch.

## Test coverage

- **New regression test** (`Base.test.js`): renders a visualization, swaps only
  the source while keeping args identical, and asserts a second fetch fires with
  the new source. Verified to fail without fix #1 and pass with it.
- **`subplotToggle.js` → 100% branch coverage** (was 97.79%): added tests for
  the four uncovered branch directions (default table domain, null `panes` in
  `classifyArrangement`, zero-height colorbar band, colorbar override without a
  visibility flip). One provably-unreachable guard in `applySubplotToggle` is
  marked `istanbul ignore if` with a comment explaining the invariant.

## Verification

- `Base.test.js`: all tests pass (regression test confirmed to fail without the
  fix).
- `Map.test.js` + all PopupModal suites: 153/153 pass.
- `subplotToggle.test.js`: 65/65 pass, 100% statements / branches / functions /
  lines.
- ESLint and Prettier clean on all changed files.

## Manual QA

Open a map with colocated per-layer popups, click a point, and carousel
MRR → Disdrometer → MRR. The MRR plot now reloads instead of showing the
Disdrometer figure.

> Note: popup date-range edits still reset to their initial values when
> switching carousel entries (the variable input re-pushes `initial_value` when
> its variable name changes). That is pre-existing behavior, out of scope here,
> and can be a follow-up if we want edits persisted across entries.
