### PR TITLE
Feat/vector layer snap tolerance

### DIFF
--- a/reactapp/__tests__/components/map/Map.test.js
+++ b/reactapp/__tests__/components/map/Map.test.js
@@ -6,7 +6,10 @@ import MapContextProvider, {
   useMapContext,
 } from "components/contexts/MapContext";
 import { Map, View } from "ol";
-import { exampleStyle } from "__tests__/utilities/constants";
+import {
+  exampleStyle,
+  layerConfigGeoJSON,
+} from "__tests__/utilities/constants";
 import { VariableInputsContext } from "components/contexts/Contexts";
 import { wrapMercatorX } from "components/map/utilities";
 import * as olMapboxStyle from "ol-mapbox-style";
@@ -2477,7 +2480,10 @@ describe("onMapMoveEnd registration and mount-time prime", () => {
   // must un+on re-register (no handler pile-up) and the handler must be
   // primed exactly once per map instance so the snap cache exists before the
   // first user pan.
-  const renderMoveEndMap = (onMapMoveEnd) => {
+  const renderMoveEndMap = (
+    onMapMoveEnd,
+    initialLayers = [layerConfigGeoJSON.configuration],
+  ) => {
     let capturedRef;
     const RefCapture = ({ mapProps }) => {
       const ref = useRef();
@@ -2499,11 +2505,11 @@ describe("onMapMoveEnd registration and mount-time prime", () => {
         </MapContextProvider>
       </VariableInputsContext.Provider>
     );
-    const { rerender } = render(tree([]));
+    const { rerender } = render(tree(initialLayers));
     return {
       getMap: () => capturedRef.current,
       // A fresh array identity re-runs the [layers] effect → re-registration.
-      rerenderLayers: () => rerender(tree([])),
+      rerenderLayers: (layers = initialLayers) => rerender(tree([...layers])),
     };
   };
 
@@ -2559,5 +2565,20 @@ describe("onMapMoveEnd registration and mount-time prime", () => {
     // A real moveend still reaches the (re-registered) handler.
     getMap().dispatchEvent({ type: "moveend" });
     expect(onMapMoveEnd).toHaveBeenCalledTimes(2);
+  });
+
+  test("the prime waits for the first layers-bearing effect run", async () => {
+    const onMapMoveEnd = jest.fn();
+    // Mount with NO layers: the parent's layer state hasn't resolved on the
+    // first effect pass, and live-source snap caches (GeoJSON/Feature
+    // Service) need their OL layers mounted before the prime is useful.
+    const { rerenderLayers } = renderMoveEndMap(onMapMoveEnd, []);
+
+    expect(await screen.findByText("Map Ready")).toBeInTheDocument();
+    expect(onMapMoveEnd).not.toHaveBeenCalled();
+
+    // The first run that actually carries layers primes exactly once.
+    rerenderLayers([layerConfigGeoJSON.configuration]);
+    await waitFor(() => expect(onMapMoveEnd).toHaveBeenCalledTimes(1));
   });
 });

--- a/reactapp/__tests__/components/map/snapping.test.js
+++ b/reactapp/__tests__/components/map/snapping.test.js
@@ -579,6 +579,16 @@ describe("findBestSnap", () => {
     expect(findBestSnap(caches, [50, 50], identityMap, 15)).toBeNull();
   });
 
+  test("a cache entry's own snapPx overrides the shared radius", () => {
+    // Entry radius wider than the call's default: 20px away still snaps.
+    const wide = { ...makeCache("A", 0), snapPx: 30 };
+    expect(findBestSnap([wide], [20, 50], identityMap, 15)).not.toBeNull();
+
+    // Entry radius tighter than the call's default: 10px away does not.
+    const tight = { ...makeCache("A", 0), snapPx: 5 };
+    expect(findBestSnap([tight], [10, 50], identityMap, 15)).toBeNull();
+  });
+
   test("returns null for empty / missing caches", () => {
     expect(findBestSnap([], [4, 50], identityMap)).toBeNull();
     expect(findBestSnap(null, [4, 50], identityMap)).toBeNull();
@@ -634,6 +644,17 @@ describe("findSnapFeatures", () => {
     expect(
       findSnapFeatures([cacheWithLine("A", 0)], [5, 50], nullPixelMap, 35),
     ).toEqual([]);
+  });
+
+  test("an entry snapPx wider than the gather radius widens that entry's gather", () => {
+    // Feature 50px away: outside the default 35px gather, but the entry's
+    // snapPx of 60 widens its gather to max(35, 60) = 60.
+    const cache = { ...cacheWithLine("A", 50), snapPx: 60 };
+    expect(findSnapFeatures([cache], [0, 50], gatherMap, 35)).toHaveLength(1);
+    // Without the entry radius the same feature is out of gather range.
+    expect(
+      findSnapFeatures([cacheWithLine("A", 50)], [0, 50], gatherMap, 35),
+    ).toHaveLength(0);
   });
 
   test("uses the default gather radius when none is given", () => {

--- a/reactapp/__tests__/components/map/snapping.test.js
+++ b/reactapp/__tests__/components/map/snapping.test.js
@@ -103,6 +103,16 @@ describe("resolveSnapSublayer", () => {
     expect(resolveSnapSublayer({ snapSublayer: "abc" })).toBe(0);
   });
 
+  test("a whitespace-only snapSublayer is treated as unset (falls back to LAYERS)", () => {
+    expect(
+      resolveSnapSublayer({
+        snapSublayer: " ",
+        source: { props: { params: { LAYERS: "show:2" } } },
+      }),
+    ).toBe(2);
+    expect(resolveSnapSublayer({ snapSublayer: " " })).toBe(0);
+  });
+
   test("explicit snapSublayer of 0 is respected (not treated as unset)", () => {
     const props = {
       snapSublayer: 0,

--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -18,6 +18,7 @@ import {
   buildShiftedMercatorWKT,
   rewriteArcGISExportUrlForAntimeridian,
   shiftEPSG3857ExtentAndPoint,
+  coerceOptionalNumber,
 } from "components/map/utilities";
 import VectorSource from "ol/source/Vector.js";
 import { LineString, Point, MultiPolygon, Polygon } from "ol/geom";
@@ -787,7 +788,39 @@ test("queryLayerFeatures GeoJSON coerces a string clickTolerance from the GUI to
   );
 });
 
-test.each(["", "abc"])(
+describe("coerceOptionalNumber", () => {
+  test("passes through finite numbers, including 0", () => {
+    expect(coerceOptionalNumber(15)).toBe(15);
+    expect(coerceOptionalNumber(0)).toBe(0);
+    expect(coerceOptionalNumber(2.5)).toBe(2.5);
+    expect(coerceOptionalNumber(-3)).toBe(-3);
+  });
+
+  test('coerces numeric strings, including "0" and padded values', () => {
+    expect(coerceOptionalNumber("15")).toBe(15);
+    expect(coerceOptionalNumber("0")).toBe(0);
+    expect(coerceOptionalNumber(" 7 ")).toBe(7);
+  });
+
+  test("treats null and undefined as unset", () => {
+    expect(coerceOptionalNumber(null)).toBeUndefined();
+    expect(coerceOptionalNumber(undefined)).toBeUndefined();
+  });
+
+  test("treats blank strings as unset (empty and whitespace-only)", () => {
+    expect(coerceOptionalNumber("")).toBeUndefined();
+    expect(coerceOptionalNumber(" ")).toBeUndefined();
+    expect(coerceOptionalNumber("\t\n")).toBeUndefined();
+  });
+
+  test("treats non-numeric values as unset", () => {
+    expect(coerceOptionalNumber("abc")).toBeUndefined();
+    expect(coerceOptionalNumber(NaN)).toBeUndefined();
+    expect(coerceOptionalNumber(Infinity)).toBeUndefined();
+  });
+});
+
+test.each(["", " ", "abc"])(
   "queryLayerFeatures GeoJSON treats an invalid clickTolerance %p as unset",
   async (invalidTolerance) => {
     const mockMap = {

--- a/reactapp/__tests__/components/map/utilities.test.js
+++ b/reactapp/__tests__/components/map/utilities.test.js
@@ -721,6 +721,211 @@ test("queryLayerFeatures Valid GeoJSON GeometryCollection Found No Points Close 
   expect(features).toStrictEqual([]);
 });
 
+test("queryLayerFeatures GeoJSON clickTolerance is forwarded as hitTolerance", async () => {
+  const mockMap = {
+    getView: jest.fn(() => ({
+      getResolution: jest.fn(() => 100),
+      getZoom: jest.fn(() => 10),
+    })),
+    forEachFeatureAtPixel: jest.fn(),
+  };
+  const coordinate = [0, 0];
+  const pixel = [639, 366];
+
+  const layerConfig = JSON.parse(JSON.stringify(layerConfigGeoJSON));
+  layerConfig.configuration.props.clickTolerance = 15;
+
+  await queryLayerFeatures(layerConfig, mockMap, coordinate, pixel);
+
+  expect(mockMap.forEachFeatureAtPixel).toHaveBeenCalledWith(
+    pixel,
+    expect.any(Function),
+    { hitTolerance: 15 },
+  );
+});
+
+test("queryLayerFeatures GeoJSON with no clickTolerance passes hitTolerance 0", async () => {
+  const mockMap = {
+    getView: jest.fn(() => ({
+      getResolution: jest.fn(() => 100),
+      getZoom: jest.fn(() => 10),
+    })),
+    forEachFeatureAtPixel: jest.fn(),
+  };
+  const coordinate = [0, 0];
+  const pixel = [639, 366];
+
+  await queryLayerFeatures(layerConfigGeoJSON, mockMap, coordinate, pixel);
+
+  expect(mockMap.forEachFeatureAtPixel).toHaveBeenCalledWith(
+    pixel,
+    expect.any(Function),
+    { hitTolerance: 0 },
+  );
+});
+
+test("queryLayerFeatures GeoJSON coerces a string clickTolerance from the GUI to a number", async () => {
+  const mockMap = {
+    getView: jest.fn(() => ({
+      getResolution: jest.fn(() => 100),
+      getZoom: jest.fn(() => 10),
+    })),
+    forEachFeatureAtPixel: jest.fn(),
+  };
+  const coordinate = [0, 0];
+  const pixel = [639, 366];
+
+  const layerConfig = JSON.parse(JSON.stringify(layerConfigGeoJSON));
+  layerConfig.configuration.props.clickTolerance = "15";
+
+  await queryLayerFeatures(layerConfig, mockMap, coordinate, pixel);
+
+  expect(mockMap.forEachFeatureAtPixel).toHaveBeenCalledWith(
+    pixel,
+    expect.any(Function),
+    { hitTolerance: 15 },
+  );
+});
+
+test.each(["", "abc"])(
+  "queryLayerFeatures GeoJSON treats an invalid clickTolerance %p as unset",
+  async (invalidTolerance) => {
+    const mockMap = {
+      getView: jest.fn(() => ({
+        getResolution: jest.fn(() => 100),
+        getZoom: jest.fn(() => 10),
+      })),
+      forEachFeatureAtPixel: jest.fn(),
+    };
+    const coordinate = [0, 0];
+    const pixel = [639, 366];
+
+    const layerConfig = JSON.parse(JSON.stringify(layerConfigGeoJSON));
+    layerConfig.configuration.props.clickTolerance = invalidTolerance;
+
+    await queryLayerFeatures(layerConfig, mockMap, coordinate, pixel);
+
+    expect(mockMap.forEachFeatureAtPixel).toHaveBeenCalledWith(
+      pixel,
+      expect.any(Function),
+      { hitTolerance: 0 },
+    );
+  },
+);
+
+test("queryLayerFeatures GeoJSON GeometryCollection sub-geometry included when within a custom clickTolerance", async () => {
+  const mockMap = {
+    getView: jest.fn(() => ({
+      getResolution: jest.fn(() => 1),
+      getZoom: jest.fn(() => 10),
+    })),
+    forEachFeatureAtPixel: jest.fn((pixel, callback) => {
+      // Simulate a GeometryCollection feature whose LineString sub-geometry
+      // sits 15 map units (== 15px at resolution 1) from the clicked coordinate
+      const mockFeature = {
+        getId: () => "feature-123",
+        getProperties: () => ({
+          geometry: {
+            getType: jest.fn(() => "GeometryCollection"),
+            getGeometries: jest.fn(() => [
+              {
+                getType: jest.fn(() => "LineString"),
+                getCoordinates: jest.fn(() => [
+                  [1, 2],
+                  [3, 4],
+                ]),
+                getClosestPoint: jest.fn(() => [15, 0]),
+              },
+            ]),
+          },
+        }),
+      }; // Mocked feature object
+      const mockLayer = {
+        get: jest.fn(() => "GeoJSON Layer"),
+        getProperties: () => ({
+          name: "GeoJSON Layer",
+        }),
+      };
+      callback(mockFeature, mockLayer); // Call the callback with the mock feature
+    }),
+  };
+  const coordinate = [0, 0];
+  const pixel = [639, 366];
+
+  const layerConfig = JSON.parse(JSON.stringify(layerConfigGeoJSON));
+  layerConfig.configuration.props.clickTolerance = 20;
+
+  const features = await queryLayerFeatures(
+    layerConfig,
+    mockMap,
+    coordinate,
+    pixel,
+  );
+
+  expect(features).toStrictEqual([
+    {
+      layerName: "GeoJSON Layer",
+      attributes: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [1, 2],
+          [3, 4],
+        ],
+      },
+    },
+  ]);
+});
+
+test("queryLayerFeatures GeoJSON GeometryCollection sub-geometry excluded beyond the default inner threshold when no clickTolerance is set", async () => {
+  const mockMap = {
+    getView: jest.fn(() => ({
+      getResolution: jest.fn(() => 1),
+      getZoom: jest.fn(() => 10),
+    })),
+    forEachFeatureAtPixel: jest.fn((pixel, callback) => {
+      // Same 15 map-unit (15px) offset as the custom-tolerance test above,
+      // but with no clickTolerance the default inner threshold of 10 excludes it
+      const mockFeature = {
+        getId: () => "feature-123",
+        getProperties: () => ({
+          geometry: {
+            getType: jest.fn(() => "GeometryCollection"),
+            getGeometries: jest.fn(() => [
+              {
+                getType: jest.fn(() => "LineString"),
+                getCoordinates: jest.fn(() => [
+                  [1, 2],
+                  [3, 4],
+                ]),
+                getClosestPoint: jest.fn(() => [15, 0]),
+              },
+            ]),
+          },
+        }),
+      }; // Mocked feature object
+      const mockLayer = {
+        get: jest.fn(() => "GeoJSON Layer"),
+        getProperties: () => ({
+          name: "GeoJSON Layer",
+        }),
+      };
+      callback(mockFeature, mockLayer); // Call the callback with the mock feature
+    }),
+  };
+  const coordinate = [0, 0];
+  const pixel = [639, 366];
+
+  const features = await queryLayerFeatures(
+    layerConfigGeoJSON,
+    mockMap,
+    coordinate,
+    pixel,
+  );
+
+  expect(features).toStrictEqual([]);
+});
+
 test("queryLayerFeatures ImageArcGISRest", async () => {
   const mockArgisResults = [
     {

--- a/reactapp/__tests__/components/visualizations/Map.test.js
+++ b/reactapp/__tests__/components/visualizations/Map.test.js
@@ -6370,4 +6370,55 @@ describe("snap pipeline integration", () => {
     expect(previewLayer.getSource().getFeatures()).toHaveLength(0);
     expect(mapRef.current.getTargetElement().style.cursor).toBe("");
   });
+
+  test("snapping obeys the layer's min/max zoom: a zoom-hidden layer stops snapping without a refresh", async () => {
+    const layerName = "GeoJSON Rivers";
+    const mapRef = await mountSnapMap(
+      [geoJsonRiversLayer({ name: layerName })],
+      {
+        expectedFetches: 0,
+      },
+    );
+    await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
+    await dispatch(mapRef, { type: "moveend" });
+    findOlLayer(mapRef, layerName)
+      .getSource()
+      .addFeatures([
+        makeRiver("Test River", [
+          [0, 20],
+          [30, 20],
+        ]),
+      ]);
+
+    // Positive control at the current view zoom.
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    const previewLayer = findOlLayer(mapRef, "Snap Preview");
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+
+    // Constrain the layer's maxZoom below the current view zoom: the layer
+    // stops rendering while getVisible() stays true — snapping must follow
+    // the renderer's visibility, immediately, with no cache refresh.
+    const viewZoom = mapRef.current.getView().getZoom();
+    findOlLayer(mapRef, layerName).setMaxZoom(viewZoom - 1);
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(0);
+    expect(mapRef.current.getTargetElement().style.cursor).toBe("");
+
+    // Lifting the constraint restores snapping, again with no refresh.
+    findOlLayer(mapRef, layerName).setMaxZoom(Infinity);
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+  });
 });

--- a/reactapp/__tests__/components/visualizations/Map.test.js
+++ b/reactapp/__tests__/components/visualizations/Map.test.js
@@ -6145,19 +6145,11 @@ describe("snap pipeline integration", () => {
   // branch: the snap cache entry IS the GeoJSON layer's own live OL
   // VectorSource, populated directly here (no fetchLayerVectorFeatures
   // network fetch involved for this layer at all).
-  // NOTE on the extra `moveend` dispatch below: map/Map.js's mount-time
-  // auto-prime (the one-shot call documented at mountSnapMap above) fires
-  // during the FIRST layer-reconciliation pass, when MapComponent's `layers`
-  // prop is still the parent's initial `undefined` (its own `mapLayers`
-  // state hasn't resolved yet) — so at that instant the GeoJSON layer's OL
-  // VectorLayer doesn't exist yet, `getOlLayerByName` finds nothing, and the
-  // vector cache entry never gets built. The ESRI/fetch branch doesn't
-  // notice this because fetchLayerVectorFeatures doesn't depend on any OL
-  // layer existing; the new live-source branch does. Because the auto-prime
-  // guard only fires once, a real `moveend` (e.g. the user's first pan) is
-  // what actually populates the cache in practice, so each test below
-  // dispatches one right after confirming the OL layer is mounted to
-  // establish that baseline before exercising the live-source behavior.
+  // The mount-time prime in map/Map.js waits for the first layers-bearing
+  // effect run, so by the time the OL layers are mounted the live-source
+  // cache entry exists — no moveend is required before snapping works.
+  // (The hover assertions re-dispatch inside waitFor because the prime runs
+  // in the same async effect that mounted the layer.)
   test("R2: hover near a GeoJSON river draws the cyan preview and pointer cursor; singleclick snap-selects it locally without querying the layer", async () => {
     const layerName = "GeoJSON Rivers";
     jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);
@@ -6170,11 +6162,10 @@ describe("snap pipeline integration", () => {
       },
     );
     await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
-    await dispatch(mapRef, { type: "moveend" });
 
     // Populate the layer's real, live OL VectorSource directly — the cache
-    // entry built by refreshSnapCaches on that moveend IS this same source
-    // object, so it already reflects whatever features live on it.
+    // entry built by the mount-time prime IS this same source object, so it
+    // already reflects whatever features live on it.
     findOlLayer(mapRef, layerName)
       .getSource()
       .addFeatures([
@@ -6186,14 +6177,16 @@ describe("snap pipeline integration", () => {
 
     // Hover near the river: cyan preview (feature outline + snapped-point
     // dot = 2 features) and the pointer-cursor affordance.
-    await dispatch(mapRef, {
-      type: "pointermove",
-      coordinate: [12, 24],
-      pixel: [12, 24],
+    await waitFor(async () => {
+      await dispatch(mapRef, {
+        type: "pointermove",
+        coordinate: [12, 24],
+        pixel: [12, 24],
+      });
+      expect(
+        findOlLayer(mapRef, "Snap Preview")?.getSource().getFeatures(),
+      ).toHaveLength(2);
     });
-    const previewLayer = findOlLayer(mapRef, "Snap Preview");
-    expect(previewLayer).toBeDefined();
-    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
     expect(mapRef.current.getTargetElement().style.cursor).toBe("pointer");
 
     // Click 4 "pixels" off the river line (within SNAP_PIXELS = 15): local
@@ -6297,14 +6290,11 @@ describe("snap pipeline integration", () => {
       },
     );
     await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
-    // Establish the baseline cache entry (see the note above the R2 test for
-    // why this one dispatch is needed before the live-source behavior below
-    // can be exercised at all).
-    await dispatch(mapRef, { type: "moveend" });
 
     // First hover: the live source is still empty (simulating features that
     // haven't loaded yet), so nothing snaps and the preview layer is never
-    // even created.
+    // even created. No moveend is dispatched anywhere in this test — the
+    // mount-time prime created the live-source cache entry.
     await dispatch(mapRef, {
       type: "pointermove",
       coordinate: [12, 24],
@@ -6313,8 +6303,8 @@ describe("snap pipeline integration", () => {
     expect(findOlLayer(mapRef, "Snap Preview")).toBeUndefined();
 
     // Simulate async feature loading landing directly on the live OL source
-    // — the cache entry IS this source object (U2), so NO FURTHER moveend is
-    // needed for the new features to become snappable.
+    // — the cache entry IS this source object (U2), so NO moveend is needed
+    // for the new features to become snappable.
     findOlLayer(mapRef, layerName)
       .getSource()
       .addFeatures([
@@ -6324,15 +6314,16 @@ describe("snap pipeline integration", () => {
         ]),
       ]);
 
-    await dispatch(mapRef, {
-      type: "pointermove",
-      coordinate: [12, 24],
-      pixel: [12, 24],
+    await waitFor(async () => {
+      await dispatch(mapRef, {
+        type: "pointermove",
+        coordinate: [12, 24],
+        pixel: [12, 24],
+      });
+      expect(
+        findOlLayer(mapRef, "Snap Preview")?.getSource().getFeatures(),
+      ).toHaveLength(2);
     });
-
-    const previewLayer = findOlLayer(mapRef, "Snap Preview");
-    expect(previewLayer).toBeDefined();
-    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
     expect(mapRef.current.getTargetElement().style.cursor).toBe("pointer");
   });
 

--- a/reactapp/__tests__/components/visualizations/Map.test.js
+++ b/reactapp/__tests__/components/visualizations/Map.test.js
@@ -5775,6 +5775,37 @@ describe("snap pipeline integration", () => {
   const makeRiver = (name, coords) =>
     new Feature({ geometry: new LineString(coords), river_name: name });
 
+  // A GeoJSON/VectorLayer fixture whose features live in a real OL
+  // VectorSource (built by the component's normal ModuleLoader path from an
+  // empty FeatureCollection, then populated directly via
+  // findOlLayer(...).getSource().addFeatures(...) once mounted). Covers U2's
+  // live-source snap-cache branch (source.type "GeoJSON") and U1's
+  // clickTolerance-on-vector-layers branch, as opposed to riversLayer()'s
+  // ESRI Image and Map Service fetch-based cache.
+  const geoJsonRiversLayer = ({
+    name = "GeoJSON Rivers",
+    snapToFeatures = true,
+    clickTolerance,
+  } = {}) => ({
+    configuration: {
+      type: "VectorLayer",
+      props: {
+        name,
+        ...(snapToFeatures ? { snapToFeatures } : {}),
+        ...(clickTolerance !== undefined ? { clickTolerance } : {}),
+        source: {
+          type: "GeoJSON",
+          props: {},
+          geojson: {
+            type: "FeatureCollection",
+            features: [],
+            crs: { type: "name", properties: { name: "EPSG:3857" } },
+          },
+        },
+      },
+    },
+  });
+
   const SnapHarness = ({ mapRef, layers }) => {
     const { mapReady } = useMapContext();
     return (
@@ -6107,5 +6138,245 @@ describe("snap pipeline integration", () => {
       .getArray()
       .filter((olLayer) => olLayer.get("name") === "Snap Preview");
     expect(previewLayers).toHaveLength(1);
+  });
+
+  // --- Vector (GeoJSON) snap layers — U3 integration coverage -------------
+  // These mirror the ESRI-cache tests above but exercise the U2 live-source
+  // branch: the snap cache entry IS the GeoJSON layer's own live OL
+  // VectorSource, populated directly here (no fetchLayerVectorFeatures
+  // network fetch involved for this layer at all).
+  // NOTE on the extra `moveend` dispatch below: map/Map.js's mount-time
+  // auto-prime (the one-shot call documented at mountSnapMap above) fires
+  // during the FIRST layer-reconciliation pass, when MapComponent's `layers`
+  // prop is still the parent's initial `undefined` (its own `mapLayers`
+  // state hasn't resolved yet) — so at that instant the GeoJSON layer's OL
+  // VectorLayer doesn't exist yet, `getOlLayerByName` finds nothing, and the
+  // vector cache entry never gets built. The ESRI/fetch branch doesn't
+  // notice this because fetchLayerVectorFeatures doesn't depend on any OL
+  // layer existing; the new live-source branch does. Because the auto-prime
+  // guard only fires once, a real `moveend` (e.g. the user's first pan) is
+  // what actually populates the cache in practice, so each test below
+  // dispatches one right after confirming the OL layer is mounted to
+  // establish that baseline before exercising the live-source behavior.
+  test("R2: hover near a GeoJSON river draws the cyan preview and pointer cursor; singleclick snap-selects it locally without querying the layer", async () => {
+    const layerName = "GeoJSON Rivers";
+    jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);
+    const popSetPosition = jest.spyOn(Overlay.prototype, "setPosition");
+
+    const mapRef = await mountSnapMap(
+      [geoJsonRiversLayer({ name: layerName })],
+      {
+        expectedFetches: 0,
+      },
+    );
+    await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
+    await dispatch(mapRef, { type: "moveend" });
+
+    // Populate the layer's real, live OL VectorSource directly — the cache
+    // entry built by refreshSnapCaches on that moveend IS this same source
+    // object, so it already reflects whatever features live on it.
+    findOlLayer(mapRef, layerName)
+      .getSource()
+      .addFeatures([
+        makeRiver("Test River", [
+          [0, 20],
+          [30, 20],
+        ]),
+      ]);
+
+    // Hover near the river: cyan preview (feature outline + snapped-point
+    // dot = 2 features) and the pointer-cursor affordance.
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    const previewLayer = findOlLayer(mapRef, "Snap Preview");
+    expect(previewLayer).toBeDefined();
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+    expect(mapRef.current.getTargetElement().style.cursor).toBe("pointer");
+
+    // Click 4 "pixels" off the river line (within SNAP_PIXELS = 15): local
+    // snapped selection, popup anchored at the SNAPPED coordinate.
+    await dispatch(mapRef, {
+      type: "singleclick",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    await waitFor(() => expect(popSetPosition).toHaveBeenCalledWith([12, 20]));
+
+    // The click resolved entirely from the local live source — no /identify
+    // (queryLayerFeatures) call for this (or any) layer.
+    expect(mockedQueryLayerFeatures).not.toHaveBeenCalled();
+    expect(await screen.findByText(layerName)).toBeInTheDocument();
+    expect(await screen.findByText("Test River")).toBeInTheDocument();
+  });
+
+  test("R3: fetchLayerVectorFeatures is never invoked for a GeoJSON snap layer across prime, moveend, hover, and click", async () => {
+    jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);
+    const layerName = "GeoJSON Rivers";
+
+    const mapRef = await mountSnapMap(
+      [geoJsonRiversLayer({ name: layerName })],
+      {
+        expectedFetches: 0,
+      },
+    );
+    await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
+    // Mount-time prime already ran above; confirm it issued no fetch.
+    expect(mockedFetchLayerVectorFeatures).not.toHaveBeenCalled();
+
+    findOlLayer(mapRef, layerName)
+      .getSource()
+      .addFeatures([
+        makeRiver("Test River", [
+          [0, 20],
+          [30, 20],
+        ]),
+      ]);
+
+    await dispatch(mapRef, { type: "moveend" });
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    await dispatch(mapRef, {
+      type: "singleclick",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+
+    expect(mockedFetchLayerVectorFeatures).not.toHaveBeenCalled();
+  });
+
+  test("R1 (integration): clickTolerance on a non-snap GeoJSON layer widens forEachFeatureAtPixel's hitTolerance during the click pipeline", async () => {
+    // queryLayerFeatures is module-mocked at the top of this file; restore
+    // the REAL implementation for this test only so getGeoJSONLayerFeatures'
+    // forEachFeatureAtPixel({ hitTolerance }) call actually runs.
+    mockedQueryLayerFeatures.mockImplementation(
+      jest.requireActual("components/map/utilities").queryLayerFeatures,
+    );
+    const forEachSpy = jest.spyOn(Map.prototype, "forEachFeatureAtPixel");
+    jest.spyOn(Overlay.prototype, "getRect").mockReturnValue([0, 0, 10, 10]);
+
+    const layerName = "GeoJSON Other (tolerant)";
+    const layer = geoJsonRiversLayer({
+      name: layerName,
+      snapToFeatures: false,
+      clickTolerance: 20,
+    });
+
+    try {
+      const mapRef = await mountSnapMap([layer], { expectedFetches: 0 });
+      await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
+
+      await dispatch(mapRef, {
+        type: "singleclick",
+        coordinate: [12, 24],
+        pixel: [12, 24],
+      });
+
+      await waitFor(() => expect(forEachSpy).toHaveBeenCalled());
+      const callWithTolerance = forEachSpy.mock.calls.find(
+        (call) => call[2]?.hitTolerance === 20,
+      );
+      expect(callWithTolerance).toBeDefined();
+    } finally {
+      forEachSpy.mockRestore();
+      mockedQueryLayerFeatures.mockReset();
+    }
+  });
+
+  test("features added to the live GeoJSON source after mount are snappable on the next hover without any moveend", async () => {
+    const layerName = "GeoJSON Rivers";
+    const mapRef = await mountSnapMap(
+      [geoJsonRiversLayer({ name: layerName })],
+      {
+        expectedFetches: 0,
+      },
+    );
+    await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
+    // Establish the baseline cache entry (see the note above the R2 test for
+    // why this one dispatch is needed before the live-source behavior below
+    // can be exercised at all).
+    await dispatch(mapRef, { type: "moveend" });
+
+    // First hover: the live source is still empty (simulating features that
+    // haven't loaded yet), so nothing snaps and the preview layer is never
+    // even created.
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    expect(findOlLayer(mapRef, "Snap Preview")).toBeUndefined();
+
+    // Simulate async feature loading landing directly on the live OL source
+    // — the cache entry IS this source object (U2), so NO FURTHER moveend is
+    // needed for the new features to become snappable.
+    findOlLayer(mapRef, layerName)
+      .getSource()
+      .addFeatures([
+        makeRiver("Late River", [
+          [0, 20],
+          [30, 20],
+        ]),
+      ]);
+
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+
+    const previewLayer = findOlLayer(mapRef, "Snap Preview");
+    expect(previewLayer).toBeDefined();
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+    expect(mapRef.current.getTargetElement().style.cursor).toBe("pointer");
+  });
+
+  test("hiding a GeoJSON snap layer's OL layer stops the hover preview (visibleSnapCaches extends to live vector sources)", async () => {
+    const layerName = "GeoJSON Rivers";
+    const mapRef = await mountSnapMap(
+      [geoJsonRiversLayer({ name: layerName })],
+      {
+        expectedFetches: 0,
+      },
+    );
+    await waitFor(() => expect(findOlLayer(mapRef, layerName)).toBeDefined());
+    await dispatch(mapRef, { type: "moveend" });
+    findOlLayer(mapRef, layerName)
+      .getSource()
+      .addFeatures([
+        makeRiver("Test River", [
+          [0, 20],
+          [30, 20],
+        ]),
+      ]);
+
+    // Positive control: hovering near the river draws the preview and sets
+    // the pointer-cursor affordance.
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    const previewLayer = findOlLayer(mapRef, "Snap Preview");
+    expect(previewLayer).toBeDefined();
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+    expect(mapRef.current.getTargetElement().style.cursor).toBe("pointer");
+
+    // Hide the layer the way LayersControl does: OL visibility only, no
+    // moveend — the stale cache entry must be filtered out at use time.
+    findOlLayer(mapRef, layerName).setVisible(false);
+
+    await dispatch(mapRef, {
+      type: "pointermove",
+      coordinate: [12, 24],
+      pixel: [12, 24],
+    });
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(0);
+    expect(mapRef.current.getTargetElement().style.cursor).toBe("");
   });
 });

--- a/reactapp/__tests__/components/visualizations/useSnapping.test.js
+++ b/reactapp/__tests__/components/visualizations/useSnapping.test.js
@@ -271,6 +271,50 @@ describe("useSnapping vector-layer live-source snap caches (U2)", () => {
     expect(tightMap.addLayer).not.toHaveBeenCalled();
   });
 
+  test("a clickTolerance edit takes effect immediately, without waiting for a cache refresh", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const stubLayer = makeStubOlLayer("Rivers", liveSource);
+    const map = makeMapWithLayers([stubLayer]);
+    const withTolerance = (clickTolerance) => [
+      {
+        configuration: {
+          props: {
+            name: "Rivers",
+            snapToFeatures: true,
+            clickTolerance,
+            source: { type: "GeoJSON" },
+          },
+        },
+      },
+    ];
+
+    const { result, rerender } = renderHook((props) => useSnapping(props), {
+      initialProps: { layers: withTolerance(30) },
+    });
+    await result.current.refreshSnapCaches(map);
+
+    // Baseline: 25px out snaps at tolerance 30.
+    result.current.updateSnap(map, [25, 50]);
+    expect(map.addLayer).toHaveBeenCalledTimes(1);
+    const previewLayer = map.addLayer.mock.calls[0][0];
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+
+    // The user saves a tighter tolerance: the layers prop updates but NO
+    // refreshSnapCaches runs (that only happens on moveend/prime). The new
+    // radius must apply on the very next hover.
+    rerender({ layers: withTolerance(5) });
+    result.current.updateSnap(map, [25, 50]);
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(0);
+  });
+
   test("snapping obeys the layer's min/max zoom bounds (renderer visibility, not just getVisible)", async () => {
     const liveSource = new VectorSource();
     liveSource.addFeature(

--- a/reactapp/__tests__/components/visualizations/useSnapping.test.js
+++ b/reactapp/__tests__/components/visualizations/useSnapping.test.js
@@ -229,6 +229,48 @@ describe("useSnapping vector-layer live-source snap caches (U2)", () => {
     expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
   });
 
+  test("a layer's clickTolerance overrides the default snap radius in both directions", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const stubLayer = makeStubOlLayer("Rivers", liveSource);
+    const withTolerance = (clickTolerance) => ({
+      configuration: {
+        props: {
+          name: "Rivers",
+          snapToFeatures: true,
+          clickTolerance,
+          source: { type: "GeoJSON" },
+        },
+      },
+    });
+
+    // Wider than the default: a cursor 25px out (beyond SNAP_PIXELS = 15)
+    // still snaps when the layer sets clickTolerance 30.
+    const wideMap = makeMapWithLayers([stubLayer]);
+    const wide = renderHook(() =>
+      useSnapping({ layers: [withTolerance(30)] }),
+    ).result;
+    await wide.current.refreshSnapCaches(wideMap);
+    wide.current.updateSnap(wideMap, [25, 50]);
+    expect(wideMap.addLayer).toHaveBeenCalledTimes(1);
+
+    // Tighter than the default: 10px out does NOT snap at clickTolerance 5.
+    const tightMap = makeMapWithLayers([stubLayer]);
+    const tight = renderHook(() =>
+      useSnapping({ layers: [withTolerance(5)] }),
+    ).result;
+    await tight.current.refreshSnapCaches(tightMap);
+    tight.current.updateSnap(tightMap, [10, 50]);
+    expect(tightMap.addLayer).not.toHaveBeenCalled();
+  });
+
   test("snapping obeys the layer's min/max zoom bounds (renderer visibility, not just getVisible)", async () => {
     const liveSource = new VectorSource();
     liveSource.addFeature(

--- a/reactapp/__tests__/components/visualizations/useSnapping.test.js
+++ b/reactapp/__tests__/components/visualizations/useSnapping.test.js
@@ -294,4 +294,83 @@ describe("useSnapping vector-layer live-source snap caches (U2)", () => {
     // Excluded by the zoom gate entirely, so no snap and no preview layer.
     expect(map.addLayer).not.toHaveBeenCalled();
   });
+
+  test("snapping follows a rebuilt OL layer without a moveend", async () => {
+    // The reconciliation sweep in map/Map.js rebuilds VectorLayers on any
+    // layers change: the OL instance (and its VectorSource) is replaced while
+    // the configured name stays the same, and no moveend fires. Live entries
+    // must resolve the OL source at use time so snapping targets the NEW
+    // source immediately.
+    const oldSource = new VectorSource();
+    oldSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const olLayers = [makeStubOlLayer("Rivers", oldSource)];
+    const map = makeMapWithLayers(olLayers);
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [geoJsonRiverLayerConfig] }),
+    );
+
+    await result.current.refreshSnapCaches(map);
+
+    // Rebuild: a NEW stub layer with the same name but a different
+    // VectorSource whose only feature sits at a new position.
+    const newSource = new VectorSource();
+    newSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [500, 500],
+          [500, 600],
+        ]),
+      }),
+    );
+    olLayers.splice(0, 1, makeStubOlLayer("Rivers", newSource));
+
+    // No further refreshSnapCaches call — snap near the NEW feature.
+    result.current.updateSnap(map, [500 + SNAP_PIXELS - 5, 550]);
+    expect(map.addLayer).toHaveBeenCalledTimes(1);
+    const previewLayer = map.addLayer.mock.calls[0][0];
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+
+    // And the OLD source's feature is no longer snappable — the stale
+    // reference is gone, not merely supplemented.
+    result.current.updateSnap(map, [SNAP_PIXELS - 5, 50]);
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(0);
+  });
+
+  test("a snap layer that mounts after the refresh becomes snappable without another refresh", async () => {
+    // Late mount: the refresh (e.g. the one-shot prime) runs before the OL
+    // layer exists. The live marker entry is still recorded, so once the
+    // layer mounts, use-time resolution makes it snappable with no further
+    // refresh.
+    const olLayers = [];
+    const map = makeMapWithLayers(olLayers);
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [geoJsonRiverLayerConfig] }),
+    );
+
+    await result.current.refreshSnapCaches(map);
+    expect(mockedFetch).not.toHaveBeenCalled();
+
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    olLayers.push(makeStubOlLayer("Rivers", liveSource));
+
+    result.current.updateSnap(map, [SNAP_PIXELS - 5, 50]);
+    expect(map.addLayer).toHaveBeenCalledTimes(1);
+    const previewLayer = map.addLayer.mock.calls[0][0];
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+  });
 });

--- a/reactapp/__tests__/components/visualizations/useSnapping.test.js
+++ b/reactapp/__tests__/components/visualizations/useSnapping.test.js
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import Feature from "ol/Feature";
 import { LineString } from "ol/geom";
+import VectorSource from "ol/source/Vector";
 import useSnapping, {
   SNAP_PIXELS,
 } from "components/visualizations/useSnapping";
@@ -33,6 +34,48 @@ const makeDetachedMap = () => ({
 const riverLayerConfig = {
   configuration: {
     props: { name: "Rivers", snapToFeatures: true },
+  },
+};
+
+// A map stand-in whose OL layers array is caller-supplied — used to exercise
+// the U2 live-source branch, which resolves the OL layer instance by name
+// from map.getLayers().getArray().
+const makeMapWithLayers = (olLayers, { zoom = 10 } = {}) => ({
+  getLayers: () => ({ getArray: () => olLayers }),
+  getView: () => ({ getZoom: () => zoom, getResolution: () => 1 }),
+  getPixelFromCoordinate: (c) => (c ? [...c] : null),
+  getTargetElement: () => null,
+  addLayer: jest.fn(),
+});
+
+// Minimal stub of an OL layer instance: only the surface refreshSnapCaches'
+// getOlLayerByName / getOlVisibilityMap lookups touch.
+const makeStubOlLayer = (name, source, visible = true) => ({
+  get: (key) => (key === "name" ? name : undefined),
+  getVisible: () => visible,
+  getSource: () => source,
+});
+
+const geoJsonRiverLayerConfig = {
+  configuration: {
+    props: {
+      name: "Rivers",
+      snapToFeatures: true,
+      source: { type: "GeoJSON" },
+    },
+  },
+};
+
+const mapServiceRiverLayerConfig = {
+  configuration: {
+    props: {
+      name: "MapServiceRivers",
+      snapToFeatures: true,
+      source: {
+        type: "ESRI Image and Map Service",
+        props: { url: "http://example.com/MapServer" },
+      },
+    },
   },
 };
 
@@ -74,5 +117,181 @@ describe("useSnapping with a detached map target element", () => {
     expect(map.addLayer).toHaveBeenCalledTimes(1);
     const previewLayer = map.addLayer.mock.calls[0][0];
     expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+  });
+});
+
+describe("useSnapping vector-layer live-source snap caches (U2)", () => {
+  afterEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  test("a GeoJSON snap layer resolves to the live OL source with no fetch, and stays live after refresh", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const stubLayer = makeStubOlLayer("Rivers", liveSource);
+    const map = makeMapWithLayers([stubLayer]);
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [geoJsonRiverLayerConfig] }),
+    );
+
+    await result.current.refreshSnapCaches(map);
+    result.current.updateSnap(map, [SNAP_PIXELS - 5, 50]);
+
+    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(map.addLayer).toHaveBeenCalledTimes(1);
+    const previewLayer = map.addLayer.mock.calls[0][0];
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+
+    // Mutate the live source AFTER refresh (no second refreshSnapCaches call)
+    // by adding a feature far from the first one. Only the new feature is
+    // within snap range of the next coordinate, so a drawn preview there
+    // proves the cache entry is a live reference to `liveSource`, not a copy
+    // taken at refresh time.
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [1000, 1000],
+          [1000, 1100],
+        ]),
+      }),
+    );
+    result.current.updateSnap(map, [1000 + SNAP_PIXELS - 5, 1050]);
+    const previewFeatures = previewLayer.getSource().getFeatures();
+    expect(previewFeatures).toHaveLength(2);
+  });
+
+  test("does not call fetchLayerVectorFeatures for a GeoJSON snap layer", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const stubLayer = makeStubOlLayer("Rivers", liveSource);
+    const map = makeMapWithLayers([stubLayer]);
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [geoJsonRiverLayerConfig] }),
+    );
+
+    await result.current.refreshSnapCaches(map);
+
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  test("mixed map: fetch runs once for the Map Service layer while the GeoJSON layer resolves live, both snappable", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const stubLayer = makeStubOlLayer("Rivers", liveSource);
+    const map = makeMapWithLayers([stubLayer]);
+    mockedFetch.mockResolvedValue([
+      new Feature({
+        geometry: new LineString([
+          [1000, 1000],
+          [1000, 1100],
+        ]),
+      }),
+    ]);
+    const { result } = renderHook(() =>
+      useSnapping({
+        layers: [geoJsonRiverLayerConfig, mapServiceRiverLayerConfig],
+      }),
+    );
+
+    await result.current.refreshSnapCaches(map);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    // The GeoJSON layer's live feature is snappable.
+    result.current.updateSnap(map, [SNAP_PIXELS - 5, 50]);
+    expect(map.addLayer).toHaveBeenCalledTimes(1);
+    const previewLayer = map.addLayer.mock.calls[0][0];
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+
+    // The Map Service layer's fetched feature is also snappable.
+    result.current.updateSnap(map, [1000 + SNAP_PIXELS - 5, 1050]);
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+  });
+
+  test("a GeoJSON snap layer with no matching OL instance contributes no cache entry and does not throw", async () => {
+    // No stub layer named "Rivers" — simulates a layer mid-rebuild.
+    const map = makeMapWithLayers([]);
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [geoJsonRiverLayerConfig] }),
+    );
+
+    await expect(result.current.refreshSnapCaches(map)).resolves.not.toThrow();
+    expect(mockedFetch).not.toHaveBeenCalled();
+
+    expect(() =>
+      result.current.updateSnap(map, [SNAP_PIXELS - 5, 50]),
+    ).not.toThrow();
+    // No cache entry means nothing to snap to and no preview layer created.
+    expect(map.addLayer).not.toHaveBeenCalled();
+  });
+
+  test("a GeoJSON snap layer whose OL instance's getSource() returns null is skipped without throwing", async () => {
+    const stubLayer = makeStubOlLayer("Rivers", null);
+    const map = makeMapWithLayers([stubLayer]);
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [geoJsonRiverLayerConfig] }),
+    );
+
+    await expect(result.current.refreshSnapCaches(map)).resolves.not.toThrow();
+    expect(mockedFetch).not.toHaveBeenCalled();
+
+    expect(() =>
+      result.current.updateSnap(map, [SNAP_PIXELS - 5, 50]),
+    ).not.toThrow();
+    expect(map.addLayer).not.toHaveBeenCalled();
+  });
+
+  test("zoom gate: a GeoJSON snap layer below its minZoomQuery is excluded without fetching or resolving the OL instance", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const stubLayer = makeStubOlLayer("Rivers", liveSource);
+    // Map zoom (10, the makeMapWithLayers default) is below minZoomQuery (15).
+    const map = makeMapWithLayers([stubLayer], { zoom: 10 });
+    const zoomGatedConfig = {
+      configuration: {
+        props: {
+          ...geoJsonRiverLayerConfig.configuration.props,
+          minZoomQuery: 15,
+        },
+      },
+    };
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [zoomGatedConfig] }),
+    );
+
+    await result.current.refreshSnapCaches(map);
+    expect(mockedFetch).not.toHaveBeenCalled();
+
+    result.current.updateSnap(map, [SNAP_PIXELS - 5, 50]);
+    // Excluded by the zoom gate entirely, so no snap and no preview layer.
+    expect(map.addLayer).not.toHaveBeenCalled();
   });
 });

