### PR TITLE
Fix/fillviewport stack order

### DIFF
--- a/reactapp/__tests__/components/dashboard/DashboardItem.test.js
+++ b/reactapp/__tests__/components/dashboard/DashboardItem.test.js
@@ -1699,6 +1699,52 @@ test("Dashboard Item fill viewport fills the content area in view mode", async (
   ).not.toBeInTheDocument();
 });
 
+test("Dashboard Item fill viewport does not force a z-index (stacks by grid order)", async () => {
+  const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
+  const gridItem = mockedDashboard.tabs[0].gridItems[0];
+  gridItem.metadata_string = JSON.stringify({ fillViewport: true });
+
+  render(
+    createLoadedComponent({
+      children: (
+        <>
+          <GridItemContext.Provider
+            value={{
+              gridItemSource: gridItem.source,
+              gridItemI: gridItem.i,
+              gridItemMetadataString: gridItem.metadata_string,
+              gridItemArgsString: gridItem.args_string,
+              gridItemIndex: 0,
+              enableFillViewport: true,
+            }}
+          >
+            <DashboardItem />
+          </GridItemContext.Provider>
+          <EditingPComponent />
+        </>
+      ),
+      options: {
+        initialDashboard: mockedDashboard,
+      },
+    }),
+  );
+
+  const dashboardGridItem = await screen.findByLabelText("gridItemDiv");
+  // Regression lock: the fill item must stay position:fixed (so it still fills
+  // the viewport) but must NOT carry the old fixed z-index:1020. With
+  // z-index:auto it paints in DOM/array order, so items ordered after it stay
+  // visible on top. The actual paint stacking is verified in-browser (jsdom
+  // does no layout/paint); this guards against re-introducing the override.
+  await waitFor(() => {
+    expect(
+      window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
+    ).toBe("fixed");
+  });
+  expect(
+    window.getComputedStyle(dashboardGridItem).getPropertyValue("z-index"),
+  ).not.toBe("1020");
+});
+
 test("Dashboard Item fill viewport shows grid size with indicator while editing", async () => {
   const mockedDashboard = JSON.parse(JSON.stringify(userDashboard));
   const gridItem = mockedDashboard.tabs[0].gridItems[0];

--- a/reactapp/__tests__/components/dashboard/DashboardItem.test.js
+++ b/reactapp/__tests__/components/dashboard/DashboardItem.test.js
@@ -1740,9 +1740,13 @@ test("Dashboard Item fill viewport does not force a z-index (stacks by grid orde
       window.getComputedStyle(dashboardGridItem).getPropertyValue("position"),
     ).toBe("fixed");
   });
+  // Not just "not 1020" — the fill item must carry no explicit stacking value
+  // at all, so it participates in DOM-order painting.
   expect(
+    ["", "auto"],
+  ).toContain(
     window.getComputedStyle(dashboardGridItem).getPropertyValue("z-index"),
-  ).not.toBe("1020");
+  );
 });
 
 test("Dashboard Item fill viewport shows grid size with indicator while editing", async () => {

--- a/reactapp/__tests__/components/dashboard/DashboardItem.test.js
+++ b/reactapp/__tests__/components/dashboard/DashboardItem.test.js
@@ -1742,9 +1742,7 @@ test("Dashboard Item fill viewport does not force a z-index (stacks by grid orde
   });
   // Not just "not 1020" — the fill item must carry no explicit stacking value
   // at all, so it participates in DOM-order painting.
-  expect(
-    ["", "auto"],
-  ).toContain(
+  expect(["", "auto"]).toContain(
     window.getComputedStyle(dashboardGridItem).getPropertyValue("z-index"),
   );
 });

--- a/reactapp/components/dashboard/DashboardItem.js
+++ b/reactapp/components/dashboard/DashboardItem.js
@@ -61,8 +61,12 @@ const StyledDiv = styled.div`
   position: relative;
   /* Fill-viewport override: escape the react-grid-layout-positioned parent via
      position:fixed so the item spans the content area below the fixed header
-     (and tab bar when shown), independent of screen size. Kept below Bootstrap
-     modal/backdrop z-index (1040) so modals from the visualization stay usable. */
+     (and tab bar when shown), independent of screen size. No explicit z-index:
+     a fixed element with z-index:auto still paints in DOM/tree order with the
+     other z-index:auto grid tiles, so the fill item stacks by its position in
+     the gridItems array. Items ordered after it stay visible on top; items
+     ordered before it sit behind. Positive-z-index chrome (modals 1040+,
+     alerts 1000/1081) paints above it automatically. */
   ${(props) =>
     props.$fillViewport &&
     css`