--- a/reactapp/__tests__/components/visualizations/useSnapping.test.js
+++ b/reactapp/__tests__/components/visualizations/useSnapping.test.js
@@ -315,6 +315,47 @@ describe("useSnapping vector-layer live-source snap caches (U2)", () => {
     expect(previewLayer.getSource().getFeatures()).toHaveLength(0);
   });
 
+  test("an entry whose layer left the layers prop falls back to its refresh-time radius", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    const stubLayer = makeStubOlLayer("Rivers", liveSource);
+    const map = makeMapWithLayers([stubLayer]);
+    const riversWithTolerance = [
+      {
+        configuration: {
+          props: {
+            name: "Rivers",
+            snapToFeatures: true,
+            clickTolerance: 30,
+            source: { type: "GeoJSON" },
+          },
+        },
+      },
+    ];
+
+    const { result, rerender } = renderHook((props) => useSnapping(props), {
+      initialProps: { layers: riversWithTolerance },
+    });
+    await result.current.refreshSnapCaches(map);
+
+    // The layer config disappears from the layers prop (removed/renamed
+    // mid-edit) while its cache entry and OL layer are still present: the
+    // use-time tolerance lookup misses and the refresh-time radius (30)
+    // still applies until the next cache refresh drops the entry.
+    rerender({ layers: [] });
+    result.current.updateSnap(map, [25, 50]);
+    expect(map.addLayer).toHaveBeenCalledTimes(1);
+    const previewLayer = map.addLayer.mock.calls[0][0];
+    expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
+  });
+
   test("snapping obeys the layer's min/max zoom bounds (renderer visibility, not just getVisible)", async () => {
     const liveSource = new VectorSource();
     liveSource.addFeature(

--- a/reactapp/__tests__/components/visualizations/useSnapping.test.js
+++ b/reactapp/__tests__/components/visualizations/useSnapping.test.js
@@ -229,6 +229,53 @@ describe("useSnapping vector-layer live-source snap caches (U2)", () => {
     expect(previewLayer.getSource().getFeatures()).toHaveLength(2);
   });
 
+  test("snapping obeys the layer's min/max zoom bounds (renderer visibility, not just getVisible)", async () => {
+    const liveSource = new VectorSource();
+    liveSource.addFeature(
+      new Feature({
+        geometry: new LineString([
+          [0, 0],
+          [0, 100],
+        ]),
+      }),
+    );
+    // getVisible() reports true, but the layer's own minZoom hides it at the
+    // current view zoom — snapping must follow the renderer, not the flag.
+    const zoomBoundLayer = (minZoom) => ({
+      ...makeStubOlLayer("Rivers", liveSource),
+      getLayerState: () => ({
+        visible: true,
+        minResolution: 0,
+        maxResolution: Infinity,
+        minZoom,
+        maxZoom: Infinity,
+      }),
+    });
+    const mapAtZoom = (olLayer, zoom) => ({
+      ...makeMapWithLayers([olLayer], { zoom }),
+      getView: () => ({
+        getZoom: () => zoom,
+        getResolution: () => 1,
+        getState: () => ({ zoom, resolution: 1 }),
+      }),
+    });
+
+    // View zoom 5 is NOT above the layer's minZoom 8 -> hidden -> no snap.
+    const hiddenMap = mapAtZoom(zoomBoundLayer(8), 5);
+    const { result } = renderHook(() =>
+      useSnapping({ layers: [geoJsonRiverLayerConfig] }),
+    );
+    await result.current.refreshSnapCaches(hiddenMap);
+    result.current.updateSnap(hiddenMap, [SNAP_PIXELS - 5, 50]);
+    expect(hiddenMap.addLayer).not.toHaveBeenCalled();
+
+    // Same layer shape within its zoom bounds -> snaps normally.
+    const shownMap = mapAtZoom(zoomBoundLayer(2), 5);
+    await result.current.refreshSnapCaches(shownMap);
+    result.current.updateSnap(shownMap, [SNAP_PIXELS - 5, 50]);
+    expect(shownMap.addLayer).toHaveBeenCalledTimes(1);
+  });
+
   test("a GeoJSON snap layer with no matching OL instance contributes no cache entry and does not throw", async () => {
     // No stub layer named "Rivers" — simulates a layer mid-rebuild.
     const map = makeMapWithLayers([]);

--- a/reactapp/components/map/Map.js
+++ b/reactapp/components/map/Map.js
@@ -595,8 +595,11 @@ const MapComponent = ({
           // before the handler is attached and snapping would stay inert
           // until the first user pan. Guarded to run once per map instance —
           // this block re-runs on every layer update and the handler issues
-          // real network fetches.
-          if (!onMapMoveEndPrimed.current) {
+          // real network fetches. The prime waits for the first run that
+          // actually carries layers: the very first effect pass runs before
+          // the parent's layer state resolves, and live-source snap caches
+          // (GeoJSON/Feature Service) need their OL layers mounted to resolve.
+          if (!onMapMoveEndPrimed.current && (layers?.length ?? 0) > 0) {
             onMapMoveEndPrimed.current = true;
             onMapMoveEndCurrent.current();
           }

--- a/reactapp/components/map/snapping.js
+++ b/reactapp/components/map/snapping.js
@@ -13,7 +13,10 @@ import { Point } from "ol/geom";
 import { Stroke, Style, Circle, Fill } from "ol/style";
 import GeoJSONFormat from "ol/format/GeoJSON";
 import JSON5 from "json5";
-import { shiftEPSG3857ExtentAndPoint } from "components/map/utilities";
+import {
+  shiftEPSG3857ExtentAndPoint,
+  coerceOptionalNumber,
+} from "components/map/utilities";
 
 // Cyan hover-preview color — visually distinct from the dark-blue
 // click/selection highlight so the two never clobber each other.
@@ -64,18 +67,14 @@ export function layerDefsToWhere(layerDefs, sublayer = 0) {
 // translation the /identify path (getESRILayerFeatures) already does for its
 // `layers` param; falls back to 0 when neither is present/parseable.
 export function resolveSnapSublayer(props) {
-  const explicit = props?.snapSublayer ?? props?.querySublayer;
   // GUI inputs emit strings, so accept any numeric value but treat anything
-  // non-numeric (including "") as unset rather than an explicit override —
-  // otherwise a cleared field would produce a malformed `//query` URL.
-  if (
-    explicit !== null &&
-    explicit !== undefined &&
-    explicit !== "" &&
-    Number.isFinite(Number(explicit))
-  ) {
-    return Number(explicit);
-  }
+  // blank or non-numeric (including whitespace-only strings) as unset rather
+  // than an explicit override — otherwise a cleared field would produce a
+  // malformed `//query` URL.
+  const explicit = coerceOptionalNumber(
+    props?.snapSublayer ?? props?.querySublayer,
+  );
+  if (explicit !== undefined) return explicit;
   const match = props?.source?.props?.params?.LAYERS?.match(
     /^(show|include):\s*(\d+)/,
   );

--- a/reactapp/components/map/snapping.js
+++ b/reactapp/components/map/snapping.js
@@ -192,12 +192,19 @@ export function findSnapFeature(vectorSource, coordinate, map, snapPx = 15) {
 }
 
 // Snap across multiple cached vector sources, returning the closest qualifying
-// feature. `caches` is an array of { layerName, source }. Returns
+// feature. `caches` is an array of { layerName, source, snapPx? } — an entry's
+// own snapPx (derived from the layer's clickTolerance, so one setting governs
+// hit-testing AND snap reach) overrides the shared default. Returns
 // { layerName, feature, coordinate, pixelDistance } or null when nothing snaps.
 export function findBestSnap(caches, coordinate, map, snapPx = 15) {
   let best = null;
   for (const cache of caches ?? []) {
-    const hit = findSnapFeature(cache?.source, coordinate, map, snapPx);
+    const hit = findSnapFeature(
+      cache?.source,
+      coordinate,
+      map,
+      cache?.snapPx ?? snapPx,
+    );
     if (hit && (!best || hit.pixelDistance < best.pixelDistance)) {
       best = { ...hit, layerName: cache.layerName };
     }
@@ -215,23 +222,27 @@ export function findSnapFeatures(caches, coordinate, map, gatherPx = 35) {
   const cursorPixel = map.getPixelFromCoordinate(coordinate);
   const resolution = map.getView().getResolution();
   if (!cursorPixel || !resolution) return [];
-  const r = gatherPx * resolution;
-  const extent = [
-    coordinate[0] - r,
-    coordinate[1] - r,
-    coordinate[0] + r,
-    coordinate[1] + r,
-  ];
   const results = [];
   for (const cache of caches ?? []) {
     const source = cache?.source;
     if (!source?.forEachFeatureInExtent) continue;
+    // A layer's own snap radius (from clickTolerance) can exceed the shared
+    // gather default — the gather must never be narrower than the snap
+    // itself, or a confluence click would page fewer reaches than it snaps.
+    const cacheGatherPx = Math.max(gatherPx, cache?.snapPx ?? 0);
+    const r = cacheGatherPx * resolution;
+    const extent = [
+      coordinate[0] - r,
+      coordinate[1] - r,
+      coordinate[0] + r,
+      coordinate[1] + r,
+    ];
     source.forEachFeatureInExtent(extent, (feature) => {
       const geometry = feature.getGeometry?.();
       if (!geometry) return;
       const snapped = geometry.getClosestPoint(coordinate);
       const pixelDistance = pixelDistanceBetween(map, coordinate, snapped);
-      if (pixelDistance !== null && pixelDistance <= gatherPx) {
+      if (pixelDistance !== null && pixelDistance <= cacheGatherPx) {
         results.push({
           feature,
           coordinate: snapped,

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -219,7 +219,7 @@ export const layerPropertiesOptions = {
   clickTolerance: {
     type: "number",
     placeholder:
-      "Pixel tolerance for ESRI Image and Map Service identify (click) requests. Defaults to 10.",
+      "Pixel tolerance for ESRI Image and Map Service identify (click) requests (default 10) and for GeoJSON / ESRI Feature Service feature queries (default 0).",
   },
   snapToFeatures: {
     type: "checkbox",
@@ -599,11 +599,21 @@ export async function queryLayerFeatures(layerInfo, map, coordinate, pixel) {
       sourceType === "GeoJSON" ||
       sourceType === "ESRI Feature Service"
     ) {
+      // GUI inputs emit strings; coerce and treat non-finite (including "") as unset
+      const rawClickTolerance = layerInfo.configuration.props.clickTolerance;
+      const clickTolerance =
+        rawClickTolerance !== null &&
+        rawClickTolerance !== undefined &&
+        rawClickTolerance !== "" &&
+        Number.isFinite(Number(rawClickTolerance))
+          ? Number(rawClickTolerance)
+          : undefined;
       features = await getGeoJSONLayerFeatures(
         map,
         pixel,
         coordinate,
         LayerName,
+        clickTolerance,
       );
     } else if (sourceType === "PMTiles Vector") {
       features = getVectorTileLayerFeatures(map, pixel);
@@ -821,78 +831,88 @@ async function getImageWMSLayerFeatures(sourceUrl, sourceParams, map, pixel) {
   return features;
 }
 
-async function getGeoJSONLayerFeatures(map, pixel, coordinate, LayerName) {
+async function getGeoJSONLayerFeatures(
+  map,
+  pixel,
+  coordinate,
+  LayerName,
+  tolerance,
+) {
   const features = [];
 
   // loop through the feature layers that are found at the clicked pixel
-  map.forEachFeatureAtPixel(pixel, function (feature, layer) {
-    // dont get any features that are highlights or markers
-    if (layer.get("name") !== LayerName) {
-      return;
-    }
-
-    if (feature) {
-      let clickedGeometries = [];
-      const { geometry, ...properties } = feature.getProperties();
-
-      // if a feature is a collection of geometries, then check each individual item in the collection and check if it was clicked
-      if (
-        geometry.getType() === "GeometryCollection" ||
-        geometry.getType() === "MultiGeometry"
-      ) {
-        const resolution = map.getView().getResolution();
-
-        // loop through each individual geometry in the collection
-        geometry.getGeometries().forEach((geom) => {
-          const type = geom.getType();
-
-          // if the geometry is a point or string (not a polygon) then see how close the click was to the feature
-          if (
-            type === "Point" ||
-            type === "LineString" ||
-            type === "MultiLineString"
-          ) {
-            // get the closest feature point to the clicked coordinate
-            const closestPoint = geom.getClosestPoint(coordinate);
-
-            // calculate the distance from the closest point to the clicked coordinate and convert from coordinate unit to pixel
-            const distance =
-              Math.sqrt(
-                Math.pow(closestPoint[0] - coordinate[0], 2) +
-                  Math.pow(closestPoint[1] - coordinate[1], 2),
-              ) / resolution;
-
-            // if the closest point distance is less than the threshold, count it as being clicked
-            const threshold = 10; // pixel threshold
-            if (distance < threshold) {
-              clickedGeometries.push(geom);
-            }
-          } else {
-            // check to see if the geometry intersects with the coordinate
-            if (geom.intersectsCoordinate(coordinate)) {
-              clickedGeometries.push(geom);
-            }
-          }
-        });
-      } else {
-        clickedGeometries.push(geometry);
+  map.forEachFeatureAtPixel(
+    pixel,
+    function (feature, layer) {
+      // dont get any features that are highlights or markers
+      if (layer.get("name") !== LayerName) {
+        return;
       }
 
-      // for each geometry that was clicked or within a threshold of clicking, add it feature and attributes
-      if (clickedGeometries.length > 0) {
-        clickedGeometries.forEach((clickedGeometry) => {
-          features.push({
-            layerName: layer.getProperties().name,
-            attributes: properties,
-            geometry: {
-              type: clickedGeometry.getType(),
-              coordinates: clickedGeometry.getCoordinates(),
-            },
+      if (feature) {
+        let clickedGeometries = [];
+        const { geometry, ...properties } = feature.getProperties();
+
+        // if a feature is a collection of geometries, then check each individual item in the collection and check if it was clicked
+        if (
+          geometry.getType() === "GeometryCollection" ||
+          geometry.getType() === "MultiGeometry"
+        ) {
+          const resolution = map.getView().getResolution();
+
+          // loop through each individual geometry in the collection
+          geometry.getGeometries().forEach((geom) => {
+            const type = geom.getType();
+
+            // if the geometry is a point or string (not a polygon) then see how close the click was to the feature
+            if (
+              type === "Point" ||
+              type === "LineString" ||
+              type === "MultiLineString"
+            ) {
+              // get the closest feature point to the clicked coordinate
+              const closestPoint = geom.getClosestPoint(coordinate);
+
+              // calculate the distance from the closest point to the clicked coordinate and convert from coordinate unit to pixel
+              const distance =
+                Math.sqrt(
+                  Math.pow(closestPoint[0] - coordinate[0], 2) +
+                    Math.pow(closestPoint[1] - coordinate[1], 2),
+                ) / resolution;
+
+              // if the closest point distance is less than the threshold, count it as being clicked
+              const threshold = tolerance ?? 10; // pixel threshold
+              if (distance < threshold) {
+                clickedGeometries.push(geom);
+              }
+            } else {
+              // check to see if the geometry intersects with the coordinate
+              if (geom.intersectsCoordinate(coordinate)) {
+                clickedGeometries.push(geom);
+              }
+            }
           });
-        });
+        } else {
+          clickedGeometries.push(geometry);
+        }
+
+        // for each geometry that was clicked or within a threshold of clicking, add it feature and attributes
+        if (clickedGeometries.length > 0) {
+          clickedGeometries.forEach((clickedGeometry) => {
+            features.push({
+              layerName: layer.getProperties().name,
+              attributes: properties,
+              geometry: {
+                type: clickedGeometry.getType(),
+                coordinates: clickedGeometry.getCoordinates(),
+              },
+            });
+          });
+        }
       }
-    }
-  });
+    },
+    { hitTolerance: tolerance ?? 0 },
+  );
 
   return features;
 }

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -224,7 +224,7 @@ export const layerPropertiesOptions = {
   snapToFeatures: {
     type: "checkbox",
     placeholder:
-      "Snap hover/click to the nearest feature of this ESRI Map Service layer (loads vector features for the current view).",
+      "Snap hover/click to the nearest feature of this layer (ESRI Map Service, GeoJSON, or ESRI Feature Service).",
   },
   snapSublayer: {
     type: "number",

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -16,6 +16,20 @@ import { PMTiles } from "pmtiles";
 import { VectorTile } from "@mapbox/vector-tile";
 import Protobuf from "pbf";
 
+// Source types whose features live in a client-side OL VectorSource (vs
+// server-rendered services queried remotely).
+export const CLIENT_VECTOR_SOURCE_TYPES = ["GeoJSON", "ESRI Feature Service"];
+
+// Coerce an optional numeric layer prop: GUI inputs emit strings, so accept
+// any numeric value but treat null/undefined/blank/non-numeric as unset.
+export function coerceOptionalNumber(value) {
+  if (value === null || value === undefined) return undefined;
+  const str = String(value).trim();
+  if (str === "") return undefined;
+  const num = Number(str);
+  return Number.isFinite(num) ? num : undefined;
+}
+
 export const sourcePropertiesOptions = {
   "ESRI Image and Map Service": {
     required: {
@@ -595,19 +609,10 @@ export async function queryLayerFeatures(layerInfo, map, coordinate, pixel) {
         map,
         pixel,
       );
-    } else if (
-      sourceType === "GeoJSON" ||
-      sourceType === "ESRI Feature Service"
-    ) {
-      // GUI inputs emit strings; coerce and treat non-finite (including "") as unset
-      const rawClickTolerance = layerInfo.configuration.props.clickTolerance;
-      const clickTolerance =
-        rawClickTolerance !== null &&
-        rawClickTolerance !== undefined &&
-        rawClickTolerance !== "" &&
-        Number.isFinite(Number(rawClickTolerance))
-          ? Number(rawClickTolerance)
-          : undefined;
+    } else if (CLIENT_VECTOR_SOURCE_TYPES.includes(sourceType)) {
+      const clickTolerance = coerceOptionalNumber(
+        layerInfo.configuration.props.clickTolerance,
+      );
       features = await getGeoJSONLayerFeatures(
         map,
         pixel,

--- a/reactapp/components/map/utilities.js
+++ b/reactapp/components/map/utilities.js
@@ -233,7 +233,7 @@ export const layerPropertiesOptions = {
   clickTolerance: {
     type: "number",
     placeholder:
-      "Pixel tolerance for ESRI Image and Map Service identify (click) requests (default 10) and for GeoJSON / ESRI Feature Service feature queries (default 0).",
+      "Pixel tolerance for ESRI Image and Map Service identify (click) requests (default 10) and for GeoJSON / ESRI Feature Service feature queries (default 0). Also sets the snap radius when Snap To Features is on (default 15).",
   },
   snapToFeatures: {
     type: "checkbox",

--- a/reactapp/components/visualizations/useSnapping.js
+++ b/reactapp/components/visualizations/useSnapping.js
@@ -32,6 +32,15 @@ const getOlVisibilityMap = (map) => {
   return olVisibility;
 };
 
+// Resolve a live OL layer instance by its configured `name` — same lookup
+// convention as getOlVisibilityMap. Returns undefined when no OL layer with
+// that name is currently mounted (e.g. mid-rebuild).
+const getOlLayerByName = (map, name) =>
+  map
+    .getLayers()
+    .getArray()
+    .find((olLayer) => olLayer.get("name") === name);
+
 export default function useSnapping({ layers }) {
   const snapLayer = useRef(null);
   const snapCachesRef = useRef([]);
@@ -88,13 +97,38 @@ export default function useSnapping({ layers }) {
       clearSnap(map);
       return;
     }
-    const caches = await Promise.all(
-      snapLayers.map(async (layer) => {
-        const source = new VectorSource();
-        source.addFeatures(await fetchLayerVectorFeatures(layer, map));
-        return { layerName: layer.configuration.props.name, source };
-      }),
-    );
+    const caches = (
+      await Promise.all(
+        snapLayers.map(async (layer) => {
+          const layerName = layer.configuration.props.name;
+          const sourceType = layer.configuration?.props?.source?.type;
+          if (
+            sourceType === "GeoJSON" ||
+            sourceType === "ESRI Feature Service"
+          ) {
+            // Live source, not a snapshot: these layers' features already
+            // live in an OL VectorSource in the browser, so the cache entry
+            // IS that source — no fetch, no new VectorSource. This means the
+            // snap set always equals the rendered set (strictly better than
+            // the fetch path's approximation); features streaming in via the
+            // source's loading strategy become snappable as they load, with
+            // no moveend dependency; and the generation token above is
+            // irrelevant for these entries since there's nothing async to
+            // discard — they resolve synchronously below. Rebuilt every
+            // refresh so a layer rebuild re-resolves the OL instance.
+            const olLayer = getOlLayerByName(map, layerName);
+            const source = olLayer?.getSource?.();
+            // Unresolved OL instance (mid-rebuild) or a missing source:
+            // contribute nothing this cycle rather than throw — the next
+            // refresh picks it up.
+            return source ? { layerName, source } : null;
+          }
+          const source = new VectorSource();
+          source.addFeatures(await fetchLayerVectorFeatures(layer, map));
+          return { layerName, source };
+        }),
+      )
+    ).filter(Boolean);
     // Discard if a newer refresh started while this one was in flight.
     if (refreshId === snapRefreshId.current) {
       snapCachesRef.current = caches;

--- a/reactapp/components/visualizations/useSnapping.js
+++ b/reactapp/components/visualizations/useSnapping.js
@@ -157,6 +157,17 @@ export default function useSnapping({ layers }) {
   // against live OL visibility at use time instead of event-wiring the control.
   const visibleSnapCaches = (map) => {
     const olVisibility = getOlVisibilityMap(map);
+    // The snap radius is re-read from the CURRENT layers prop at use time —
+    // the refresh-time value baked into the entry only serves as a fallback.
+    // Cache refreshes only run on moveend/prime, so a saved clickTolerance
+    // edit must not have to wait for the next pan to take effect.
+    const snapPxByName = new Map(
+      layers.map((item) => [
+        item.configuration?.props?.name,
+        coerceOptionalNumber(item.configuration?.props?.clickTolerance) ??
+          SNAP_PIXELS,
+      ]),
+    );
     // snapCachesRef.current is initialized to [] and only ever assigned arrays.
     return (
       snapCachesRef.current
@@ -175,11 +186,10 @@ export default function useSnapping({ layers }) {
         // dropped for this call — there is nothing to snap against — and the
         // next call re-resolves it.
         .map((cache) => {
-          if (!cache.live) return cache;
+          const snapPx = snapPxByName.get(cache.layerName) ?? cache.snapPx;
+          if (!cache.live) return { ...cache, snapPx };
           const source = getOlLayerByName(map, cache.layerName)?.getSource?.();
-          return source
-            ? { layerName: cache.layerName, source, snapPx: cache.snapPx }
-            : null;
+          return source ? { layerName: cache.layerName, source, snapPx } : null;
         })
         .filter(Boolean)
     );

--- a/reactapp/components/visualizations/useSnapping.js
+++ b/reactapp/components/visualizations/useSnapping.js
@@ -7,13 +7,18 @@ import {
   fetchLayerVectorFeatures,
   findBestSnap,
 } from "components/map/snapping";
-import { CLIENT_VECTOR_SOURCE_TYPES } from "components/map/utilities";
+import {
+  CLIENT_VECTOR_SOURCE_TYPES,
+  coerceOptionalNumber,
+} from "components/map/utilities";
 
 // --- Feature snapping (Approach A) -------------------------------------
 // Maintain a hidden vector cache of snap-enabled layers' features for the
 // current view, snap the cursor to the nearest one on hover, and on a snapped
 // click select the river directly from that local feature (no ESRI /identify,
 // which is slow on a cache miss and sometimes returns empty on-geometry).
+// Default hover-snap radius; a layer's clickTolerance overrides it per layer
+// (one setting governs hit-testing, hover popups, and snap reach).
 export const SNAP_PIXELS = 15;
 // Wider radius (mirrors the old /identify tolerance) for gathering the
 // connected reaches at a confluence into the click popup's swiper.
@@ -114,6 +119,11 @@ export default function useSnapping({ layers }) {
         snapLayers.map(async (layer) => {
           const layerName = layer.configuration.props.name;
           const sourceType = layer.configuration?.props?.source?.type;
+          // The layer's clickTolerance doubles as its snap radius so one
+          // setting governs all pointer interaction with the layer.
+          const snapPx =
+            coerceOptionalNumber(layer.configuration.props.clickTolerance) ??
+            SNAP_PIXELS;
           if (CLIENT_VECTOR_SOURCE_TYPES.includes(sourceType)) {
             // Live source, not a snapshot: these layers' features already
             // live in an OL VectorSource in the browser, so no fetch and no
@@ -128,11 +138,11 @@ export default function useSnapping({ layers }) {
             // (b) use-time resolution also covers snap layers that mount
             // after the one-shot prime. Nothing async here, so the
             // generation token above is irrelevant for these entries.
-            return { layerName, live: true };
+            return { layerName, live: true, snapPx };
           }
           const source = new VectorSource();
           source.addFeatures(await fetchLayerVectorFeatures(layer, map));
-          return { layerName, source };
+          return { layerName, source, snapPx };
         }),
       )
     ).filter(Boolean);
@@ -167,7 +177,9 @@ export default function useSnapping({ layers }) {
         .map((cache) => {
           if (!cache.live) return cache;
           const source = getOlLayerByName(map, cache.layerName)?.getSource?.();
-          return source ? { layerName: cache.layerName, source } : null;
+          return source
+            ? { layerName: cache.layerName, source, snapPx: cache.snapPx }
+            : null;
         })
         .filter(Boolean)
     );

--- a/reactapp/components/visualizations/useSnapping.js
+++ b/reactapp/components/visualizations/useSnapping.js
@@ -6,6 +6,7 @@ import {
   fetchLayerVectorFeatures,
   findBestSnap,
 } from "components/map/snapping";
+import { CLIENT_VECTOR_SOURCE_TYPES } from "components/map/utilities";
 
 // --- Feature snapping (Approach A) -------------------------------------
 // Maintain a hidden vector cache of snap-enabled layers' features for the
@@ -102,26 +103,21 @@ export default function useSnapping({ layers }) {
         snapLayers.map(async (layer) => {
           const layerName = layer.configuration.props.name;
           const sourceType = layer.configuration?.props?.source?.type;
-          if (
-            sourceType === "GeoJSON" ||
-            sourceType === "ESRI Feature Service"
-          ) {
+          if (CLIENT_VECTOR_SOURCE_TYPES.includes(sourceType)) {
             // Live source, not a snapshot: these layers' features already
-            // live in an OL VectorSource in the browser, so the cache entry
-            // IS that source — no fetch, no new VectorSource. This means the
-            // snap set always equals the rendered set (strictly better than
-            // the fetch path's approximation); features streaming in via the
-            // source's loading strategy become snappable as they load, with
-            // no moveend dependency; and the generation token above is
-            // irrelevant for these entries since there's nothing async to
-            // discard — they resolve synchronously below. Rebuilt every
-            // refresh so a layer rebuild re-resolves the OL instance.
-            const olLayer = getOlLayerByName(map, layerName);
-            const source = olLayer?.getSource?.();
-            // Unresolved OL instance (mid-rebuild) or a missing source:
-            // contribute nothing this cycle rather than throw — the next
-            // refresh picks it up.
-            return source ? { layerName, source } : null;
+            // live in an OL VectorSource in the browser, so no fetch and no
+            // new VectorSource — the snap set always equals the rendered set
+            // (strictly better than the fetch path's approximation), and
+            // features streaming in via the source's loading strategy become
+            // snappable as they load, with no moveend dependency. The entry
+            // is only a marker; the OL source is resolved at USE time
+            // (visibleSnapCaches) because (a) the reconciliation sweep in
+            // map/Map.js rebuilds VectorLayers on any layers change, so a
+            // reference captured here goes stale until the next moveend, and
+            // (b) use-time resolution also covers snap layers that mount
+            // after the one-shot prime. Nothing async here, so the
+            // generation token above is irrelevant for these entries.
+            return { layerName, live: true };
           }
           const source = new VectorSource();
           source.addFeatures(await fetchLayerVectorFeatures(layer, map));
@@ -141,13 +137,28 @@ export default function useSnapping({ layers }) {
   const visibleSnapCaches = (map) => {
     const olVisibility = getOlVisibilityMap(map);
     // snapCachesRef.current is initialized to [] and only ever assigned arrays.
-    return snapCachesRef.current.filter(
-      // Entries with no matching OL layer are retained on purpose: mid-rebuild
-      // the layer may not be mounted yet (matches refreshSnapCaches'
-      // benefit-of-the-doubt filter).
-      (cache) =>
-        !olVisibility.has(cache.layerName) ||
-        olVisibility.get(cache.layerName) === true,
+    return (
+      snapCachesRef.current
+        .filter(
+          // Entries with no matching OL layer pass the visibility check on
+          // purpose: mid-rebuild the layer may not be mounted yet (matches
+          // refreshSnapCaches' benefit-of-the-doubt filter).
+          (cache) =>
+            !olVisibility.has(cache.layerName) ||
+            olVisibility.get(cache.layerName) === true,
+        )
+        // Live entries resolve their OL source at use time so snapping always
+        // targets the currently-mounted VectorSource (the reconciliation
+        // sweep rebuilds VectorLayers on any layers change). When the OL
+        // layer/source isn't currently resolvable (mid-rebuild), the entry is
+        // dropped for this call — there is nothing to snap against — and the
+        // next call re-resolves it.
+        .map((cache) => {
+          if (!cache.live) return cache;
+          const source = getOlLayerByName(map, cache.layerName)?.getSource?.();
+          return source ? { layerName: cache.layerName, source } : null;
+        })
+        .filter(Boolean)
     );
   };
 

--- a/reactapp/components/visualizations/useSnapping.js
+++ b/reactapp/components/visualizations/useSnapping.js
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import VectorSource from "ol/source/Vector";
+import { inView } from "ol/layer/Layer";
 import {
   createSnapLayer,
   addSnapPreview,
@@ -18,17 +19,27 @@ export const SNAP_PIXELS = 15;
 // connected reaches at a confluence into the click popup's swiper.
 export const GATHER_PIXELS = 35;
 
+// Effective per-layer visibility: the renderer's own test (visible flag plus
+// the layer's min/max zoom and resolution bounds) via ol's `inView` —
+// `getVisible()` alone reports true for layers the view has zoomed out of.
+// Falls back to the plain flag for layer objects without OL layer state.
+const isLayerShown = (olLayer, viewState) =>
+  viewState && olLayer.getLayerState
+    ? inView(olLayer.getLayerState(), viewState)
+    : olLayer.getVisible();
+
 // Live OL-layer visibility keyed by layer name — built fresh per call because
 // LayersControl mutates visibility directly on the OL layer without any React
 // state change this hook could subscribe to.
 const getOlVisibilityMap = (map) => {
   const olVisibility = new Map();
+  const viewState = map.getView().getState?.();
   map
     .getLayers()
     .getArray()
     .forEach((olLayer) => {
       const name = olLayer.get("name");
-      if (name) olVisibility.set(name, olLayer.getVisible());
+      if (name) olVisibility.set(name, isLayerShown(olLayer, viewState));
     });
   return olVisibility;
 };


### PR DESCRIPTION
# feat(map): extend snapToFeatures and clickTolerance to GeoJSON and ESRI Feature Service layers

**Branch:** `feat/vector-layer-snap-tolerance` → `main`
**Follow-up to** #157, which introduced these options for ESRI Image and Map Service layers.

## Summary

The two per-layer interaction options shipped in #157 now work on client-side vector layers:

1. **`clickTolerance`** — GeoJSON and ESRI Feature Service clicks (and hover popups) previously required pixel-perfect hits. A configured tolerance now widens the hit area via OL's native `hitTolerance`, including the previously hardcoded 10px inner threshold used for GeometryCollection/MultiLineString sub-geometry matching — so tolerances above 10 aren't silently capped on exactly the river-like shapes this targets.
2. **`snapToFeatures`** — vector layers get the full snap experience (cyan hover preview + pointer cursor, instant local click selection, confluence gathering) with **none** of the Map Service machinery: no `/query` fetches, no truncation degrade, no sublayer resolution. The snap cache reads the layer's **live** OL `VectorSource`, so what you can snap to is exactly what's rendered, and features that stream in as the source loads become snappable immediately.

Both options were already registered in the layer editor GUI; their placeholder text now reflects the wider support.

## How it works

- `refreshSnapCaches` stores a lightweight marker for vector snap layers and resolves the actual OL source **at use time** (each hover/click), not at refresh time. This matters because the layer-reconciliation sweep rebuilds every `VectorLayer` whenever the layers array changes (e.g., any variable-input update) — a captured source reference would go stale until the next pan. Use-time resolution also covers snap layers that finish mounting after the initial cache prime.
- The mount-time snap-cache prime (from #157) now waits for the first effect run that actually carries layers — previously it fired on the very first pass, before any OL layers existed, which would have left vector snap layers inert until the user's first pan.
- Defaults preserve existing behavior exactly: no `clickTolerance` means exact-hit clicking for vector layers (0, unlike the ESRI identify default of 10) and the inner collection threshold stays at its historical 10.
- Numeric layer props (`clickTolerance`, `snapSublayer`) now share one coercion rule (`coerceOptionalNumber`): GUI strings accepted, blank/whitespace/non-numeric treated as unset. One deliberate behavior tweak rides along: a whitespace-only `snapSublayer` (`" "`) previously resolved to an explicit sublayer 0; it now correctly falls back to the `LAYERS "show:N"` derivation.

## Behavioral notes for reviewers

- Setting `clickTolerance` on a vector layer widens **hover popups too** (click and hover share the query path) — deliberate, so hover and click agree on what's interactive.
- Snap-set equals rendered-set for vector layers by design: if a Feature Service tile response is server-truncated, the map renders the truncated set and snapping matches it — there's no separate completeness guarantee to enforce (unlike the Map Service `/query` path, which keeps its `exceededTransferLimit` degrade).
- **KML is deliberately out of scope** (its click path is a near-identical one-line extension; deferred as documented in the plan). The Layer Properties GUI shows `clickTolerance` for all layer types, so a KML author could set it and see no effect — accepted for now.
- Accepted residual: during the brief add-before-remove window of an in-flight layer rebuild, a name-keyed source lookup can still resolve the outgoing layer instance. Harmless (identical feature data at swap time) and self-healing at the next lookup.

## Testing

- **2,251 tests green** (45 new on this branch), ESLint + Prettier clean.
- Unit: both tolerance sites (outer `hitTolerance`, inner collection threshold), GUI string/blank/garbage coercion, `coerceOptionalNumber` edges, whitespace `snapSublayer`.
- Hook-level: live-source resolution (reference identity proven by mutating the source post-refresh), rebuilt-OL-layer follow-through without a moveend, late-mounting layers becoming snappable, mixed Map Service + GeoJSON maps (fetch fires exactly once, for the Map Service), zoom gating, null-source safety.
- Integration (real click/hover pipeline): hover preview + pointer cursor on a GeoJSON river, local snapped click selection with zero `queryLayerFeatures`/`fetchLayerVectorFeatures` calls, streamed-in features snappable with no moveend, visibility toggles stopping the preview, `hitTolerance` asserted through the unmocked click path, and the prime firing exactly once on the first layers-bearing run.

## Post-Deploy Monitoring & Validation

- **Verify:** a GeoJSON line layer with `clickTolerance: 20` accepts near-miss clicks and hover popups; a `snapToFeatures` GeoJSON layer shows the cyan preview on initial load *without panning*; network tab shows no snap-related requests for vector layers.
- **Watch:** after changing a variable input that rebuilds map layers, hover a snap-enabled vector layer — the preview should keep working immediately (failure signal: snapping goes dead until a pan, which would indicate the use-time resolution regressed).
- **No effect expected** on ESRI Map Service snapping, WMS/KML/PMTiles layers, or any layer without the new options set.
- **Window/owner:** first week of dashboard use; dashboard maintainer.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