@@ -71,7 +75,6 @@ const StyledDiv = styled.div`
       left: 0;
       width: 100vw;
       height: calc(100vh - (${props.$fillOffset}));
-      z-index: 1020;
     `}
 `;
 

--- a/reactapp/components/modals/DataViewer/SettingsPane.js
+++ b/reactapp/components/modals/DataViewer/SettingsPane.js
@@ -249,7 +249,8 @@ function SettingsPane({
         style={{ display: "block", marginBottom: ".5rem", color: "#666" }}
       >
         Fills the screen below the navigation when viewed, on any screen size.
-        Covers other items on the tab.
+        Stacking follows item order — items placed in front of it stay visible;
+        reorder from the item menu where available.
       </small>
       <CustomMessaging
         vizInputsValues={vizInputsValues}

--- a/tethysapp/tethysdash/plugin_helpers.py
+++ b/tethysapp/tethysdash/plugin_helpers.py
@@ -233,7 +233,7 @@ class TethysDashPlugin(base.DataSource):
         result = {}
         for key, value in self.received_args.items():
             if key.startswith(prefix):
-                leaf = key[len(prefix) :]
+                leaf = key[len(prefix):]
                 if "." not in leaf:
                     result[leaf] = value
         return result


### PR DESCRIPTION
# fix: fillViewport stacks by grid item order

## Summary

A `fillViewport` grid item currently paints on top of every other tile because it applies a hard-coded `z-index: 1020`, which escapes react-grid-layout's normal stacking. That hides any tile a user intentionally places in front of it — e.g. a Base Map dropdown over a fill map.

This change removes the fixed z-index so the fill tile keeps `position: fixed` (still filling the viewport) but falls back to `z-index: auto`, painting in DOM/array order alongside every other tile. Stacking now follows grid-item order: tiles ordered **after** a fill tile stay visible on top of it, tiles ordered **before** it sit behind. This works in both restricted and unrestricted placement, and in unrestricted mode the existing **Bring to Front / Send to Back** controls now govern the fill tile's layering with no extra wiring.

## Motivation

`fillViewport` was documented as "Covers other items on the tab," but users need to keep controls, legends, and inputs visible over a fill visualization. The single fixed z-index was the only thing lifting the fill tile above the array-order stacking that every other tile already uses.

## Changes

- **`reactapp/components/dashboard/DashboardItem.js`** — Removed `z-index: 1020` from the fillViewport styled block; kept `position: fixed` and all sizing. Updated the comment to explain the DOM-order stacking rationale.
- **`reactapp/components/modals/DataViewer/SettingsPane.js`** — Corrected the Fill Viewport help text (the old "Covers other items on the tab" is no longer accurate). Uses mode-agnostic wording so it doesn't promise the Order submenu, which only renders in unrestricted placement.
- **`reactapp/__tests__/components/dashboard/DashboardItem.test.js`** — Added a regression-lock test asserting the fill tile stays `position: fixed` but carries no explicit z-index.

## Key decisions

- **Remove the z-index rather than compute an order-based one.** Once the fill tile is no longer forced into the positive-z-index layer, it inherits the same DOM-order stacking every other tile already uses. This touches zero non-fill tiles (no new stacking contexts) and keeps grid content below modal/overlay layers automatically (modals 1040+, popups 1055, alerts 1000/1081 all paint above it). The surgical alternative — explicit per-tile z-index — is documented as a fallback if browser verification ever shows the fixed tile mis-stacking.
- **Intentional side effect:** positive-z-index dashboard chrome (e.g. alerts at 1000) now paints above a fill map, where the old `1020` covered them. This is more correct — alerts and modals should sit above content.
- **Unchanged:** the "first fill item wins" selection logic, and enabling Fill Viewport does not reorder the item.

## Testing

- `npx jest reactapp/__tests__/components/dashboard/DashboardItem.test.js reactapp/__tests__/components/dashboard/DashboardLayout.test.js` — 61/61 pass, including the new regression lock.
- `npx jest reactapp/__tests__/components/modals/DataViewer/SettingsPane.test.js` — 19/19 pass.
- ESLint clean on all changed files.

### Required pre-merge browser check

jsdom performs no layout or paint, so the automated tests can only lock the mechanical change (fill tile is `position: fixed` with no z-index). Confirm the actual visual stacking in a running instance:

- [ ] A tile ordered after a fill map (e.g. a Base Map dropdown) is visible on top of it in view mode.
- [ ] "Bring to Front" on the fill map covers the dropdown; "Send to Back" reveals it.
- [ ] Restricted-placement mode: a later-ordered tile still stacks above the fill tile.
- [ ] A modal/alert opened over the tab renders above the fill tile.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a frontend CSS/stacking change with no backend, data, or runtime-contract impact. Validate visually via the browser checklist above; if a fill dashboard renders incorrectly, revert this commit range on `fix/fillviewport-stack-order`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
